### PR TITLE
fix for when file open is successful but the path isn't a file

### DIFF
--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -198,6 +198,9 @@ FileStream::FileStream(const fs::path& path, bool isOpen, bool isWriteable)
 		m_fileStream.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
 		m_isValid = m_fileStream.is_open();
 	}
+	m_isValid &= !is_directory(path);
+	if(!m_isValid)
+		m_fileStream.close();
 }
 
 void FileStream::SyncReadWriteSeek(bool nextOpIsWrite)

--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -198,7 +198,7 @@ FileStream::FileStream(const fs::path& path, bool isOpen, bool isWriteable)
 		m_fileStream.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
 		m_isValid = m_fileStream.is_open();
 	}
-	if(m_isValid && is_directory(path))
+	if(m_isValid && fs::is_directory(path))
 	{
 		m_isValid = false;
 		m_fileStream.close();

--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -198,9 +198,11 @@ FileStream::FileStream(const fs::path& path, bool isOpen, bool isWriteable)
 		m_fileStream.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
 		m_isValid = m_fileStream.is_open();
 	}
-	m_isValid &= !is_directory(path);
-	if(!m_isValid)
+	if(is_directory(path) && m_isValid)
+	{
+		m_isValid = false;
 		m_fileStream.close();
+	}
 }
 
 void FileStream::SyncReadWriteSeek(bool nextOpIsWrite)

--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -198,7 +198,7 @@ FileStream::FileStream(const fs::path& path, bool isOpen, bool isWriteable)
 		m_fileStream.open(path, std::ios_base::in | std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
 		m_isValid = m_fileStream.is_open();
 	}
-	if(is_directory(path) && m_isValid)
+	if(m_isValid && is_directory(path))
 	{
 		m_isValid = false;
 		m_fileStream.close();


### PR DESCRIPTION
In some cases when trying to open a directory it's opened as a file instead because no error is reported when creating a FileStream for a directory.