### PR TITLE
Fix asserts in TitleManager and DownloadManager

### DIFF
--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -629,7 +629,13 @@ void wxDownloadManagerList::SortEntries()
 	RefreshPage();
 }
 
-void wxDownloadManagerList::RefreshPage() { RefreshItems(GetTopItem(), GetTopItem() + GetCountPerPage() + 1); }
+void wxDownloadManagerList::RefreshPage()
+{
+	long item_count = GetItemCount();
+
+	if (item_count > 0)
+		RefreshItems(GetTopItem(), std::min(item_count - 1, GetTopItem() + GetCountPerPage() + 1));
+}
 
 int wxDownloadManagerList::Filter(const wxString& filter, const wxString& prefix, ItemColumn column)
 {

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -1170,7 +1170,13 @@ void wxTitleManagerList::SortEntries(int column)
 	RefreshPage();
 }
 
-void wxTitleManagerList::RefreshPage() { RefreshItems(GetTopItem(), GetTopItem() + GetCountPerPage() + 1); }
+void wxTitleManagerList::RefreshPage()
+{
+	long item_count = GetItemCount();
+
+	if (item_count > 0)
+		RefreshItems(GetTopItem(), std::min(item_count - 1, GetTopItem() + GetCountPerPage() + 1));
+}
 
 int wxTitleManagerList::Filter(const wxString& filter, const wxString& prefix, ItemColumn column)
 {


### PR DESCRIPTION
Fix debug asserts when opening the TitleManager or DownloadManager.

Indices of `RefreshItems()` must be greater than 0 and smaller or equal to the index of the last item.