### PR TITLE
Fix ImGui::Text() format strings

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -432,7 +432,7 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 				}
 
 				ImGui::SetCursorPosX(width - ImGui::CalcTextSize(text.c_str()).x / 2);
-				ImGui::Text(text.c_str());
+				ImGui::Text("%s", text.c_str());
 
 				float percentLoaded;
 				if(isPipelines)
@@ -446,7 +446,7 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 				else
 					text = fmt::format("{}/{} ({}%%)", g_shaderCacheLoaderState.loadedShaderFiles, g_shaderCacheLoaderState.shaderFileCount, (int)(percentLoaded * 100));
 				ImGui::SetCursorPosX(width - ImGui::CalcTextSize(text.c_str()).x / 2);
-				ImGui::Text(text.c_str());
+				ImGui::Text("%s", text.c_str());
 				ImGui::End();
 			}
 			ImGui::PopFont();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VKRMemoryManager.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VKRMemoryManager.cpp
@@ -531,6 +531,6 @@ void VKRMemoryManager::appendOverlayHeapDebugInfo()
 		uint32 heapSizeMB = (heapSize / 1024 / 1024);
 		uint32 allocatedBytesMB = (allocatedBytes / 1024 / 1024);
 
-		ImGui::Text(fmt::format("{0:#08x} Size: {1}MB/{2}MB", itr.first, allocatedBytesMB, heapSizeMB).c_str());
+		ImGui::Text("%s", fmt::format("{0:#08x} Size: {1}MB/{2}MB", itr.first, allocatedBytesMB, heapSizeMB).c_str());
 	}
 }

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -390,7 +390,7 @@ void swkbd_render(bool mainWindow)
 	ImGui::PushFont(font);
 	if (ImGui::Begin("Keyboard Input", nullptr, kPopupFlags))
 	{
-		ImGui::Text(_utf8WrapperPtr(ICON_FA_KEYBOARD));
+		ImGui::Text("%s", _utf8WrapperPtr(ICON_FA_KEYBOARD));
 		ImGui::SameLine(70);
 		auto text = boost::nowide::narrow(fmt::format(L"{}", swkbdInternalState->formStringBuffer));
 


### PR DESCRIPTION
This patch fixes the compiler warnings/errors with `format-security` enabled.