### PR TITLE
gfxpack: Fix graphic pack content not being loaded

### DIFF
--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -48,6 +48,9 @@ bool GraphicPack2::LoadGraphicPack(const std::wstring& filename, IniParser& rule
 			}
 			
 			gp->SetEnabled(enabled);
+			
+			if (gp->IsEnabled())
+				s_active_graphic_packs.emplace_back(gp);
 		}
 
 		gp->UpdatePresetVisibility();


### PR DESCRIPTION
This prevented custom shaders and file mods from loading for graphic packs.

It's seemingly indicating a more complicated problem with the graphic packs being "activated" after the game has started using custom shaders.