### PR TITLE
build: update required fmt version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ find_package(ZLIB REQUIRED)
 find_package(zstd MODULE REQUIRED) # MODULE so that zstd::zstd is available
 find_package(OpenSSL COMPONENTS Crypto SSL REQUIRED)
 find_package(glm REQUIRED)
-find_package(fmt 7.0.0 REQUIRED)
+find_package(fmt 9.1.0 REQUIRED)
 find_package(PNG REQUIRED)
 
 # glslang versions older than 11.11.0 define targets without a namespace


### PR DESCRIPTION
Cemu requires fmt 9.1.0 after https://github.com/cemu-project/Cemu/commit/0ed4fdcd789081f210d9587b24af7e5c050cfc55