### PR TITLE
Fix the reloading of game cache from settings.xml on Linux

### DIFF
--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -160,15 +160,15 @@ void CemuConfig::Load(XMLConfigParser& parser)
 		{
 			GameEntry entry{};
 			entry.rpx_file = boost::nowide::widen(rpx);
-			entry.title_id = element.get("title_id", 0LL);
+			entry.title_id = element.get<decltype(entry.title_id)>("title_id");
 			entry.legacy_name = boost::nowide::widen(element.get("name", ""));
 			entry.custom_name = element.get("custom_name", "");
 			entry.legacy_region = element.get("region", 0);
 			entry.legacy_version = element.get("version", 0);
 			entry.legacy_update_version = element.get("version", 0);
 			entry.legacy_dlc_version = element.get("dlc_version", 0);
-			entry.legacy_time_played = element.get("time_played", 0ULL);
-			entry.legacy_last_played = element.get("last_played", 0ULL);
+			entry.legacy_time_played = element.get<decltype(entry.legacy_time_played)>("time_played");
+			entry.legacy_last_played = element.get<decltype(entry.legacy_last_played)>("last_played");
 			entry.favorite = element.get("favorite", false);
 			game_cache_entries.emplace_back(entry);
 


### PR DESCRIPTION
`std::is_same_v<decltype(0LL), int64_t>` does not evaluate the same on Linux Clang and MSVC. MSVC returns true but Clang and GCC both returns false resulting in failing to read the game id from the XML file and therefore rebuilding the cache.

Solution: Don't rely on the type of `0LL` and `0ULL` literals but explicitly provide the type of the field we are trying to read.

Fixes #164 