### PR TITLE
Use _Exit instead of exit under Linux

### DIFF
--- a/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
@@ -26,7 +26,7 @@ void handler_SIGINT(int sig)
      * by any mean ends up with a SIGABRT from the standard library destroying
      * threads.
      */
-    exit(0);
+    _Exit(0);
 }
 
 void ExceptionHandler_init()

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -142,7 +142,7 @@ int CemuApp::OnExit()
 #if BOOST_OS_WINDOWS
 	ExitProcess(0);
 #else
-	exit(0);
+	_Exit(0);
 #endif
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -47,6 +47,8 @@
 
 #if BOOST_OS_WINDOWS
 #define exit(__c) ExitProcess(__c)
+#else
+#define exit(__c) _Exit(__c)
 #endif
 
 #if BOOST_OS_LINUX || BOOST_OS_MACOS


### PR DESCRIPTION
The best ExitProcess alternative for Linux is _exit since it doesn't call exit handlers.

This fixes also #178 since, with exit, it aborts due to some std::threads not correctly joined.

In the future, if VS2022 supports it, we may use std::jthread instead of std::thread since they automatically joins; when jthread will be used, `CemuApp::OnExit` may be removed since ExitProcess/_exit will not be necessary anymore