### PR TITLE
CI: Try checkout v2 instead of v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       with:
         submodules: "recursive"
         
@@ -92,7 +92,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       with:
         submodules: "recursive"
         


### PR DESCRIPTION
Just a quick test. I have another workaround if this doesn't resolve the issue where pull request commits checkout the wrong commit