### PR TITLE
Cleanup udiv128

### DIFF
--- a/src/Cafe/HW/Espresso/PPCTimer.cpp
+++ b/src/Cafe/HW/Espresso/PPCTimer.cpp
@@ -108,14 +108,8 @@ uint64 PPCTimer_tscToMicroseconds(uint64 us)
 	uint128_t r{};
 	r.low = _umul128(us, 1000000ULL, &r.high);
 
-
 	uint64 remainder;
-
-#if defined(_MSC_VER) && _MSC_VER >= 1923 && !defined(__clang__)
 	const uint64 microseconds = _udiv128(r.high, r.low, _rdtscFrequency, &remainder);
-#else
-	const uint64 microseconds = udiv128(r.low, r.high, _rdtscFrequency, &remainder);
-#endif
 
 	return microseconds;
 }
@@ -159,12 +153,7 @@ uint64 PPCTimer_getFromRDTSC()
 	#endif
 
 	uint64 remainder;
-#if defined(_MSC_VER) && _MSC_VER >= 1923 && !defined(__clang__)
 	uint64 elapsedTick = _udiv128(_rdtscAcc.high, _rdtscAcc.low, _rdtscFrequency, &remainder);
-#else
-	uint64 elapsedTick = udiv128(_rdtscAcc.low, _rdtscAcc.high, _rdtscFrequency, &remainder);
-#endif
-
 
 	_rdtscAcc.low = remainder;
 	_rdtscAcc.high = 0;

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -210,7 +210,7 @@ typedef union _LARGE_INTEGER {
     inline T& operator^= (T& a, T b) { return reinterpret_cast<T&>( reinterpret_cast<std::underlying_type<T>::type&>(a) ^= static_cast<std::underlying_type<T>::type>(b) ); }
 #endif
 
-#if !defined(_MSC_VER) || defined(__clang__) // clang-cl does not support _udiv128
+#if !defined(_MSC_VER) || defined(__clang__) // clang-cl does not have built-in _udiv128
 inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, uint64 *remainder)
 {
     unsigned __int128 dividend = (((unsigned __int128)highDividend) << 64) | ((unsigned __int128)lowDividend);

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -210,6 +210,16 @@ typedef union _LARGE_INTEGER {
     inline T& operator^= (T& a, T b) { return reinterpret_cast<T&>( reinterpret_cast<std::underlying_type<T>::type&>(a) ^= static_cast<std::underlying_type<T>::type>(b) ); }
 #endif
 
+#if !defined(_MSC_VER) || defined(__clang__) // clang-cl does not support _udiv128
+inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, uint64 *remainder)
+{
+    unsigned __int128 dividend128 = (((unsigned __int128)highDividend) << 64) | ((unsigned __int128)lowDividend);
+    unsigned __int128 divisor128 = (unsigned __int128)divisor;
+    *remainder = (uint64)((dividend128 % divisor128) & 0xFFFFFFFFFFFFFFFF);
+    return       (uint64)((dividend128 / divisor128) & 0xFFFFFFFFFFFFFFFF);
+}
+#endif
+
 #if defined(_MSC_VER)
     #define UNREACHABLE __assume(false)
 #elif defined(__GNUC__)

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -213,10 +213,9 @@ typedef union _LARGE_INTEGER {
 #if !defined(_MSC_VER) || defined(__clang__) // clang-cl does not support _udiv128
 inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, uint64 *remainder)
 {
-    unsigned __int128 dividend128 = (((unsigned __int128)highDividend) << 64) | ((unsigned __int128)lowDividend);
-    unsigned __int128 divisor128 = (unsigned __int128)divisor;
-    *remainder = (uint64)((dividend128 % divisor128) & 0xFFFFFFFFFFFFFFFF);
-    return       (uint64)((dividend128 / divisor128) & 0xFFFFFFFFFFFFFFFF);
+    unsigned __int128 dividend = (((unsigned __int128)highDividend) << 64) | ((unsigned __int128)lowDividend);
+    *remainder = (uint64)((dividend % divisor) & 0xFFFFFFFFFFFFFFFF);
+    return       (uint64)((dividend / divisor) & 0xFFFFFFFFFFFFFFFF);
 }
 #endif
 

--- a/src/asm/x64util.h
+++ b/src/asm/x64util.h
@@ -1,5 +1,4 @@
 #pragma once
 
-extern "C" uint64 ATTR_MS_ABI udiv128(uint64 low, uint64 hi, uint64 divisor, uint64 *remainder);
 extern "C" void recompiler_fres();
 extern "C" void recompiler_frsqrte();

--- a/src/asm/x64util_masm.asm
+++ b/src/asm/x64util_masm.asm
@@ -1,12 +1,5 @@
 .code
 
-udiv128 PROC
-	mov rax, rcx
-	div r8
-	mov [r9], rdx
-	ret
-udiv128 ENDP
-
 recompiler_fres	PROC
  ; store all modified registers
 push rdx


### PR DESCRIPTION
As discussed in https://github.com/cemu-project/Cemu/pull/188. Implemented _udiv128 (on compilers that don't have it built in) using 128 bit types. Some dubious performance testing [here](https://github.com/tomlally/udiv128_test).