### PR TITLE
Set timer milliseconds for "Controller settings"

### DIFF
--- a/src/gui/input/settings/DefaultControllerSettings.cpp
+++ b/src/gui/input/settings/DefaultControllerSettings.cpp
@@ -216,7 +216,7 @@ DefaultControllerSettings::DefaultControllerSettings(wxWindow* parent, const wxP
 
 	m_timer = new wxTimer(this);
 	Bind(wxEVT_TIMER, &DefaultControllerSettings::on_timer, this);
-	m_timer->Start();
+	m_timer->Start(100);
 }
 
 DefaultControllerSettings::~DefaultControllerSettings()

--- a/src/gui/input/settings/WiimoteControllerSettings.cpp
+++ b/src/gui/input/settings/WiimoteControllerSettings.cpp
@@ -234,7 +234,7 @@ WiimoteControllerSettings::WiimoteControllerSettings(wxWindow* parent, const wxP
 
 	m_timer = new wxTimer(this);
 	Bind(wxEVT_TIMER, &WiimoteControllerSettings::on_timer, this);
-	m_timer->Start();
+	m_timer->Start(100);
 }
 
 WiimoteControllerSettings::~WiimoteControllerSettings()


### PR DESCRIPTION
This is needed to avoid having the Controller settings window black on Linux