### PR TITLE
Update graphic pack url query request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin/Cemu
 # Cemu bin files
 bin/otp.bin
 bin/seeprom.bin
+bin/log.txt
 bin/Cemu.pdb
 bin/Cemu.ilk
 bin/Cemu.exe.backup
@@ -36,3 +37,5 @@ bin/controllerProfiles/*
 
 !bin/gameProfiles/default/*
 bin/gameProfiles/*
+
+bin/graphicPacks/*

--- a/src/gui/DownloadGraphicPacksWindow.cpp
+++ b/src/gui/DownloadGraphicPacksWindow.cpp
@@ -121,9 +121,9 @@ void DownloadGraphicPacksWindow::UpdateThread()
 	// get github url
 	std::string githubAPIUrl;
 	curlDownloadFileState_t tempDownloadState;
-	std::string queryUrl("http://cemu.info/api/query_graphicpack_url_1_17_0.php?");
+	std::string queryUrl("https://cemu.info/api2/query_graphicpack_url.php?");
 	char temp[64];
-	sprintf(temp, "version=%d.%d.%d%s", EMULATOR_VERSION_LEAD, EMULATOR_VERSION_MAJOR, EMULATOR_VERSION_MINOR, EMULATOR_VERSION_SUFFIX);
+	sprintf(temp, "version=%d.%d.%d", EMULATOR_VERSION_LEAD, EMULATOR_VERSION_MAJOR, EMULATOR_VERSION_MINOR);
 	queryUrl.append(temp);
 	queryUrl.append("&");
 	sprintf(temp, "t=%u", (uint32)std::chrono::seconds(std::time(NULL)).count()); // add a dynamic part to the url to bypass overly aggressive caching (like some proxies do)


### PR DESCRIPTION
The request for grabbing the gfx pack download URL was broken because of inserting the build suffix without escaping it, but it's not really necessary anyway. I also changed the URL since it's nicer to have a separate API for post 2.0 releases.

Also tweaked .gitignore