### PR TITLE
nn_act: Fix account endianness

### DIFF
--- a/src/Cafe/Account/Account.cpp
+++ b/src/Cafe/Account/Account.cpp
@@ -29,7 +29,7 @@ typedef struct
 	/* +0x0C */ uint8		ukn0C[0xA];
 	/* +0x16 */ uint8		ukn16[2];
 	/* +0x18 */ uint16		ukn18;
-	/* +0x1A */ uint16be	miiName[10];
+	/* +0x1A */ uint16le	miiName[10];
 	/* +0x2E */ uint16		ukn2E;
 	/* +0x30 */ uint8		ukn30[96 - 0x30];
 }FFLData_t;
@@ -102,7 +102,7 @@ Account::Account(uint32 persistent_id, std::wstring_view mii_name)
 	FFLData_t* fflData = (FFLData_t*)m_mii_data.data();
 	const auto tmp_name = GetMiiName();
 	memset(fflData->miiName, 0, sizeof(fflData->miiName));
-	std::copy(tmp_name.cbegin(), tmp_name.cend(), fflData->miiName);
+	std::copy(tmp_name.begin(), tmp_name.end(), fflData->miiName);
 
 	// calculate checksum
 	uint32 crcCounter = 0;

--- a/src/Cafe/IOSU/legacy/iosu_act.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_act.cpp
@@ -48,7 +48,7 @@ typedef struct
 	char country[8];
 	// Mii
 	FFLData_t miiData;
-	uint16be miiNickname[ACT_NICKNAME_LENGTH];
+	uint16le miiNickname[ACT_NICKNAME_LENGTH];
 }actAccountData_t;
 
 #define IOSU_ACT_ACCOUNT_MAX_COUNT (0xC)
@@ -103,6 +103,15 @@ void iosuAct_loadAccounts()
 	const auto& first_acc = Account::GetAccount(persistent_id);
 	FillAccountData(first_acc, online_enabled, counter);
 	++counter;
+	// enable multiple accounts for cafe functions (badly tested)
+	//for (const auto& account : Account::GetAccounts())
+	//{
+	//	if (first_acc.GetPersistentId() != account.GetPersistentId())
+	//	{
+	//		FillAccountData(account, online_enabled, counter);
+	//		++counter;
+	//	}
+	//}
 
 	cemuLog_force(L"IOSU_ACT: using account {} in first slot", first_acc.GetMiiName());
 	

--- a/src/Cafe/IOSU/legacy/iosu_act.h
+++ b/src/Cafe/IOSU/legacy/iosu_act.h
@@ -25,7 +25,7 @@ typedef struct
 	/* +0x0C */ uint8		ukn0C[0xA];
 	/* +0x16 */ uint8		ukn16[2];
 	/* +0x18 */ uint16		ukn18;
-	/* +0x1A */ uint16be	miiName[MII_FFL_NAME_LENGTH];
+	/* +0x1A */ uint16le	miiName[MII_FFL_NAME_LENGTH];
 	/* +0x2E */ uint16		ukn2E;
 	/* +0x30 */ uint8		ukn30[MII_FFL_STORAGE_SIZE-0x30];
 }FFLData_t;

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -138,11 +138,9 @@ void nnActExport_GetNumOfAccounts(PPCInterpreter_t* hCPU)
 void nnActExport_IsSlotOccupied(PPCInterpreter_t* hCPU)
 {
 	forceLogDebug_printf("nn_act.IsSlotOccupied(%d)\n", hCPU->gpr[3]);
-	sint32 slotIndex = (sint32)hCPU->gpr[3] - 1; // first slot is 1
-	bool isOccupied = false;
-	if( slotIndex == 0 )
-		isOccupied = true;
-	osLib_returnFromFunction(hCPU, isOccupied?1:0);
+	ppcDefineParamU8(slot, 0);
+	
+	osLib_returnFromFunction(hCPU, nn::act::GetPersistentIdEx(slot) != 0 ? 1 : 0);
 }
 
 uint32 GetAccountIdEx(char* accountId, uint8 slot)


### PR DESCRIPTION
I think there was a regression where Cemu 2.0 had the wrong endianness (BE) for accounts it created (which includes the default account). Meanwhile accounts obtained from the Wii U had a little-endian format and couldn't be obtained properly.

This fixes the endianness to be correct. I'm not sure where to correct it in Account too, hence the pull request.