### PR TITLE
Fixes for building on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ out/
 .cache/
 bin/Cemu
 
+.DS_Store
+
 # Cemu bin files
 bin/otp.bin
 bin/seeprom.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ if (MSVC)
   endif()
 endif()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+  # Clang versions below 14 have issues with consteval in fmt: https://github.com/fmtlib/fmt/issues/2455
+  add_compile_definitions(FMT_CONSTEVAL=)
+endif()
+
 option(ENABLE_OPENGL "Enables the OpenGL backend" ON)
 option(ENABLE_VULKAN "Enables the Vulkan backend" ON)
 option(ENABLE_DISCORD_RPC "Enables the Discord Rich Presence feature" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION
   add_compile_definitions(FMT_CONSTEVAL=)
 endif()
 
+if (APPLE)
+	enable_language(OBJC OBJCXX)
+endif()
+
 option(ENABLE_OPENGL "Enables the OpenGL backend" ON)
 option(ENABLE_VULKAN "Enables the Vulkan backend" ON)
 option(ENABLE_DISCORD_RPC "Enables the Discord Rich Presence feature" ON)

--- a/src/gui/MemorySearcherTool.cpp
+++ b/src/gui/MemorySearcherTool.cpp
@@ -300,14 +300,14 @@ void MemorySearcherTool::Load()
 		bool found = false;
 		for (const auto& entry : kDataTypeNames)
 		{
-			if (boost::iequals(entry, *option_type))
+			if (boost::iequals(std::string(entry.mb_str()), *option_type))
 			{
 				found = true;
 				break;
 			}
 		}
 
-		if (!found && !boost::iequals(kDatatypeString, *option_type))
+		if (!found && !boost::iequals(std::string(kDatatypeString.mb_str()), *option_type))
 			continue;
 
 		wxVector<wxVariant> data;

--- a/src/gui/components/wxLogCtrl.cpp
+++ b/src/gui/components/wxLogCtrl.cpp
@@ -68,7 +68,7 @@ void wxLogCtrl::PushEntry(const wxString& filter, const wxString& message)
 	ListIt_t it = m_log_entries.back();
 	lock.unlock();
 
-	if(m_active_filter.empty() || filter == m_active_filter || (m_filter_messages && boost::icontains(message, m_active_filter)))
+	if(m_active_filter.empty() || filter == m_active_filter || (m_filter_messages && boost::icontains(std::string(message.mb_str()), m_active_filter)))
 	{
 		std::unique_lock active_lock(m_active_mutex);
 		m_active_entries.emplace_back(std::cref(it));
@@ -149,7 +149,7 @@ void wxLogCtrl::UpdateActiveEntries()
 		{
 			for (const auto& it : m_log_entries)
 			{
-				if(it.first == m_active_filter || (m_filter_messages && boost::icontains(it.second, m_active_filter)) )
+				if(it.first == m_active_filter || (m_filter_messages && boost::icontains(std::string(it.second.mb_str()), m_active_filter)) )
 					m_active_entries.emplace_back(it);
 			}
 		}

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -200,10 +200,10 @@ boost::optional<wxTitleManagerList::TitleEntry&> wxTitleManagerList::GetTitleEnt
 
 boost::optional<const wxTitleManagerList::TitleEntry&> wxTitleManagerList::GetTitleEntry(const fs::path& path) const
 {
-	const auto tmp = path.generic_u8string();
+	const auto tmp = _utf8Wrapper(path);
 	for (const auto& data : m_data)
 	{
-		if (boost::iequals(data->entry.path.generic_u8string(), tmp))
+		if (boost::iequals(_utf8Wrapper(data->entry.path), tmp))
 			return data->entry;
 	}
 
@@ -211,10 +211,10 @@ boost::optional<const wxTitleManagerList::TitleEntry&> wxTitleManagerList::GetTi
 }
 boost::optional<wxTitleManagerList::TitleEntry&> wxTitleManagerList::GetTitleEntry(const fs::path& path)
 {
-	const auto tmp = path.generic_u8string();
+	const auto tmp = _utf8Wrapper(path);
 	for (const auto& data : m_data)
 	{
-		if (boost::iequals(data->entry.path.generic_u8string(), tmp))
+		if (boost::iequals(_utf8Wrapper(data->entry.path), tmp))
 			return data->entry;
 	}
 


### PR DESCRIPTION
Various fixes, including:

* `_umul128` is a built-in on clang, so we shouldn't attempt to redefine it.
* Remove usages of `u8string` in `wxTitleManagerList`.
* Always convert to `std::string` first when using `boost:icompare` in `wxLogCtrl` and `MemorySearcherTool` (not sure if this is 100% sane, but it does fix errors similar to those in the comments from [the prior macOS PR](https://github.com/cemu-project/Cemu/pull/52#issuecomment-1228516082)).