### PR TITLE
Name output binary Cemu_<CONFIG> and always place it in /bin/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,11 @@ jobs:
       run: |
         cd build
         ninja
-        
+
+    - name: Prepare artifact
+      if: ${{ inputs.deploymode == 'release' }}
+      run: mv bin/Cemu_release bin/Cemu
+              
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       if: ${{ inputs.deploymode == 'release' }}
@@ -188,7 +192,11 @@ jobs:
       run: |
         cd build
         cmake --build . --config ${{ env.BUILD_MODE }} -j 2
-        
+
+    - name: Prepare artifact
+      if: ${{ inputs.deploymode == 'release' }}
+      run: Rename-Item bin/Cemu_release.exe Cemu.exe
+      
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       if: ${{ inputs.deploymode == 'release' }}

--- a/.github/workflows/deploy_experimental.yml
+++ b/.github/workflows/deploy_experimental.yml
@@ -63,4 +63,4 @@ jobs:
           wget -O ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.15.0/ghr_v0.15.0_linux_amd64.tar.gz
           tar xvzf ghr.tar.gz; rm ghr.tar.gz
           echo "[INFO] Release tag: v${{ env.CEMU_VERSION }}"
-          ghr_v0.15.0_linux_amd64/ghr -prerelease -t ${{ secrets.GITHUB_TOKEN }} -n "Cemu ${{ env.CEMU_VERSION }} (Experimental)" -b "" "v${{ env.CEMU_VERSION }}" ./upload
+          ghr_v0.15.0_linux_amd64/ghr -prerelease -t ${{ secrets.GITHUB_TOKEN }} -n "Cemu ${{ env.CEMU_VERSION }} (Experimental)" -b "Cemu experimental release - [changelog](https://cemu.info/changelog.html)" "v${{ env.CEMU_VERSION }}" ./upload

--- a/.gitignore
+++ b/.gitignore
@@ -18,14 +18,15 @@
 build/
 out/
 .cache/
-bin/Cemu
+bin/Cemu_*
+bin/Cemu_*.exe
 
 # Cemu bin files
 bin/otp.bin
 bin/seeprom.bin
 bin/log.txt
-bin/Cemu.pdb
-bin/Cemu.ilk
+bin/Cemu_*.pdb
+bin/Cemu_*.ilk
 bin/Cemu.exe.backup
 bin/mlc01/*
 bin/settings.xml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,8 +75,10 @@ endif()
 set_property(TARGET CemuBin PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 set_target_properties(CemuBin PROPERTIES
-	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../bin/"
-	OUTPUT_NAME "Cemu"
+	# multi-configuration generators will add a config subdirectory to RUNTIME_OUTPUT_DIRECTORY if no generator expression is used
+	# to get the same behavior everywhere we append an empty generator expression
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../bin/$<1:>"
+	OUTPUT_NAME "Cemu_$<LOWER_CASE:$<CONFIG>>"
 )
 
 target_link_libraries(CemuBin PRIVATE


### PR DESCRIPTION
There was an issue where multi-configuration generators would put the binary in a `/<config>` subdirectory relative to bin. This was due to some oversight and should now be fixed.

In regards to RUNTIME_OUTPUT_DIRECTORY from the cmake documentation:
> This property specifies the directory into which runtime target files should be built. The property value may use [generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#manual:cmake-generator-expressions(7)). Multi-configuration generators ([Visual Studio](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators), [Xcode](https://cmake.org/cmake/help/latest/generator/Xcode.html#generator:Xcode), [Ninja Multi-Config](https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html#generator:Ninja%20Multi-Config)) append a per-configuration subdirectory to the specified directory unless a generator expression is used.

Additionally, to avoid overwriting the debug binary with release config binary and vice versa we append the config name to the binary.