### PR TITLE
build: minor refactoring and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,6 @@ option(PUBLIC_RELEASE "Compile with debug asserts disabled and no console" OFF)
 option(ENABLE_VCPKG "Enable the vcpkg package manager" ON)
 set(EXPERIMENTAL_VERSION "" CACHE STRING "") # used by CI script to set experimental version
 
-if (PUBLIC_RELEASE)
-  add_definitions(-DPUBLIC_RELEASE)
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE) # enable LTO
-endif()
-
 if (EXPERIMENTAL_VERSION)
   add_definitions(-DEMULATOR_VERSION_MINOR=${EXPERIMENTAL_VERSION})
 endif()
@@ -25,8 +20,7 @@ if (ENABLE_VCPKG)
 	endif()
 endif()
 
-
-project(Cemu VERSION 0.1)
+project(Cemu VERSION 2.0)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -35,20 +29,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if (PUBLIC_RELEASE)
+	add_compile_definitions(PUBLIC_RELEASE)
+	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE) # enable LTO
+endif()
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if (MSVC)
-    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CemuBin)
-endif()
-
-if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise") # floating point model: precise
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GT") # fiber safe optimizations
-  if (PUBLIC_RELEASE)
-    message(STATUS "Using additional optimization flags for MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Oi /Ot") # enable intrinsic functions, favor speed
-  endif()
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CemuBin)
+	# floating point model: precise, fiber safe optimizations
+	add_compile_options(/EHsc /fp:precise /GT)
+	if (PUBLIC_RELEASE)
+		message(STATUS "Using additional optimization flags for MSVC")
+		add_compile_options(/Oi /Ot) # enable intrinsic functions, favor speed
+	endif()
 endif()
 
 option(ENABLE_OPENGL "Enables the OpenGL backend" ON)
@@ -57,16 +52,16 @@ option(ENABLE_DISCORD_RPC "Enables the Discord Rich Presence feature" ON)
 
 # input backends
 if (WIN32)
-  option(ENABLE_XINPUT "Enables the usage of XInput" ON)
-  option(ENABLE_DIRECTINPUT "Enables the usage of DirectInput" ON)
-  add_definitions(-DHAS_DIRECTINPUT)
+	option(ENABLE_XINPUT "Enables the usage of XInput" ON)
+	option(ENABLE_DIRECTINPUT "Enables the usage of DirectInput" ON)
+	add_compile_definitions(HAS_DIRECTINPUT)
 endif()
 option(ENABLE_SDL "Enables the SDLController backend" ON)
 
 # audio backends
 if (WIN32)
-  option(ENABLE_DIRECTAUDIO "Enables the directaudio backend" ON)
-  option(ENABLE_XAUDIO "Enables the xaudio backend" ON)
+	option(ENABLE_DIRECTAUDIO "Enables the directaudio backend" ON)
+	option(ENABLE_XAUDIO "Enables the xaudio backend" ON)
 endif()
 option(ENABLE_CUBEB "Enabled cubeb backend" ON)
 
@@ -99,17 +94,17 @@ if (UNIX AND NOT APPLE)
 endif()
 
 if (ENABLE_VULKAN)
-  include_directories("dependencies/Vulkan-Headers/include")
+	include_directories("dependencies/Vulkan-Headers/include")
 endif()
 
 if (ENABLE_OPENGL)
-  find_package(OpenGL REQUIRED)
+	find_package(OpenGL REQUIRED)
 endif()
 
 if (ENABLE_DISCORD_RPC)
-  add_definitions(-DENABLE_DISCORD_RPC)
-  add_subdirectory(dependencies/discord-rpc EXCLUDE_FROM_ALL)
-  target_include_directories(discord-rpc INTERFACE ./dependencies/discord-rpc/include)
+	add_compile_definitions(ENABLE_DISCORD_RPC)
+	add_subdirectory(dependencies/discord-rpc EXCLUDE_FROM_ALL)
+	target_include_directories(discord-rpc INTERFACE ./dependencies/discord-rpc/include)
 endif()
 
 if (ENABLE_WXWIDGETS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,42 +2,43 @@ project(cemuMain)
 
 option(CEMU_CXX_FLAGS "Additional flags used for compiling Cemu source code")
 if(CEMU_CXX_FLAGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CEMU_CXX_FLAGS}")
+	add_compile_options(${CEMU_CXX_FLAGS})
 endif()
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    # all ok
-else()
-    message( FATAL_ERROR "Pointers are not 64bit" )
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+	message( FATAL_ERROR "Pointers are not 64bit" )
 endif()
 
 if(MSVC)
-    add_definitions(-DWIN32_LEAN_AND_MEAN)
-    add_definitions(-DCURL_STATICLIB)
-    #add_definitions(-DVK_USE_PLATFORM_WIN32_KHR)
-    # _CRT_SECURE_NO_WARNINGS
-    # _WINSOCK_DEPRECATED_NO_WARNINGS
-    # _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
-    # _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
+	add_compile_definitions(WIN32_LEAN_AND_MEAN CURL_STATICLIB)
+	#add_compile_definitions(VK_USE_PLATFORM_WIN32_KHR)
+	# _CRT_SECURE_NO_WARNINGS
+	# _WINSOCK_DEPRECATED_NO_WARNINGS
+	# _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+	# _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 elseif(UNIX)
-    if(APPLE)
-        add_definitions(-D_XOPEN_SOURCE)
-        add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
-        add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
-    else()
-        add_definitions(-DVK_USE_PLATFORM_XLIB_KHR) # legacy. Do we need to support XLIB surfaces?
-        add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
-    endif()
-    add_definitions(-maes)
-    # warnings
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-	add_compile_options(-Wno-ambiguous-reversed-operator)
-    endif()
+	if(APPLE)
+		add_compile_definitions(
+			_XOPEN_SOURCE
+			VK_USE_PLATFORM_MACOS_MVK
+			VK_USE_PLATFORM_METAL_EXT
+		)
+	else()
+		add_compile_definitions(
+			VK_USE_PLATFORM_XLIB_KHR # legacy. Do we need to support XLIB surfaces?
+			VK_USE_PLATFORM_XCB_KHR
+		)
+	endif()
+	add_compile_options(-maes)
+	# warnings
+	if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+		add_compile_options(-Wno-ambiguous-reversed-operator)
+	endif()
 
     add_compile_options(-Wno-multichar -Wno-invalid-offsetof -Wno-switch -Wno-ignored-attributes -Wno-deprecated-enum-enum-conversion)
 endif()
 
-add_definitions(-DVK_NO_PROTOTYPES)
+add_compile_definitions(VK_NO_PROTOTYPES)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -54,32 +55,29 @@ add_subdirectory(resource)
 add_subdirectory(asm)
 
 if(PUBLIC_RELEASE)
-add_executable(CemuBin WIN32
-main.cpp
-mainLLE.cpp
-)
+	add_executable(CemuBin WIN32
+		main.cpp
+		mainLLE.cpp
+	)
 else()
-add_executable(CemuBin
-main.cpp
-mainLLE.cpp
-)
+	add_executable(CemuBin
+		main.cpp
+		mainLLE.cpp
+	)
 endif()
 
-target_precompile_headers(CemuBin PRIVATE Common/precompiled.h)
-
 if(WIN32)
-  target_sources(CemuBin PRIVATE
-  resource/cemu.rc
-  )
+	target_sources(CemuBin PRIVATE
+	resource/cemu.rc
+)
 endif()
 
 set_property(TARGET CemuBin PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 set_target_properties(CemuBin PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_SOURCE_DIR}/../bin/
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/../bin/
-        OUTPUT_NAME "Cemu"
-        )
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../bin/"
+	OUTPUT_NAME "Cemu"
+)
 
 target_link_libraries(CemuBin PRIVATE
 	CemuAudio
@@ -90,11 +88,9 @@ target_link_libraries(CemuBin PRIVATE
 	CemuGui
 	CemuInput
 	CemuUtil
+	OpenGL::GL
+	SDL2::SDL2
 )
-
-target_link_libraries(CemuBin PRIVATE CemuAsm)
-target_link_libraries(CemuBin PRIVATE SDL2::SDL2 SDL2::SDL2main) # is SDL2main needed?
-target_link_libraries(CemuBin PRIVATE imguiImpl OpenGL::GL)
 
 if (ENABLE_WXWIDGETS)
 	target_link_libraries(CemuBin PRIVATE wx::base wx::core)

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -16,8 +16,6 @@ endif()
 
 set_property(TARGET CemuCafe PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_precompile_headers(CemuCafe PRIVATE ../Common/precompiled.h)
-
 target_include_directories(CemuCafe PUBLIC "../")
 
 target_link_libraries(CemuCafe PRIVATE

--- a/src/Cemu/CMakeLists.txt
+++ b/src/Cemu/CMakeLists.txt
@@ -6,8 +6,6 @@ add_library(CemuComponents ${CPP_FILES} ${H_FILES})
 
 set_property(TARGET CemuComponents PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_precompile_headers(CemuComponents PRIVATE ../Common/precompiled.h)
-
 target_include_directories(CemuComponents PUBLIC "../")
 
 target_link_libraries(CemuComponents PRIVATE
@@ -28,5 +26,5 @@ target_link_libraries(CemuComponents PRIVATE
 target_link_libraries(CemuComponents PUBLIC fmt::fmt)
 
 if(ENABLE_DISCORD_RPC)
-target_link_libraries(CemuComponents PRIVATE discord-rpc)
+	target_link_libraries(CemuComponents PRIVATE discord-rpc)
 endif()

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -7,12 +7,11 @@ add_library(CemuCommon ${CPP_FILES} ${H_FILES})
 set_property(TARGET CemuCommon PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(WIN32)
-target_sources(CemuCommon
-PRIVATE
-    windows/platform.cpp
-    windows/platform.h
-    ExceptionHandler/ExceptionHandler_win32.cpp
-)
+	target_sources(CemuCommon PRIVATE
+		windows/platform.cpp
+		windows/platform.h
+		ExceptionHandler/ExceptionHandler_win32.cpp
+	)
 else()
 target_sources(CemuCommon
 PRIVATE
@@ -22,11 +21,12 @@ PRIVATE
 )
 endif()
 
-target_sources(CemuCommon
-        PRIVATE
-        ExceptionHandler/ExceptionHandler.h
-        )
+target_sources(CemuCommon PRIVATE
+	ExceptionHandler/ExceptionHandler.h
+)
 
+# All the targets wanting to use the precompiled.h header
+# have to link to CemuCommon
 target_precompile_headers(CemuCommon PUBLIC precompiled.h)
 target_include_directories(CemuCommon PUBLIC "../")
 

--- a/src/asm/CMakeLists.txt
+++ b/src/asm/CMakeLists.txt
@@ -1,43 +1,39 @@
 project(CemuAsm C)
 
-IF (WIN32)
+if (WIN32)
 
-enable_language(C ASM_MASM)
+	enable_language(C ASM_MASM)
 
-add_library(CemuAsm
-x64util_masm.asm
-)
-set_source_files_properties(x64util_masm.asm PROPERTIES LANGUAGE ASM_MASM)
+	add_library(CemuAsm x64util_masm.asm)
+	set_source_files_properties(x64util_masm.asm PROPERTIES LANGUAGE ASM_MASM)
 
-# workaround for cr flag being passed to LINK.exe which considers it an input file and thus fails
-# doesn't always seem to happen. The Windows CI builds were fine, but locally I would run into this problem
-# possibly related to https://gitlab.kitware.com/cmake/cmake/-/issues/18889
-set(CMAKE_ASM_MASM_CREATE_STATIC_LIBRARY "<CMAKE_AR> /OUT:<TARGET> <LINK_FLAGS> <OBJECTS>")
+	# workaround for cr flag being passed to LINK.exe which considers it an input file and thus fails
+	# doesn't always seem to happen. The Windows CI builds were fine, but locally I would run into this problem
+	# possibly related to https://gitlab.kitware.com/cmake/cmake/-/issues/18889
+	set(CMAKE_ASM_MASM_CREATE_STATIC_LIBRARY "<CMAKE_AR> /OUT:<TARGET> <LINK_FLAGS> <OBJECTS>")
 
-ELSE()
+else()
 
-# NASM
-IF (APPLE)
-set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> -g -Fdwarf -f macho64 --prefix _ -o <OBJECT> <SOURCE>")
-ELSE()
-set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> -g -Fdwarf -f elf64 -o <OBJECT> <SOURCE>")
-ENDIF()
-set(CMAKE_ASM_NASM_LINK_EXECUTABLE "ld <FLAGS> <CMAKE_ASM_NASM_LINK_FLAGS> <LINK_FLAGS> -fPIC <OBJECTS>  -o <TARGET> <LINK_LIBRARIES>")
+	# NASM
+	if (APPLE)
+		set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> -g -Fdwarf -f macho64 --prefix _ -o <OBJECT> <SOURCE>")
+	else()
+		set(CMAKE_ASM_NASM_COMPILE_OBJECT "<CMAKE_ASM_NASM_COMPILER> -g -Fdwarf -f elf64 -o <OBJECT> <SOURCE>")
+	endif()
+	set(CMAKE_ASM_NASM_LINK_EXECUTABLE "ld <FLAGS> <CMAKE_ASM_NASM_LINK_FLAGS> <LINK_FLAGS> -fPIC <OBJECTS>  -o <TARGET> <LINK_LIBRARIES>")
 
-enable_language(C ASM_NASM)
+	enable_language(C ASM_NASM)
 
-add_library(CemuAsm
-x64util_nasm.asm
-)
-set_source_files_properties(x64util_nasm.asm PROPERTIES LANGUAGE ASM_NASM)
+	add_library(CemuAsm x64util_nasm.asm)
+	set_source_files_properties(x64util_nasm.asm PROPERTIES LANGUAGE ASM_NASM)
 
-IF (APPLE)
-set_target_properties(CemuAsm PROPERTIES NASM_OBJ_FORMAT macho64)
-ELSE()
-set_target_properties(CemuAsm PROPERTIES NASM_OBJ_FORMAT elf64)
-ENDIF()
-set_target_properties(CemuAsm PROPERTIES LINKER_LANGUAGE C)
+	if (APPLE)
+		set_target_properties(CemuAsm PROPERTIES NASM_OBJ_FORMAT macho64)
+	else()
+		set_target_properties(CemuAsm PROPERTIES NASM_OBJ_FORMAT elf64)
+	endif()
+	set_target_properties(CemuAsm PROPERTIES LINKER_LANGUAGE C)
 
-ENDIF()
+endif()
 
 set_property(TARGET CemuAsm PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,42 +1,46 @@
 project(CemuAudio)
 
 add_library(CemuAudio
-IAudioAPI.cpp
-IAudioAPI.h
+	IAudioAPI.cpp
+	IAudioAPI.h
 )
 
 set_property(TARGET CemuAudio PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # move these to UI folder
 target_sources(CemuAudio PRIVATE
-  audioDebuggerWindow.cpp
-  audioDebuggerWindow.h
+	audioDebuggerWindow.cpp
+	audioDebuggerWindow.h
 )
 
 if(WIN32)
-  target_sources(CemuAudio PRIVATE
-      DirectSoundAPI.cpp
-      DirectSoundAPI.h
-      XAudio2API.cpp
-      XAudio2API.h
-      XAudio27API.cpp
-      XAudio27API.h
-  )
+	target_sources(CemuAudio PRIVATE
+		DirectSoundAPI.cpp
+		DirectSoundAPI.h
+		XAudio2API.cpp
+		XAudio2API.h
+		XAudio27API.cpp
+		XAudio27API.h
+	)
 endif()
 
 if(ENABLE_CUBEB)
-  target_sources(CemuAudio PRIVATE
-          CubebAPI.cpp
-          CubebAPI.h
-  )
-  #add_definitions(HAS_CUBEB)
+	target_sources(CemuAudio PRIVATE
+		CubebAPI.cpp
+		CubebAPI.h
+	)
+	#add_compile_definitions(HAS_CUBEB)
 endif()
-
-target_precompile_headers(CemuAudio PRIVATE ../Common/precompiled.h)
 
 target_include_directories(CemuAudio PUBLIC "../")
 
-target_link_libraries(CemuAudio PRIVATE CemuCafe CemuConfig CemuGui CemuUtil)
+target_link_libraries(CemuAudio PRIVATE
+	CemuCafe
+	CemuCommon
+	CemuConfig
+	CemuGui
+	CemuUtil
+)
 
 if(ENABLE_CUBEB)
 	# PUBLIC because cubeb.h/cubeb.h is included in CubebAPI.h

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -6,8 +6,6 @@ add_library(CemuConfig ${CPP_FILES} ${H_FILES})
 
 set_property(TARGET CemuConfig PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_precompile_headers(CemuConfig PRIVATE ../Common/precompiled.h)
-
 target_include_directories(CemuConfig PUBLIC "../")
 
 target_link_libraries(CemuConfig PRIVATE

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -7,13 +7,11 @@ add_library(CemuGui ${CPP_FILES} ${H_FILES})
 set_property(TARGET CemuGui PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 target_sources(CemuGui PRIVATE
-wxcomponents/checkedlistctrl.cpp
-wxcomponents/checkedlistctrl.h
-wxcomponents/checktree.cpp
-wxcomponents/checktree.h
+	wxcomponents/checkedlistctrl.cpp
+	wxcomponents/checkedlistctrl.h
+	wxcomponents/checktree.cpp
+	wxcomponents/checktree.h
 )
-
-target_precompile_headers(CemuGui PRIVATE ../Common/precompiled.h)
 
 target_include_directories(CemuGui PUBLIC "../")
 # PUBLIC because rapidjson/document.h is included in ChecksumTool.h

--- a/src/imgui/CMakeLists.txt
+++ b/src/imgui/CMakeLists.txt
@@ -5,15 +5,13 @@ add_library(imguiImpl)
 set_property(TARGET imguiImpl PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 target_sources(imguiImpl PRIVATE
-  imgui_impl_opengl3.cpp
-  imgui_impl_opengl3.h
-  imgui_impl_vulkan.cpp
-  imgui_impl_vulkan.h
-  imgui_extension.cpp
-  imgui_extension.h
+	imgui_impl_opengl3.cpp
+	imgui_impl_opengl3.h
+	imgui_impl_vulkan.cpp
+	imgui_impl_vulkan.h
+	imgui_extension.cpp
+	imgui_extension.h
 )
-
-target_precompile_headers(imguiImpl PRIVATE ../Common/precompiled.h)
 
 target_include_directories(imguiImpl PUBLIC "../")
 

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -1,97 +1,95 @@
 project(CemuInput)
 
 add_library(CemuInput
-InputManager.cpp
-InputManager.h
-ControllerFactory.cpp
-ControllerFactory.h
-api/ControllerState.h
-api/Controller.cpp
-api/Controller.h
-api/ControllerState.cpp
-api/InputAPI.h
-api/ControllerProvider.h
-emulated/ProController.cpp
-emulated/EmulatedController.h
-emulated/EmulatedController.cpp
-emulated/ProController.h
-emulated/WPADController.cpp
-emulated/WPADController.h
-emulated/WiimoteController.h
-emulated/VPADController.cpp
-emulated/WiimoteController.cpp
-emulated/VPADController.h
-emulated/ClassicController.cpp
-emulated/ClassicController.h
+	InputManager.cpp
+	InputManager.h
+	ControllerFactory.cpp
+	ControllerFactory.h
+	api/ControllerState.h
+	api/Controller.cpp
+	api/Controller.h
+	api/ControllerState.cpp
+	api/InputAPI.h
+	api/ControllerProvider.h
+	emulated/ProController.cpp
+	emulated/EmulatedController.h
+	emulated/EmulatedController.cpp
+	emulated/ProController.h
+	emulated/WPADController.cpp
+	emulated/WPADController.h
+	emulated/WiimoteController.h
+	emulated/VPADController.cpp
+	emulated/WiimoteController.cpp
+	emulated/VPADController.h
+	emulated/ClassicController.cpp
+	emulated/ClassicController.h
 )
 
 set_property(TARGET CemuInput PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # SDL
 target_sources(CemuInput PRIVATE
-api/SDL/SDLController.cpp
-api/SDL/SDLControllerProvider.cpp
-api/SDL/SDLController.h
-api/SDL/SDLControllerProvider.h
+	api/SDL/SDLController.cpp
+	api/SDL/SDLControllerProvider.cpp
+	api/SDL/SDLController.h
+	api/SDL/SDLControllerProvider.h
 )
 
 # DSU
 target_sources(CemuInput PRIVATE
-api/DSU/DSUController.h
-api/DSU/DSUControllerProvider.cpp
-api/DSU/DSUController.cpp
-api/DSU/DSUControllerProvider.h
-api/DSU/DSUMessages.h
-api/DSU/DSUMessages.cpp
+	api/DSU/DSUController.h
+	api/DSU/DSUControllerProvider.cpp
+	api/DSU/DSUController.cpp
+	api/DSU/DSUControllerProvider.h
+	api/DSU/DSUMessages.h
+	api/DSU/DSUMessages.cpp
 )
 
 # Keyboard controller
 target_sources(CemuInput PRIVATE
-api/Keyboard/KeyboardControllerProvider.h
-api/Keyboard/KeyboardControllerProvider.cpp
-api/Keyboard/KeyboardController.cpp
-api/Keyboard/KeyboardController.h
+	api/Keyboard/KeyboardControllerProvider.h
+	api/Keyboard/KeyboardControllerProvider.cpp
+	api/Keyboard/KeyboardController.cpp
+	api/Keyboard/KeyboardController.h
 )
 
 # Native gamecube
 target_sources(CemuInput PRIVATE
-api/GameCube/GameCubeController.cpp
-api/GameCube/GameCubeControllerProvider.h
-api/GameCube/GameCubeControllerProvider.cpp
-api/GameCube/GameCubeController.h
+	api/GameCube/GameCubeController.cpp
+	api/GameCube/GameCubeControllerProvider.h
+	api/GameCube/GameCubeControllerProvider.cpp
+	api/GameCube/GameCubeController.h
 )
 
 if(WIN32)
-# Native wiimote (Win32 only for now)
-target_sources(CemuInput PRIVATE
-api/Wiimote/WiimoteControllerProvider.h
-api/Wiimote/windows/WinWiimoteDevice.cpp
-api/Wiimote/windows/WinWiimoteDevice.h
-api/Wiimote/WiimoteControllerProvider.cpp
-api/Wiimote/WiimoteMessages.h
-api/Wiimote/NativeWiimoteController.h
-api/Wiimote/NativeWiimoteController.cpp
-api/Wiimote/WiimoteDevice.h
-)
+	# Native wiimote (Win32 only for now)
+	target_sources(CemuInput PRIVATE
+		api/Wiimote/WiimoteControllerProvider.h
+		api/Wiimote/windows/WinWiimoteDevice.cpp
+		api/Wiimote/windows/WinWiimoteDevice.h
+		api/Wiimote/WiimoteControllerProvider.cpp
+		api/Wiimote/WiimoteMessages.h
+		api/Wiimote/NativeWiimoteController.h
+		api/Wiimote/NativeWiimoteController.cpp
+		api/Wiimote/WiimoteDevice.h
+	)
 
-# XInput
-target_sources(CemuInput PRIVATE
-api/XInput/XInputControllerProvider.cpp
-api/XInput/XInputControllerProvider.h
-api/XInput/XInputController.cpp
-api/XInput/XInputController.h
-)
+	# XInput
+	target_sources(CemuInput PRIVATE
+		api/XInput/XInputControllerProvider.cpp
+		api/XInput/XInputControllerProvider.h
+		api/XInput/XInputController.cpp
+		api/XInput/XInputController.h
+	)
 
-# DirectInput
-target_sources(CemuInput PRIVATE
-api/DirectInput/DirectInputControllerProvider.cpp
-api/DirectInput/DirectInputController.h
-api/DirectInput/DirectInputControllerProvider.h
-api/DirectInput/DirectInputController.cpp
-)
+	# DirectInput
+	target_sources(CemuInput PRIVATE
+		api/DirectInput/DirectInputControllerProvider.cpp
+		api/DirectInput/DirectInputController.h
+		api/DirectInput/DirectInputControllerProvider.h
+		api/DirectInput/DirectInputController.cpp
+	)
 endif()
-
-target_precompile_headers(CemuInput PRIVATE ../Common/precompiled.h)
 
 target_include_directories(CemuInput PUBLIC "../")
 

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -2,20 +2,16 @@ add_library(CemuResource)
 
 set_property(TARGET CemuResource PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_precompile_headers(CemuResource PRIVATE ../Common/precompiled.h)
-
 # icon resources
 if(UNIX)
-  target_sources(CemuResource PRIVATE
-  embedded/resources.cpp
-  embedded/resources.h
-  )
+	target_sources(CemuResource PRIVATE
+	embedded/resources.cpp
+	embedded/resources.h
+	)
 endif()
 
-target_sources(CemuResource PRIVATE
-        CafeDefaultFont.cpp
-        )
+target_sources(CemuResource PRIVATE CafeDefaultFont.cpp)
 
 target_include_directories(CemuResource PUBLIC "../")
 
-target_link_libraries(CemuResource PRIVATE CemuComponents)
+target_link_libraries(CemuResource PRIVATE CemuCommon CemuComponents)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,8 +7,6 @@ add_library(CemuUtil ${CPP_FILES} ${H_FILES})
 
 set_property(TARGET CemuUtil PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_precompile_headers(CemuUtil PRIVATE ../Common/precompiled.h)
-
 target_include_directories(CemuUtil PUBLIC "../")
 
 target_link_libraries(CemuUtil PRIVATE


### PR DESCRIPTION
Some bits originated from #75

- Fix `target_precompile_headers()` usage; the CemuCommon target exposes the `src/Common/precompiled.h` precompiled header as part of its public interface with `target_precompile_headers(CemuCommon PUBLIC precompiled.h)`, so all the other targets wanting to use the precompiled header have to link to the CemuCommon target with `target_precompile_headers(TargetName PRIVATE CemuCommon)`.
- Set the project version to 2.0
- Set `RUNTIME_OUTPUT_DIRECTORY` instead of only their `_DEBUG` and `_RELEASE` variants, fixing the compilation when neither build types are defined (see https://github.com/cemu-project/Cemu/issues/1#issuecomment-1229359719)
- Use a consistent indentation style (tabs, like in the .cpp files)
- Use "modern" variants of some functions, e.g. `add_definitions` -> `add_compile_definitions`
- Use `std::enable_if` & co instead of `boost::`