### PR TITLE
Fix UI asserts

### DIFF
--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -243,7 +243,8 @@ void wxGameList::SetStyle(Style style, bool save)
 		g_config.Save();
 	}
 
-	ApplyGameListColumnWidths();
+	if (style == Style::kList)
+		ApplyGameListColumnWidths();
 }
 
 long wxGameList::GetStyleFlags(Style style) const

--- a/src/gui/debugger/SymbolCtrl.cpp
+++ b/src/gui/debugger/SymbolCtrl.cpp
@@ -73,7 +73,8 @@ void SymbolListCtrl::OnGameLoaded()
 	rplSymbolStorage_unlockSymbolMap();
 
 	SetItemCount(m_data.size());
-	RefreshItems(GetTopItem(), GetTopItem() + GetCountPerPage() + 1);
+	if (m_data.size() > 0)
+		RefreshItems(GetTopItem(), std::min<long>(m_data.size() - 1, GetTopItem() + GetCountPerPage() + 1));
 }
 
 wxString SymbolListCtrl::OnGetItemText(long item, long column) const
@@ -159,5 +160,6 @@ void SymbolListCtrl::ChangeListFilter(std::string filter)
 		}
 	}
 	SetItemCount(visible_entries);
-	RefreshItems(GetTopItem(), GetTopItem() + GetCountPerPage() + 1);
+	if (visible_entries > 0)
+		RefreshItems(GetTopItem(), std::min<long>(visible_entries - 1, GetTopItem() + GetCountPerPage() + 1));
 }

--- a/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp
+++ b/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp
@@ -372,7 +372,9 @@ void TextureRelationViewerWindow::RefreshTextureList()
 		}
 	}
 	textureRelationListA->Thaw();
-	textureRelationListA->EnsureVisible(scrollPos + textureRelationListA->GetCountPerPage() - 1);
+	long itemCount = textureRelationListA->GetItemCount();
+	if (itemCount > 0)
+		textureRelationListA->EnsureVisible(std::min<long>(itemCount - 1, scrollPos + textureRelationListA->GetCountPerPage() - 1));
 }
 
 void TextureRelationViewerWindow::OnTextureListRightClick(wxMouseEvent& event)


### PR DESCRIPTION
### wxGameList.cpp

Triggered when switching to icon view (and on program start afterwards) after
having modified column lengths in the list view:
```
  0x00007ffff7a8ec4c in __pthread_kill_implementation () from /lib64/libc.so.6
  0x00007ffff7a3e9c6 in raise () from /lib64/libc.so.6
  0x00000000004ce24b in cemu_assert_debug (_condition=false) at /root/cemu/src/gui/../Common/precompiled.h:350
  0x0000000000c0f30d in CemuApp::OnAssertFailure (this=0x2dfdc80, file=0x2ec4880 L"/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=3473, func=0x32cec00 L"SetColumnWidth", cond=0x32ce750 L"\"InReportView()\"", msg=0x333ab70 L"SetColumnWidth() can only be called in report mode.") at /root/cemu/src/gui/CemuApp.cpp:164
  0x00000000010f2c04 in wxDefaultAssertHandler (file=..., line=3473, func=..., cond=..., msg=...) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1189
  0x00000000010f34a5 in wxOnAssert (file=0x1fe87f0 "/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=3473, func=0x1fe9c05 "SetColumnWidth", cond=0x1fe9ce8 "\"InReportView()\"", msg=0x1fe9c18 L"SetColumnWidth() can only be called in report mode.") at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1275
  0x0000000001355fbc in wxListMainWindow::SetColumnWidth (this=0x31d7800, col=2, width=-2) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:3473
  0x000000000135b07b in wxGenericListCtrl::SetColumnWidth (this=0x31e6860, col=2, width=-2) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:5200
  0x0000000000d0a724 in wxAutosizeColumn (ctrl=0x31e6860, col=2) at /root/cemu/src/gui/helpers/wxHelpers.cpp:12
  0x0000000000cb1893 in wxGameList::ApplyGameListColumnWidths()::$_3::operator()(int, int) const (this=0x7fffffffac60, id=2, width=-3) at /root/cemu/src/gui/components/wxGameList.cpp:767
  0x0000000000cb09f6 in wxGameList::ApplyGameListColumnWidths (this=0x31e6860) at /root/cemu/src/gui/components/wxGameList.cpp:774
  0x0000000000cb01f1 in wxGameList::SetStyle (this=0x31e6860, style=wxGameList::Style::kIcons, save=true) at /root/cemu/src/gui/components/wxGameList.cpp:246
[Truncated]
```
Getting back to a state where Cemu can be launched without crashing
requires changing settings.xml and switching GameList Style to 0.

Solution: Don't call SetColumnWidth if the game list is not in list
view.

### SymbolCtrl.cpp
```
Triggered when clicking "View PPC debugger"

  0x00007ffff7a8ec4c in __pthread_kill_implementation () from /lib64/libc.so.6
  0x00007ffff7a3e9c6 in raise () from /lib64/libc.so.6
  0x00000000004ce24b in cemu_assert_debug (_condition=false) at /root/cemu/src/gui/../Common/precompiled.h:350
  0x0000000000c0f30d in CemuApp::OnAssertFailure (this=0x2dfdc80, file=0x2ef3200 L"/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=1966, func=0x386e580 L"RefreshLines", cond=0x385c8b0 L"lineTo < GetItemCount()", msg=0x38318a0 L"invalid line range") at /root/cemu/src/gui/CemuApp.cpp:164
  0x00000000010f2c04 in wxDefaultAssertHandler (file=..., line=1966, func=..., cond=..., msg=...) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1189
  0x00000000010f34a5 in wxOnAssert (file=0x1fe87f0 "/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=1966, func=0x1fe92db "RefreshLines", cond=0x1fe9334 "lineTo < GetItemCount()",  msg=0x1fe92e8 L"invalid line range") at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1275
  0x0000000001351175 in wxListMainWindow::RefreshLines (this=0x386d400, lineFrom=0, lineTo=7) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:1966
  0x000000000135cbb4 in wxGenericListCtrl::RefreshItems (this=0x3861d10, itemFrom=0, itemTo=7) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:5837
  0x0000000000dea5b3 in SymbolListCtrl::OnGameLoaded (this=0x3861d10) at /root/cemu/src/gui/debugger/SymbolCtrl.cpp:76
  0x0000000000de9de9 in SymbolListCtrl::SymbolListCtrl (this=0x3861d10, parent=0x385d000, id=@0x7fffffffce6c: -1, pos=..., size=...) at /root/cemu/src/gui/debugger/SymbolCtrl.cpp:41
  0x0000000000cfe5af in SymbolWindow::SymbolWindow (this=0x385d000, parent=..., main_position=..., main_size=...) at /root/cemu/src/gui/debugger/SymbolWindow.cpp:21
[Truncated]
```
Solution: Boundary checks on the indices passed to RefreshLines

### TextureRelationWindow.cpp

Triggered after opening the "View texture cache info" menu.
```
  0x00007ffff7a8ec4c in __pthread_kill_implementation () from /lib64/libc.so.6
  0x00007ffff7a3e9c6 in raise () from /lib64/libc.so.6
  0x00000000004ce24b in cemu_assert_debug (_condition=false) at /root/cemu/src/gui/../Common/precompiled.h:350
  0x0000000000c0f30d in CemuApp::OnAssertFailure (this=0x2dfdc80, file=0x2ee0200 L"/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=4478, func=0x34012c0 L"EnsureVisible", cond=0x33591c0 L"\"index >= 0 && (size_t)index < GetItemCount()\"", msg=0x3405f00 L"invalid index in EnsureVisible") at /root/cemu/src/gui/CemuApp.cpp:164
  0x00000000010f2c04 in wxDefaultAssertHandler (file=..., line=4478, func=..., cond=..., msg=...) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1189
  0x00000000010f34a5 in wxOnAssert (file=0x1fe87f0 "/root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp", line=4478, func=0x1fea6e7 "EnsureVisible", cond=0x1fea6b8 "\"index >= 0 && (size_t)index < GetItemCount()\"", msg=0x1fea638 L"invalid index in EnsureVisible") at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:1275
  0x0000000001358bf4 in wxListMainWindow::EnsureVisible (this=0x33c1300, index=22) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:4478
  0x000000000135bef8 in wxGenericListCtrl::EnsureVisible (this=0x335d000, item=22) at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/generic/listctrl.cpp:5524
  0x0000000000d45ac3 in TextureRelationViewerWindow::RefreshTextureList (this=0x33cfc00) at /root/cemu/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp:375
  0x0000000000d44e0f in TextureRelationViewerWindow::TextureRelationViewerWindow (this=0x33cfc00, parent=...) at /root/cemu/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp:129
  0x0000000000d437b3 in openTextureViewer (parentFrame=...) at /root/cemu/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp:32
  0x0000000000c1b5d9 in MainWindow::OnDebugViewTextureRelations (this=0x30d8dd0, event=...) at /root/cemu/src/gui/MainWindow.cpp:1149
  0x00000000010f177f in wxAppConsoleBase::HandleEvent (this=0x2dfdc80, handler=0x30d8dd0, func=(void (wxEvtHandler::*)(wxEvtHandler * const, wxEvent &)) 0xc1b5c0 <MainWindow::OnDebugViewTextureRelations(wxCommandEvent&)>, event=...)
    at /root/cemu/dependencies/vcpkg/buildtrees/wxwidgets/src/v3.2.0-b1a1c2cb85.clean/src/common/appbase.cpp:658
[Truncated]
```
Solution: Boundary checks before calling EnsureVisible.