### PR TITLE
Use ANSI encoding for cemu.rc (remove utf8 BOM)

### DIFF
--- a/src/resource/cemu.rc
+++ b/src/resource/cemu.rc
@@ -1,4 +1,4 @@
-﻿// Microsoft Visual C++ generated resource script.
+// Microsoft Visual C++ generated resource script.
 //
 #include "resource/resource.h"
 


### PR DESCRIPTION
Clang has issues with utf16 and MSVC does not like utf8. So ANSI it is