### PR TITLE
Fix game list ordering & Favorite checkbox

### DIFF
--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -476,7 +476,7 @@ void wxGameList::OnContextMenu(wxContextMenuEvent& event)
 
 			menu.Append(kContextMenuStart, _("&Start"));
 
-			bool isFavorite = false;
+			bool isFavorite = GetConfig().IsGameListFavorite(title_id);
 
 			menu.AppendSeparator();
 			menu.AppendCheckItem(kContextMenuFavorite, _("&Favorite"))->Check(isFavorite);


### PR DESCRIPTION
Game ordering was broken when clicking on the name column or adding/removing a favorite.
    
Unlike the standard lib's that requires a strict weak ordering comparator, wxWidgets needs a compare function that returns a negative number, 0 or a positive number when entries are respectively lower than, equal to and greater than.
    
Fixed using C++20 comparison API.