### PR TITLE
.github: Add issue template and funding information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-patreon: cemu

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+patreon: cemu

--- a/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report / Feature Request
+about: Tech support does not belong here. You should only file an issue here if you think you have experienced an actual bug with Cemu or you are requesting a feature you believe would make Cemu better.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!---
+Please keep in mind Cemu is EXPERIMENTAL SOFTWARE.
+
+Please read the FAQ:
+https://cemu.info/faq.html/
+
+THIS IS NOT A SUPPORT FORUM, FOR SUPPORT GO TO:
+https://discord.com/invite/5psYsup/
+
+If the FAQ does not answer your question, please go to:
+https://discord.com/invite/5psYsup/
+
+When submitting an issue, please check the following:
+
+- You have read the above.
+- You have provided the version (commit hash) of Cemu you are using.
+- You have provided sufficient detail for the issue to be reproduced.
+- You have provided system specs (if relevant).
+- Please also provide:
+  - For any issues, a log file
+  - For crashes, a backtrace.
+  - For graphical issues, comparison screenshots with real hardware.
+  - For emulation inaccuracies, a test-case (if able).
+
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Cemu Discord
+    url: https://discord.com/invite/5psYsup
+    about: If you are experiencing an issue with Cemu, and you need tech support, or if you have a general question, try asking in the official Cemu Discord linked here. Piracy is not allowed.


### PR DESCRIPTION
This adds a basic issue template and a Patreon link to the repository.
Suggestions for better wording/content are very welcome.

The files are loosely based on those of yuzu, but since I wrote a large part of the yuzu ones myself, there should be no licensing issues.