### PR TITLE
Check Linux dist files in CI

### DIFF
--- a/.github/workflows/linux-dist-check.yml
+++ b/.github/workflows/linux-dist-check.yml
@@ -1,0 +1,37 @@
+name: Linux dist check
+
+on:
+  pull_request:
+    paths:
+      - "dist/linux/info.cemu.Cemu.desktop"
+      - "dist/linux/info.cemu.Cemu.metainfo.xml"
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    paths:
+      - "dist/linux/info.cemu.Cemu.desktop"
+      - "dist/linux/info.cemu.Cemu.metainfo.xml"
+    branches:
+      - main
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-20.04
+    container:
+      image: archlinux:latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: "Install packages"
+      run: |
+        pacman --noconfirm -Syy
+        pacman --noconfirm -S desktop-file-utils appstream
+    - name: "Check .desktop"
+      run: 
+        desktop-file-validate ./dist/linux/info.cemu.Cemu.desktop
+        
+    - name: "Check AppStream"
+      run:
+        appstreamcli validate --explain ./dist/linux/info.cemu.Cemu.metainfo.xml


### PR DESCRIPTION
This PR adds a CI step to check if Linux dist files are valid.

In case you wondering why I use Arch: The AppStream spec has gotten a few new features since the last Ubuntu release. This is not a problem, since unknown elements will just be ignored by older AppStream versions, but the validation might fail. The validation has also been improved since them. Which Arch we always have the latest version.

The validation will currently fail, because the Linux dist files currently have a CRLF line separator while a LF separator is required.