### PR TITLE
Initial implementation of macOS Vulkan renderer over MoltenVK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if (NOT TARGET glslang::SPIRV AND TARGET SPIRV)
 	add_library(glslang::SPIRV ALIAS SPIRV)
 endif()
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,11 @@ if(MSVC)
     # _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
     # _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
 elseif(UNIX)
-    if(NOT APPLE)
+    if(APPLE)
+        add_definitions(-D_XOPEN_SOURCE)
+        add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+        add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
+    else()
         add_definitions(-DVK_USE_PLATFORM_XLIB_KHR) # legacy. Do we need to support XLIB surfaces?
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -6,7 +6,13 @@ endif()
 
 file(GLOB_RECURSE CPP_FILES *.cpp)
 file(GLOB_RECURSE H_FILES *.h)
-add_library(CemuCafe ${CPP_FILES} ${H_FILES})
+
+if(APPLE)
+	file(GLOB_RECURSE MM_FILES *.mm)
+	add_library(CemuCafe ${CPP_FILES} ${MM_FILES} ${H_FILES})
+else()
+	add_library(CemuCafe ${CPP_FILES} ${H_FILES})
+endif()
 
 set_property(TARGET CemuCafe PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -182,6 +182,8 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 			m_gfx_vendor = GfxVendor::Mesa;
 		else if (boost::iequals(*option_vendorFilter, "nvidia"))
 			m_gfx_vendor = GfxVendor::Nvidia;
+		else if (boost::iequals(*option_vendorFilter, "apple"))
+			m_gfx_vendor = GfxVendor::Apple;
 		else
 			cemuLog_force("Unknown value '{}' for vendorFilter", *option_vendorFilter);
 	}

--- a/src/Cafe/HW/Latte/Core/LatteConst.h
+++ b/src/Cafe/HW/Latte/Core/LatteConst.h
@@ -79,6 +79,7 @@
 #define GLVENDOR_INTEL_LEGACY		(3)
 #define GLVENDOR_INTEL_NOLEGACY		(4)
 #define GLVENDOR_INTEL				(5)
+#define GLVENDOR_APPLE				(6)
 
 // decompiler
 

--- a/src/Cafe/HW/Latte/Core/LatteThread.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteThread.cpp
@@ -161,6 +161,8 @@ int Latte_ThreadEntry()
 	case GfxVendor::Nvidia: 
 		LatteGPUState.glVendor = GLVENDOR_NVIDIA; 
 		break;
+	case GfxVendor::Apple:
+		LatteGPUState.glVendor = GLVENDOR_APPLE;
 	default:
 		break;
 	}

--- a/src/Cafe/HW/Latte/Renderer/Renderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Renderer.h
@@ -21,6 +21,7 @@ enum class GfxVendor
 	IntelNoLegacy,
 	Intel,
 	Nvidia,
+	Apple,
 	Mesa,
 
 	MAX

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if BOOST_OS_MACOS
+
+#include <vulkan/vulkan.h>
+
+VkSurfaceKHR CreateCocoaSurface(VkInstance instance, void* handle);
+
+#endif

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
@@ -1,0 +1,45 @@
+#include "Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.h"
+#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/CAMetalLayer.h>
+
+@interface MetalView : NSView
+@end
+
+@implementation MetalView
+
+-(BOOL) wantsUpdateLayer { return YES; }
+
++(Class) layerClass { return [CAMetalLayer class]; }
+
+-(CALayer*) makeBackingLayer { return [self.class.layerClass layer]; }
+
+@end
+
+VkSurfaceKHR CreateCocoaSurface(VkInstance instance, void* handle)
+{
+	NSView* view = (NSView*)handle;
+
+	MetalView* childView = [[MetalView alloc] initWithFrame:view.bounds];
+	childView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+	childView.wantsLayer = YES;
+
+	[view addSubview:childView];
+
+	VkMetalSurfaceCreateInfoEXT surface;
+	surface.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+	surface.pNext = NULL;
+	surface.flags = 0;
+	surface.pLayer = (CAMetalLayer*)childView.layer;
+
+	VkSurfaceKHR result;
+	VkResult err;
+	if ((err = vkCreateMetalSurfaceEXT(instance, &surface, nullptr, &result)) != VK_SUCCESS)
+	{
+		forceLog_printf("Cannot create a Metal Vulkan surface: %d", (sint32)err);
+		throw std::runtime_error(fmt::format("Cannot create a Metal Vulkan surface: {}", err));
+	}
+
+	return result;
+}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.cpp
@@ -65,10 +65,14 @@ bool InitializeDeviceVulkan(VkDevice device)
 
 void* dlopen_vulkan_loader()
 {
-    void* vulkan_so = dlopen("libvulkan.so", RTLD_NOW);
-    if(!vulkan_so)
-        vulkan_so = dlopen("libvulkan.so.1", RTLD_NOW);
-    return vulkan_so;
+#if BOOST_OS_LINUX
+	void* vulkan_so = dlopen("libvulkan.so", RTLD_NOW);
+	if(!vulkan_so)
+		vulkan_so = dlopen("libvulkan.so.1", RTLD_NOW);
+#elif BOOST_OS_MACOS
+	void* vulkan_so = dlopen("libMoltenVK.dylib", RTLD_NOW);
+#endif
+	return vulkan_so;
 }
 
 bool InitializeGlobalVulkan()

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
@@ -135,6 +135,10 @@ VKFUNC_INSTANCE(vkCreateXcbSurfaceKHR);
 VKFUNC_INSTANCE(vkCreateWin32SurfaceKHR);
 #endif
 
+#if BOOST_OS_MACOS
+VKFUNC_INSTANCE(vkCreateMetalSurfaceEXT);
+#endif
+
 VKFUNC_INSTANCE(vkDestroySurfaceKHR);
 VKFUNC_DEVICE(vkCreateSwapchainKHR);
 VKFUNC_DEVICE(vkDestroySwapchainKHR);

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(CemuCommon PRIVATE
 	glm::glm
 )
 
-if (UNIX)
+if (UNIX AND NOT APPLE)
 	target_link_libraries(CemuCommon PRIVATE X11::X11 X11::Xrender X11::Xutil)
 endif()
 

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -90,6 +90,8 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 		graphicMode = "[Intel GPU]";
 	else if (LatteGPUState.glVendor == GLVENDOR_NVIDIA)
 		graphicMode = "[NVIDIA GPU]";
+	else if (LatteGPUState.glVendor == GLVENDOR_APPLE)
+		graphicMode = "[Apple GPU]";
 
 	const uint64 titleId = CafeSystem::GetForegroundTitleId();
     windowText.append(fmt::format(" - FPS: {:.2f} {} {} [TitleId: {:08x}-{:08x}]", (double)fps, renderer, graphicMode, (uint32)(titleId >> 32), (uint32)(titleId & 0xFFFFFFFF)));
@@ -197,6 +199,8 @@ void gui_initHandleContextFromWxWidgetsWindow(WindowHandleInfo& handleInfoOut, c
     {
         cemuLog_log(LogType::Force, "Unable to get xlib display");
     }
+#else
+	handleInfoOut.handle = wxw->GetHandle();
 #endif
 }
 

--- a/src/gui/guiWrapper.h
+++ b/src/gui/guiWrapper.h
@@ -20,6 +20,8 @@ struct WindowHandleInfo
 	//xcb_window_t xcb_window{};
 	// Wayland
 	// todo
+#else
+	void* handle;
 #endif
 };
 

--- a/src/util/Fiber/FiberUnix.cpp
+++ b/src/util/Fiber/FiberUnix.cpp
@@ -1,6 +1,5 @@
 #include "Fiber.h"
 #if BOOST_OS_LINUX || BOOST_OS_MACOS
-#define _XOPEN_SOURCE
 #include <ucontext.h>
 
 thread_local Fiber* sCurrentFiber{};


### PR DESCRIPTION
Hi there!

As I promised here #52, this PR brings initial support for Vulkan over MoltenVK renderer on macOS.

This is enough to actually run some games to some extent. For now, I got a game to the stage where splash screen and loading screen appears, and actually works.

Some additional tinkering would be definitely necessary for the renderer to work on more non-trivial scenarios, but I guess it's a good step forward!

Geometry shaders and logic ops are explicitly turned off, so if any shader would emit code containing those features, it'll probably break. I believe we can work around this in future.

Some screenshots for you:
<img width="833" alt="Zrzut ekranu 2022-08-30 o 16 46 09" src="https://user-images.githubusercontent.com/849632/187473577-4deffbee-d8a0-49b9-9e6f-fe7c49d4f88d.png">
<img width="1392" alt="Zrzut ekranu 2022-08-30 o 16 46 17" src="https://user-images.githubusercontent.com/849632/187473590-f6733afa-dac6-44d5-96c1-b2df08e6a9d7.png">
<img width="1392" alt="Zrzut ekranu 2022-08-30 o 16 46 31" src="https://user-images.githubusercontent.com/849632/187473627-d3a2f1ff-f7fc-417e-9c4f-df4abf7d41fd.png">
