### PR TITLE
nn_act: Don't swap the Mii name again

### DIFF
--- a/src/Cafe/Account/Account.cpp
+++ b/src/Cafe/Account/Account.cpp
@@ -101,6 +101,7 @@ Account::Account(uint32 persistent_id, std::wstring_view mii_name)
 	// set default name
 	FFLData_t* fflData = (FFLData_t*)m_mii_data.data();
 	const auto tmp_name = GetMiiName();
+	memset(fflData->miiName, 0, sizeof(fflData->miiName));
 	std::copy(tmp_name.cbegin(), tmp_name.cend(), fflData->miiName);
 
 	// calculate checksum

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -369,7 +369,7 @@ void nnActExport_GetMiiName(PPCInterpreter_t* hCPU)
 	sint32 miiNameLength = 0;
 	for (sint32 i = 0; i < MII_FFL_NAME_LENGTH; i++)
 	{
-		miiName[i] = _swapEndianU16(miiData->miiName[i]);
+		miiName[i] = miiData->miiName[i];
 		if (miiData->miiName[i] == (const uint16be)'\0')
 			break;
 		miiNameLength = i+1;
@@ -392,7 +392,7 @@ void nnActExport_GetMiiNameEx(PPCInterpreter_t* hCPU)
 	sint32 miiNameLength = 0;
 	for (sint32 i = 0; i < MII_FFL_NAME_LENGTH; i++)
 	{
-		miiName[i] = _swapEndianU16(miiData->miiName[i]);
+		miiName[i] = miiData->miiName[i];
 		if (miiData->miiName[i] == (const uint16be)'\0')
 			break;
 		miiNameLength = i + 1;


### PR DESCRIPTION
The name obtained from `GetMiiEx` is already swapped, so it shouldn't be swapped again. I've written a [minimal program](https://github.com/cemu-project/Cemu/files/9438841/miiname.rpx.zip) ([source](https://gist.github.com/IntriguingTiles/2d3d579d07a00eab2033596fec818942)) to test this that outputs the Mii name and the raw data of the Mii name in hex.

<details><summary>Screenshots</summary>
<p>
Previous behavior:
<img src="https://user-images.githubusercontent.com/13212984/187051931-b0cf40af-e40a-4bd4-a575-8e60a77b8845.png">
New behavior:
<img src="https://user-images.githubusercontent.com/13212984/187051991-9696a41e-6e54-4668-883d-5a4d650ea943.png">
Behavior on console:
<img src="https://user-images.githubusercontent.com/13212984/187052006-8f15a224-a2a6-43a4-ac91-6b2e1864e2b5.png">
</p>
</details>

There are still some mystery 0x100s in the Mii name that shouldn't be there.