### PR TITLE
Correct wxMenu ID to resolve macOS crash

### DIFF
--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -310,7 +310,7 @@ void wxDownloadManagerList::OnItemSelected(wxListEvent& event)
 
 enum ContextMenuEntries
 {
-	kContextMenuRetry,
+	kContextMenuRetry = wxID_HIGHEST + 1,
 	kContextMenuDownload,
 	kContextMenuPause,
 	kContextMenuResume,

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -435,7 +435,7 @@ void wxGameList::OnKeyDown(wxListEvent& event)
 
 enum ContextMenuEntries
 {
-	kContextMenuRefreshGames,
+	kContextMenuRefreshGames = wxID_HIGHEST + 1,
 	
 	kContextMenuStart,
 	kWikiPage,
@@ -655,7 +655,7 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 {
 	enum ItemIds
 	{
-		ResetWidth,
+		ResetWidth = wxID_HIGHEST + 1,
 		ResetOrder,
 		
 		ShowName,

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -728,7 +728,7 @@ void wxTitleManagerList::OnItemSelected(wxListEvent& event)
 
 enum ContextMenuEntries
 {
-	kContextMenuOpenDirectory,
+	kContextMenuOpenDirectory = wxID_HIGHEST + 1,
 	kContextMenuDelete,
 	kContextMenuLaunch,
 	kContextMenuVerifyGameFiles,

--- a/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
+++ b/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
@@ -10,7 +10,7 @@
 enum
 {
 	// options
-	REFRESH_ID,
+	REFRESH_ID = wxID_HIGHEST + 1,
 	AUTO_REFRESH_ID,
 	CLOSE_ID,
 	GPLIST_ID,


### PR DESCRIPTION
wxMenu ID = 0 is illegal on macOS.

`../src/osx/menuitem_osx.cpp(42): assert "id != 0 || pSubMenu != NULL" failed in wxMenuItem(): A MenuItem ID of Zero does not work under Mac`

Let's correct all the zero-starting ids to start with `wxID_HIGHEST + 1` resolving macOS GUI crashes.