### PR TITLE
Nvidia Multithread Pipelines

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -46,7 +46,7 @@ uint32 VulkanPipelineStableCache::BeginLoading(uint64 cacheTitleId)
 	m_numCompilationThreads = std::clamp(cpuCoreCount, 1u, 8u);
 	if (g_renderer->GetVendor() == GfxVendor::Nvidia)
 	{
-		if (VulkanRenderer::GetInstance()->GetDriverVersion() < 515.0f)
+		if(VulkanRenderer::GetInstance()->GetDriverVersion() < 515)
 		{
 			forceLog_printf("Disable multi-threaded pipeline loading due to an issue with Nvidia drivers");
 			m_numCompilationThreads = 1;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -34,29 +34,29 @@ uint32 VulkanPipelineStableCache::BeginLoading(uint64 cacheTitleId)
 	std::error_code ec;
 	fs::create_directories(ActiveSettings::GetPath("shaderCache/transferable"), ec);
 	const auto pathCacheFile = ActiveSettings::GetPath("shaderCache/transferable/{:016x}_vkpipeline.bin", cacheTitleId);
+	
 	// init cache loader state
 	g_vkCacheState.pipelineLoadIndex = 0;
 	g_vkCacheState.pipelineMaxFileIndex = 0;
 	g_vkCacheState.pipelinesLoaded = 0;
 	g_vkCacheState.pipelinesQueued = 0;
+	
 	// start async compilation threads
 	m_compilationCount.store(0);	
 	m_compilationQueue.clear();
+
+	// get core count
 	uint32 cpuCoreCount = GetPhysicalCoreCount();
 	m_numCompilationThreads = std::clamp(cpuCoreCount, 1u, 8u);
-	if (g_renderer->GetVendor() == GfxVendor::Nvidia)
-	{
-		if(VulkanRenderer::GetInstance()->GetDriverVersion() < 515)
-		{
-			forceLog_printf("Disable multi-threaded pipeline loading due to an issue with Nvidia drivers");
-			m_numCompilationThreads = 1;
-		}
-	}
+	if (VulkanRenderer::GetInstance()->GetDisableMultithreadedCompilation())
+		m_numCompilationThreads = 1;
+
 	for (uint32 i = 0; i < m_numCompilationThreads; i++)
 	{
 		std::thread compileThread(&VulkanPipelineStableCache::CompilerThread, this);
 		compileThread.detach();
 	}
+
 	// open cache file or create it
 	cemu_assert_debug(s_cache == nullptr);
 	const uint32 cacheFileVersion = 1;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -46,8 +46,11 @@ uint32 VulkanPipelineStableCache::BeginLoading(uint64 cacheTitleId)
 	m_numCompilationThreads = std::clamp(cpuCoreCount, 1u, 8u);
 	if (g_renderer->GetVendor() == GfxVendor::Nvidia)
 	{
-		forceLog_printf("Disable multi-threaded pipeline loading due to an issue with Nvidia drivers");
-		m_numCompilationThreads = 1;
+		if (VulkanRenderer::GetInstance()->GetDriverVersion() < 515.0f)
+		{
+			forceLog_printf("Disable multi-threaded pipeline loading due to an issue with Nvidia drivers");
+			m_numCompilationThreads = 1;
+		}
 	}
 	for (uint32 i = 0; i < m_numCompilationThreads; i++)
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -200,16 +200,23 @@ void VulkanRenderer::DetermineVendor()
 	{
 		forceLog_printf("Driver version: %s", driverProperties.driverInfo);
 
-		// needed for multithreaded pipelines on nvidia (requires 515 or higher)
-		m_featureControl.disableMultithreadedCompilation = (StringHelpers::ToInt(std::string(driverProperties.driverInfo)) < 515);
+		if(m_vendor == GfxVendor::Nvidia)
+		{
+			// multithreaded pipelines on nvidia (requires 515 or higher)
+			m_featureControl.disableMultithreadedCompilation = (StringHelpers::ToInt(std::string(driverProperties.driverInfo)) < 515);
+		}
 	}
 
 	else
 	{
 		forceLog_printf("Driver version (as stored in device info): %08X", properties.properties.driverVersion);
-
-		// disableMultithreadedCompilation defaults to false, not like there's any other driver
-		// on the planet with broken multithreading except Nvidia, which will always have a driver version string
+		
+		if(m_vendor == GfxVendor::Nvidia)
+		{
+			// if the driver does not support the extension,
+			// it is assumed the driver is under version 515
+			m_featureControl.disableMultithreadedCompilation = 1;
+		}
 	}
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -201,15 +201,15 @@ void VulkanRenderer::DetermineVendor()
 		forceLog_printf("Driver version: %s", driverProperties.driverInfo);
 
 		// needed for multithreaded pipelines on nvidia (requires 515 or higher)
-		driverVersion = StringHelpers::ToInt(std::string(driverProperties.driverInfo));
+		m_featureControl.disableMultithreadedCompilation = (StringHelpers::ToInt(std::string(driverProperties.driverInfo)) < 515);
 	}
 
 	else
 	{
 		forceLog_printf("Driver version (as stored in device info): %08X", properties.properties.driverVersion);
 
-		// disables multithreaded pipeline loading on nvidia (requires 515.0 or higher)
-		driverVersion = -1;
+		// disableMultithreadedCompilation defaults to false, not like there's any other driver
+		// on the planet with broken multithreading except Nvidia, which will always have a driver version string
 	}
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -12,6 +12,7 @@
 #include "Cafe/CafeSystem.h"
 
 #include "util/helpers/helpers.h"
+#include "util/helpers/StringHelpers.h"
 
 #include "config/ActiveSettings.h"
 #include "config/CemuConfig.h"
@@ -199,8 +200,8 @@ void VulkanRenderer::DetermineVendor()
 	{
 		forceLog_printf("Driver version: %s", driverProperties.driverInfo);
 
-		// needed for multithreaded pipelines on nvidia (requires 515.0 or higher)
-		sscanf(driverProperties.driverInfo, "%f", &driverVersion);
+		// needed for multithreaded pipelines on nvidia (requires 515 or higher)
+		driverVersion = StringHelpers::ToInt(std::string(driverProperties.driverInfo));
 	}
 
 	else
@@ -208,7 +209,7 @@ void VulkanRenderer::DetermineVendor()
 		forceLog_printf("Driver version (as stored in device info): %08X", properties.properties.driverVersion);
 
 		// disables multithreaded pipeline loading on nvidia (requires 515.0 or higher)
-		driverVersion = 0.0f;
+		driverVersion = -1;
 	}
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -194,10 +194,22 @@ void VulkanRenderer::DetermineVendor()
 		m_vendor = GfxVendor::Mesa;
 
 	forceLog_printf("Using GPU: %s", properties.properties.deviceName);
+
 	if (m_featureControl.deviceExtensions.driver_properties)
-		forceLog_printf("Driver version: %s", driverProperties.driverInfo)
+	{
+		forceLog_printf("Driver version: %s", driverProperties.driverInfo);
+
+		// needed for multithreaded pipelines on nvidia (requires 515.0 or higher)
+		sscanf(driverProperties.driverInfo, "%f", &driverVersion);
+	}
+
 	else
+	{
 		forceLog_printf("Driver version (as stored in device info): %08X", properties.properties.driverVersion);
+
+		// disables multithreaded pipeline loading on nvidia (requires 515.0 or higher)
+		driverVersion = 0.0f;
+	}
 }
 
 void VulkanRenderer::GetDeviceFeatures()

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -215,7 +215,7 @@ void VulkanRenderer::DetermineVendor()
 		{
 			// if the driver does not support the extension,
 			// it is assumed the driver is under version 515
-			m_featureControl.disableMultithreadedCompilation = 1;
+			m_featureControl.disableMultithreadedCompilation = true;
 		}
 	}
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -1012,7 +1012,7 @@ private:
 
 
 public:
-	float GetDriverVersion() { return driverVersion; }
+	int GetDriverVersion() { return driverVersion; }
 	bool useTFViaSSBO() { return m_featureControl.mode.useTFEmulationViaSSBO; }
 	bool IsDebugUtilsEnabled() const
 	{
@@ -1021,7 +1021,7 @@ public:
 
 private:
 
-	float driverVersion;
+	int driverVersion;
 
 	// debug
 	void debug_genericBarrier();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -547,7 +547,8 @@ private:
 			uint32 nonCoherentAtomSize = 256;
 		}limits;
 
-		bool debugMarkersSupported = false; // frame debugger is attached 
+		bool debugMarkersSupported = false; // frame debugger is attached
+		bool disableMultithreadedCompilation = false; // for old nvidia drivers
 
 	}m_featureControl{};
 	static bool CheckDeviceExtensionSupport(const VkPhysicalDevice device, FeatureControl& info);
@@ -1012,7 +1013,7 @@ private:
 
 
 public:
-	int GetDriverVersion() { return driverVersion; }
+	bool GetDisableMultithreadedCompilation() { return m_featureControl.disableMultithreadedCompilation; }
 	bool useTFViaSSBO() { return m_featureControl.mode.useTFEmulationViaSSBO; }
 	bool IsDebugUtilsEnabled() const
 	{
@@ -1020,8 +1021,6 @@ public:
 	}
 
 private:
-
-	int driverVersion;
 
 	// debug
 	void debug_genericBarrier();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -1012,13 +1012,16 @@ private:
 
 
 public:
-	bool useTFViaSSBO() { return m_featureControl.mode.useTFEmulationViaSSBO; };
+	float GetDriverVersion() { return driverVersion; }
+	bool useTFViaSSBO() { return m_featureControl.mode.useTFEmulationViaSSBO; }
 	bool IsDebugUtilsEnabled() const
 	{
 		return m_featureControl.debugMarkersSupported && m_featureControl.instanceExtensions.debug_utils;
 	}
 
 private:
+
+	float driverVersion;
 
 	// debug
 	void debug_genericBarrier();


### PR DESCRIPTION
Allowing multithreaded pipelines on Nvidia, if driver version 515 or higher is found