### PR TITLE
Fix various compiler warnings and update OpenSSL hash functions

### DIFF
--- a/src/Cafe/Account/Account.cpp
+++ b/src/Cafe/Account/Account.cpp
@@ -562,9 +562,9 @@ void makePWHash(uint8* input, sint32 length, uint32 magic, uint8* output)
 	buffer[2] = (magic >> 16) & 0xFF;
 	buffer[3] = (magic >> 24) & 0xFF;
 	memcpy(buffer + 8, input, length);
-	uint8 md[32];
+	uint8 md[SHA256_DIGEST_LENGTH];
 	SHA256(buffer, 8 + length, md);
-	memcpy(output, md, 32);
+	memcpy(output, md, SHA256_DIGEST_LENGTH);
 }
 
 void actPwTest()

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VKRBase.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VKRBase.h
@@ -50,6 +50,7 @@ public:
 	VKRMoveableRefCounter& operator=(VKRMoveableRefCounter&& rhs) noexcept
 	{
 		cemu_assert(false);
+		return *this;
 	}
 
 	void addRef(VKRMoveableRefCounter* refTarget)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -420,11 +420,8 @@ void VulkanPipelineStableCache::WorkerThread()
 		SerializePipeline(memWriter, *job);
 		auto blob = memWriter.getResult();
 		// file name is derived from data hash
-		uint8 hash[256 / 8];
-		SHA256_CTX sha256;
-		SHA256_Init(&sha256);
-		SHA256_Update(&sha256, blob.data(), blob.size());
-		SHA256_Final(hash, &sha256);
+		uint8 hash[SHA256_DIGEST_LENGTH];
+		SHA256(blob.data(), blob.size(), hash);
 		uint64 nameA = *(uint64be*)(hash + 0);
 		uint64 nameB = *(uint64be*)(hash + 8);
 		s_cache->AddFileAsync({ nameA, nameB }, blob.data(), blob.size());

--- a/src/Cafe/IOSU/legacy/iosu_crypto.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.cpp
@@ -53,7 +53,7 @@ bool iosuCrypto_getDeviceId(uint32* deviceId)
 {
 	uint32be deviceIdBE;
 	*deviceId = 0;
-	if (otpMem == nullptr)
+	if (!hasOtpMem)
 		return false;
 	iosuCrypto_readOtpData(&deviceIdBE, 0x87, sizeof(uint32));
 	*deviceId = (uint32)deviceIdBE;
@@ -227,7 +227,7 @@ void iosuCrypto_generateDeviceCertificate()
 {
 	static_assert(sizeof(g_wiiuDeviceCert) == 0x180);
 	memset(&g_wiiuDeviceCert, 0, sizeof(g_wiiuDeviceCert));
-	if (otpMem == nullptr)
+	if (!hasOtpMem)
 		return; // cant generate certificate without OPT
 
 	// set header based on otp security mode

--- a/src/Cafe/IOSU/legacy/iosu_crypto.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.cpp
@@ -6,7 +6,6 @@
 #include "openssl/ec.h"
 #include "openssl/x509.h"
 #include "openssl/ssl.h"
-#include "openssl/sha.h"
 #include "openssl/ecdsa.h"
 
 #include "util/crypto/aes128.h"
@@ -291,14 +290,6 @@ void iosuCrypto_generateDeviceCertificate()
 	EC_POINT_free(pubkey);
 	BN_CTX_end(context); // clears all BN variables
 	BN_CTX_free(context);
-}
-
-void CertECC_generateHashForSignature(CertECC_t& cert, CHash256& hashOut)
-{
-	SHA256_CTX sha256;
-	SHA256_Init(&sha256);
-	SHA256_Update(&sha256, cert.certificateSubject, 0x100);
-	SHA256_Final(hashOut.b, &sha256);
 }
 
 bool iosuCrypto_hasAllDataForLogin()

--- a/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
+++ b/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
@@ -100,13 +100,13 @@ namespace nn
 			// decrypt data
 			uint8 iv[16];
 			memcpy(iv, idbeAesIv, sizeof(iv));
-			uint8 decryptedSHA256[32];
+			uint8 decryptedSHA256[SHA256_DIGEST_LENGTH];
 			AES128_CBC_decrypt_updateIV(decryptedSHA256, iconInput->hashSHA256, sizeof(decryptedSHA256), idbeAesKeys + 16 * idbeHeader->keyIndex, iv);
 			AES128_CBC_decrypt((uint8*)iconOutput, (uint8*)&iconInput->iconData, sizeof(iconInput->iconData), idbeAesKeys + 16 * idbeHeader->keyIndex, iv);
 			// calculate and compare sha256
-			uint8 calculatedSHA256[32];
-			SHA256((const unsigned char*)iconOutput, sizeof(nnIdbeIconDataV0_t), (unsigned char*)&calculatedSHA256);
-			if (memcmp(calculatedSHA256, decryptedSHA256, 32) != 0)
+			uint8 calculatedSHA256[SHA256_DIGEST_LENGTH];
+			SHA256((const unsigned char*)iconOutput, sizeof(nnIdbeIconDataV0_t), calculatedSHA256);
+			if (memcmp(calculatedSHA256, decryptedSHA256, SHA256_DIGEST_LENGTH) != 0)
 			{
 				forceLogDebug_printf("Idbe icon has incorrect sha256 hash");
 				return false;

--- a/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
+++ b/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
@@ -581,7 +581,7 @@ void DownloadManager::searchForIncompleteDownloads()
 		uint64 titleId;
 		uint32 version;
 		std::string name = p.path().filename().generic_string();
-		if( sscanf(name.c_str(), "cemu_% " PRIx64 "_v%u", &titleId, &version) != 2)
+		if( sscanf(name.c_str(), "cemu_%" PRIx64 "_v%u", &titleId, &version) != 2)
 			continue;
 		std::unique_lock<std::recursive_mutex> _l(m_mutex);
 		for (auto& itr : m_ticketCache)

--- a/src/Cemu/napi/napi_idbe.cpp
+++ b/src/Cemu/napi/napi_idbe.cpp
@@ -124,12 +124,9 @@ namespace NAPI
 		// decrypt icon data and hash
 		_decryptIDBEAndHash(&iconDataV0, hash, keyIndex);
 		// verify hash of decrypted data
-		uint8 calcHash[32];
-		SHA256_CTX shaCtx;
-		SHA256_Init(&shaCtx);
-		SHA256_Update(&shaCtx, &iconDataV0, sizeof(IDBEIconDataV0));
-		SHA256_Final(calcHash, &shaCtx);
-		if (std::memcmp(calcHash, hash, 32) != 0)
+		uint8 calcHash[SHA256_DIGEST_LENGTH];
+		SHA256((const unsigned char*) &iconDataV0, sizeof(IDBEIconDataV0), calcHash);
+		if (std::memcmp(calcHash, hash, SHA256_DIGEST_LENGTH) != 0)
 		{
 			cemuLog_log(LogType::Force, "IDBE_Request: Hash mismatch");
 			return std::nullopt;

--- a/src/Cemu/ncrypto/ncrypto.cpp
+++ b/src/Cemu/ncrypto/ncrypto.cpp
@@ -153,20 +153,14 @@ namespace NCrypto
 
 	/* Hashing */
 
-	void GenerateHashSHA256(void* data, size_t len, CHash256& hashOut)
+	void GenerateHashSHA1(const void* data, size_t len, CHash160& hashOut)
 	{
-		SHA256_CTX sha256;
-		SHA256_Init(&sha256);
-		SHA256_Update(&sha256, data, len);
-		SHA256_Final(hashOut.b, &sha256);
+		SHA1((const unsigned char*) data, len, hashOut.b);
 	}
 
-	void GenerateHashSHA1(void* data, size_t len, CHash160& hashOut)
+	void GenerateHashSHA256(const void* data, size_t len, CHash256& hashOut)
 	{
-		SHA_CTX shaCtx;
-		SHA1_Init(&shaCtx);
-		SHA1_Update(&shaCtx, data, len);
-		SHA1_Final(hashOut.b, &shaCtx);
+		SHA256((const unsigned char*) data, len, hashOut.b);
 	}
 
 	/* Ticket */
@@ -373,7 +367,7 @@ namespace NCrypto
 		EC_POINT_free(ec_publicKey);
 
 		NCrypto::CHash160 sharedKeySHA1;
-		GenerateHashSHA1(sharedKey, sharedKeyLen, sharedKeySHA1);
+		NCrypto::GenerateHashSHA1(sharedKey, sharedKeyLen, sharedKeySHA1);
 
 		uint8 aesSharedKey[16]{};
 		std::memcpy(aesSharedKey, sharedKeySHA1.b, 16);
@@ -621,11 +615,8 @@ namespace NCrypto
 
 	bool CertECC::verifySignatureViaPubKey(ECCPubKey& signerPubKey)
 	{
-		uint8 hash[32];
-		SHA256_CTX sha256;
-		SHA256_Init(&sha256);
-		SHA256_Update(&sha256, this->issuer, 0x100);
-		SHA256_Final(hash, &sha256);
+		uint8 hash[SHA256_DIGEST_LENGTH];
+		SHA256((const unsigned char *) this->issuer, 0x100, hash);
 
 		EC_KEY* ecPubKey = signerPubKey.getPublicKey();
 		ECDSA_SIG* ecSig = this->signature.getSignature();
@@ -640,11 +631,8 @@ namespace NCrypto
 
 	void CertECC::sign(ECCPrivKey& signerPrivKey)
 	{
-		uint8 hash[32];
-		SHA256_CTX sha256;
-		SHA256_Init(&sha256);
-		SHA256_Update(&sha256, this->issuer, 0x100);
-		SHA256_Final(hash, &sha256);
+		uint8 hash[SHA256_DIGEST_LENGTH];
+		SHA256((const unsigned char *) this->issuer, 0x100, hash);
 
 		// generate signature
 		EC_KEY* ec_privKey = signerPrivKey.getPrivateKey();

--- a/src/Cemu/ncrypto/ncrypto.h
+++ b/src/Cemu/ncrypto/ncrypto.h
@@ -197,7 +197,7 @@ namespace NCrypto
 
 	DEFINE_ENUM_FLAG_OPERATORS(TMDParser::TMDContentFlags);
 
-	void GenerateHashSHA256(void* data, size_t len, CHash256& hashOut);
+	void GenerateHashSHA256(const void* data, size_t len, CHash256& hashOut);
 	ECCSig signHash(uint32 signerTitleIdHigh, uint32 signerTitleIdLow, uint8* hash, sint32 hashLen, CertECC& certChainOut);
 
 	uint32 GetDeviceId();


### PR DESCRIPTION
`SHA1_Init`, `SHA1_Update`, `SHA1_Final`, `SHA256_Init`, `SHA256_Update`, `SHA256_Final` have been deprecated in OpenSSL 3.0 and will be removed in future versions.
- Replaced several simple calls to the `SHA1()` or `SHA256()` macro provided by OpenSSL
- Replaced other calls to deprecated functions with `EVP_DigestXXX` functions.
- Fixed an invalid sscanf format in DownloadManager
- Fixed unset return value  for `operator=` in VKRBase.h
- Fixed always-true checks for otpMem in `iosu_crypto`