### PR TITLE
gui: keep shown graphic pack when clicking on preset dropdown

### DIFF
--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -421,6 +421,10 @@ void GraphicPacksWindow2::OnTreeSelectionChanged(wxTreeEvent& event)
 {
 	wxWindowUpdateLocker lock(this);
 	
+	bool item_deselected = m_graphic_pack_tree->GetSelection() == m_graphic_pack_tree->GetRootItem(); 
+	if (item_deselected)
+		return;
+
 	const auto selection = m_graphic_pack_tree->GetSelection();
 	if (selection.IsOk())
 	{


### PR DESCRIPTION
On linux, the right side panel of the graphic pack window (2) is being cleared when clicking on any of the preset dropdown menus.
This PR prevents this from happening.