### PR TITLE
docs: Improve build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,30 +3,56 @@
 ## Windows
 
 Prerequisites:
-- A recent version of Visual Studio 2022 with CMake tools component
+- A recent version of Visual Studio 2022 (recommended but not required) with the following additional components:
+  - C++ CMake tools for Windows
+  - Windows 10/11 SDK
 - git
 
 Instructions:
 
-1) Run `git clone --recursive https://github.com/cemu-project/Cemu`
-2) Launch `Cemu/generate_vs_solution.bat`. If you installed VS to a custom location you may need to manually adjust the path inside the bat file
-3) Wait until done, then open `Cemu/build/Cemu.sln` in Visual Studio
-4) Right click 'CemuBin' project -> Set as startup project
-5) Then build the solution and once finished you can run and debug it
+1. Run `git clone --recursive https://github.com/cemu-project/Cemu`
+2. Launch `Cemu/generate_vs_solution.bat`.
+    - If you installed VS to a custom location or use VS 2019, you may need to manually change the path inside the .bat file
+3. Wait until it's done, then open `Cemu/build/Cemu.sln` in Visual Studio
+4. Then build the solution and once finished you can run and debug it, or build it and check the /bin folder for the final Cemu.exe.
 
-You can also skip steps 3-5 and open the root folder of the cloned repo directly in Visual Studio (as a folder) and use the inbuilt cmake support, but be warned that cmake support in VS can be a bit finicky.
+You can also skip steps 3-5 and open the root folder of the cloned repo directly in Visual Studio (as a folder) and use the built-in cmake support but be warned that cmake support in VS can be a bit finicky.
 
 ## Linux
 
-To compile Cemu, a recent enough compiler and STL with C++20 support is required! We use clang 12, other compilers may work as well.
+To compile Cemu, a recent enough compiler and STL with C++20 support is required! clang-12 or higher is what we recommend.
 
-For ubuntu and most derivatives:
+### Installing dependencies
 
-1) `sudo apt install -y libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev freeglut3-dev clang-12 nasm ninja-build`
-2) Run `git clone --recursive https://github.com/cemu-project/Cemu`
-3) `cd Cemu`
-4) `mkdir build && cd build`
-5) `cmake .. -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang-12 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-12 -G Ninja`
-6) `ninja`
+#### For Ubuntu and derivatives:
+`sudo apt install -y git cmake ninja-build nasm libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev freeglut3-dev libpulse-dev`  
+Additionally, for ubuntu 20.04 only:
+ - `sudo apt install -y clang-12`
+ - At step 3 while building, use  
+   `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang-12 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-12 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja`
 
-Build instructions for other distributions will be added in the future!
+#### For Arch and derivatives:
+`sudo pacman -S git cmake clang ninja nasm base-devel linux-headers gtk3 libsecret libgcrypt systemd freeglut zip libpulse`
+
+#### For Fedora and derivatives:
+`sudo dnf install git cmake clang ninja-build nasm kernel-headers gtk3-devel libsecret-devel libgcrypt-devel systemd-devel freeglut-devel perl-core zlib-devel cubeb-devel`
+
+### Build Cemu using cmake
+1. `git clone --recursive https://github.com/cemu-project/Cemu`
+2. `cd Cemu`
+3. `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -G Ninja`
+4. `cmake --build build`
+5. You should now have a Cemu executable file in the /bin folder, which you can run using `./bin/Cemu`.
+
+
+#### Troubleshooting steps
+ - If step 3 gives you an error about not being able to find ninja, try appending `-DCMAKE_MAKE_PROGRAM=/usr/bin/ninja` to the command and running it again.
+ - If step 3 fails while compiling the boost-build dependency, it means you don't have a working/good standard library installation. Check the integrity of your system headers and making sure that C++ related packages are installed and intact.
+ - If step 3 gives a random error, read the `[package-name-and-platform]-out.log` and `[package-name-and-platform]-err.log` for the actual reason to see if you might be lacking the headers from a dependency.
+ - If step 3 is still failing or if you're not able to find the cause, please make an issue on our Github about it!
+ - If step 4 gives you a template error (usually will show a very long error message!), you could report it to this repo or try using GCC.
+
+#### Using GCC
+While we use and test Cemu using clang, using GCC might work better with your distro (they should be fairly similar performance/issues wise and should only be considered if compilation is the issue).  
+You can use it by replacing the step 3 with the following:
+`cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -G Ninja`


### PR DESCRIPTION
I've taken the liberty of reviving PR https://github.com/cemu-project/Cemu/pull/94 that got closed (he's still credited in this commit) and reworked it with some things that I wanted to improve regardless.

I'm only really able to test SteamOS 3.0, Ubuntu 20.04 and Manjaro, so let me know if anyone has any additional suggestions or notes about certain distros.