### PR TITLE
Disable Doxygen in CMake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.21.1)
 
 option(PUBLIC_RELEASE "Compile with debug asserts disabled and no console" OFF)
 option(ENABLE_VCPKG "Enable the vcpkg package manager" ON)
+option(CMAKE_DISABLE_FIND_PACKAGE_Doxygen "Disable Doxygen in dependencies" TRUE)
 set(EXPERIMENTAL_VERSION "" CACHE STRING "") # used by CI script to set experimental version
 
 if (PUBLIC_RELEASE)


### PR DESCRIPTION
Reduces the verbosity of the cubeb dependency build (and saves a bit of
processing time and disk space)

```
[10/484] Generating API documentation with Doxygen
/root/cemu/dependencies/cubeb/include/cubeb/cubeb.h:188: warning: Member cubeb_channel_layout (typedef) of file cubeb.h is not documented.
/root/cemu/dependencies/cubeb/include/cubeb/cubeb.h:166: warning: Member cubeb_channel (enumeration) of file cubeb.h is not documented.
/root/cemu/dependencies/cubeb/include/cubeb/cubeb.h:436: warning: argument 'user' of command @param is not found in the argument list of cubeb_device_changed_callback(void *user_ptr)
/root/cemu/dependencies/cubeb/include/cubeb/cubeb.h:437: warning: The following parameter of cubeb_device_changed_callback(void *user_ptr) is not documented:
  parameter 'user_ptr'
```