### PR TITLE
Add Rudimentray Proxy Support

### DIFF
--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -73,6 +73,10 @@ CurlRequestHelper::CurlRequestHelper()
 
 	curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, 1);
 	curl_easy_setopt(m_curl, CURLOPT_MAXREDIRS, 2);
+
+	if(GetConfig().proxy_server.GetValue() != "") {
+		curl_easy_setopt(m_curl, CURLOPT_PROXY, GetConfig().proxy_server.GetValue().c_str());
+	}
 }
 
 CurlRequestHelper::~CurlRequestHelper()

--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -74,7 +74,8 @@ CurlRequestHelper::CurlRequestHelper()
 	curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, 1);
 	curl_easy_setopt(m_curl, CURLOPT_MAXREDIRS, 2);
 
-	if(GetConfig().proxy_server.GetValue() != "") {
+	if(GetConfig().proxy_server.GetValue() != "")
+	{
 		curl_easy_setopt(m_curl, CURLOPT_PROXY, GetConfig().proxy_server.GetValue().c_str());
 	}
 }
@@ -220,6 +221,11 @@ CurlSOAPHelper::CurlSOAPHelper()
 	// SSL
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_FUNCTION, _sslctx_function_SOAP);
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_DATA, NULL);
+	
+	if(GetConfig().proxy_server.GetValue() != "")
+	{
+		curl_easy_setopt(m_curl, CURLOPT_PROXY, GetConfig().proxy_server.GetValue().c_str());
+	}
 }
 
 CurlSOAPHelper::~CurlSOAPHelper()

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -65,6 +65,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	did_show_vulkan_warning = parser.get("vk_warning", did_show_vulkan_warning);
 	did_show_graphic_pack_download = parser.get("gp_download", did_show_graphic_pack_download);
 	fullscreen = parser.get("fullscreen", fullscreen);
+	proxy_server = parser.get("proxy_server", "");
 
 	// cpu_mode = parser.get("cpu_mode", cpu_mode.GetInitValue());
 	//console_region = parser.get("console_region", console_region.GetInitValue());
@@ -340,6 +341,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	config.set<bool>("vk_warning", did_show_vulkan_warning);
 	config.set<bool>("gp_download", did_show_graphic_pack_download);
 	config.set<bool>("fullscreen", fullscreen);
+	config.set("proxy_server", proxy_server.GetValue().c_str());
 	
 	// config.set("cpu_mode", cpu_mode.GetValue());
 	//config.set("console_region", console_region.GetValue());

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -331,6 +331,7 @@ struct CemuConfig
 	ConfigValue<std::wstring> mlc_path {};
 	ConfigValue<bool> fullscreen_menubar{ false };
 	ConfigValue<bool> fullscreen{ false };
+	ConfigValue<std::string> proxy_server{};
 
 	std::vector<std::wstring> game_paths;
 	std::mutex game_cache_entries_mutex;


### PR DESCRIPTION
This will add rudimentary proxy support for napi.
This can be used to manipulate/sniff the packets. (Needs CACERT_NINTENDO_CA_G3.der to be swapped out)
Or simply connect to the official servers when a proxy server is required.

Right now this will add a new config to the settings.xml called <proxy_server>.
This has to be edited to something like <proxy_server>http://127.0.0.1:8080</proxy_server> manually to use a proxy because no GUI exists right now.