### PR TITLE
Add SIGINT handler on posix systems 

### DIFF
--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -11,18 +11,19 @@ target_sources(CemuCommon
 PRIVATE
     windows/platform.cpp
     windows/platform.h
+    ExceptionHandler/ExceptionHandler_win32.cpp
 )
 else()
 target_sources(CemuCommon
 PRIVATE
     unix/platform.cpp
     unix/platform.h
+    ExceptionHandler/ExceptionHandler_posix.cpp
 )
 endif()
 
 target_sources(CemuCommon
         PRIVATE
-        ExceptionHandler/ExceptionHandler.cpp
         ExceptionHandler/ExceptionHandler.h
         )
 

--- a/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
@@ -1,0 +1,36 @@
+#include <signal.h>
+#include <execinfo.h>
+
+void handler_SIGSEGV(int sig)
+{
+    printf("SIGSEGV!\n");
+
+    void *array[32];
+    size_t size;
+
+    // get void*'s for all entries on the stack
+    size = backtrace(array, 32);
+
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d:\n", sig);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+    exit(1);
+}
+
+void handler_SIGINT(int sig)
+{
+    /*
+     * Received when pressing CTRL + C in a console
+     * Ideally should be exiting cleanly after saving settings but currently
+     * there's no clean exit pathway (at least on linux) and exiting the app
+     * by any mean ends up with a SIGABRT from the standard library destroying
+     * threads.
+     */
+    exit(0);
+}
+
+void ExceptionHandler_init()
+{
+    signal(SIGSEGV, handler_SIGSEGV);
+    signal(SIGINT, handler_SIGINT);
+}

--- a/src/Common/ExceptionHandler/ExceptionHandler_win32.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler_win32.cpp
@@ -1,12 +1,6 @@
 #include "Common/precompiled.h"
 #include "Cafe/CafeSystem.h"
 
-#if BOOST_OS_LINUX || BOOST_OS_MACOS
-#include <signal.h>
-#include <execinfo.h>
-#endif
-
-#if BOOST_OS_WINDOWS
 #include <Windows.h>
 #include <Dbghelp.h>
 #include <shellapi.h>
@@ -16,16 +10,11 @@
 #include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
 #include "Cafe/HW/Espresso/PPCState.h"
 
-#endif
-
 extern uint32 currentBaseApplicationHash;
 extern uint32 currentUpdatedApplicationHash;
 
-#if BOOST_OS_WINDOWS
-
 LONG handleException_SINGLE_STEP(PEXCEPTION_POINTERS pExceptionInfo)
 {
-
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
@@ -416,27 +405,3 @@ void ExceptionHandler_init()
 	AddVectoredExceptionHandler(1, VectoredExceptionHandler);
 	SetErrorMode(SEM_FAILCRITICALERRORS);
 }
-#else
-
-void handler_SIGSEGV(int sig)
-{
-    printf("SIGSEGV!\n");
-
-    void *array[32];
-    size_t size;
-
-    // get void*'s for all entries on the stack
-    size = backtrace(array, 32);
-
-    // print out all the frames to stderr
-    fprintf(stderr, "Error: signal %d:\n", sig);
-    backtrace_symbols_fd(array, size, STDERR_FILENO);
-    exit(1);
-}
-
-void ExceptionHandler_init()
-{
-    signal(SIGSEGV, handler_SIGSEGV);
-}
-
-#endif

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -399,11 +399,4 @@ void CemuApp::ActivateApp(wxActivateEvent& event)
 	event.Skip();
 }
 
-extern "C"
-{
-	CemuApp& wxGetAppWrapper()
-	{
-		return *static_cast<CemuApp*>(wxApp::GetInstance());
-	};
-}
 


### PR DESCRIPTION
There's currently no overlap between the windows and posix
implementation of the exception handler so I split them into
different files for better clarity.

Added a signal handler for `SIGINT` to allow exiting on `CTRL+C`.
Note that like the rest of the program it does not exit cleanly and
triggers a `SIGABRT.`

Also removes function `CemuApp& wxGetAppWrapper()`
that was seemingly unused but declared with C linkage despite
returning a C++ reference, which was causing a warning.