### PR TITLE
Bug #620 Fixed crash when no audio devices are present

### DIFF
--- a/src/audio/DirectSoundAPI.cpp
+++ b/src/audio/DirectSoundAPI.cpp
@@ -226,6 +226,11 @@ std::vector<DirectSoundAPI::DeviceDescriptionPtr> DirectSoundAPI::GetDevices()
 			return TRUE;
 		}, &result);
 
+	//Exclude default primary sound device if no other sound devices are available
+	if (result.size() == 1 && result.at(0).get()->GetIdentifier() == L"default") {
+		result.clear();
+	}
+	
 	return result;
 }
 

--- a/src/audio/XAudio2API.cpp
+++ b/src/audio/XAudio2API.cpp
@@ -187,10 +187,6 @@ const std::vector<XAudio2API::DeviceDescriptionPtr>& XAudio2API::RefreshDevices(
 	// this function must be called from the same thread as we called CoInitializeEx
 	s_devices.clear();
 
-	// always add the default device
-	auto default_device = std::make_shared<XAudio2DeviceDescription>(L"Primary Sound Driver", L"");
-	s_devices.emplace_back(default_device);
-
 	if (FAILED(CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE)))
 		return s_devices;
 
@@ -262,6 +258,12 @@ const std::vector<XAudio2API::DeviceDescriptionPtr>& XAudio2API::RefreshDevices(
 			}
 		}
 
+		// Only add default device if audio devices exist
+		if (s_devices.size() > 0) {
+			auto default_device = std::make_shared<XAudio2DeviceDescription>(L"Primary Sound Driver", L"");
+			s_devices.insert(s_devices.begin(), default_device);
+		}
+		
 		wbem_enum->Release();
 
 		// Clean up


### PR DESCRIPTION
[Bug #620](http://bugs.cemu.info/issues/620) Fixed crash when no audio devices are present

Steps to reproduce: 
1. In Window Sound manager, under Playback devices, disable all output devices
2. Start Cemu
3. Start any game
4. Cemu immediately closes

Updated functionality
1. When no audio devices are present on the PC, Cemu will no longer crash when starting a game.
2. Options-> General Settings ->  Audio, for both the APIs DirectSound and XAudio2, the TV/Device will now show as "Disabled" when no audio devices are present, previously it would display as "Primary Sound Driver"