### PR TITLE
Check if raw keycode is out of bounds

### DIFF
--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -170,12 +170,16 @@ int CemuApp::FilterEvent(wxEvent& event)
 	{
 		const auto& key_event = (wxKeyEvent&)event;
 		wxGetKeyState(wxKeyCode::WXK_F17);
-		g_window_info.keydown[fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags())] = true;
+		uint32 keycode=fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags());
+		if(0<=keycode && keycode<256)
+			g_window_info.keydown[keycode] = true;
 	}
 	else if(event.GetEventType() == wxEVT_KEY_UP)
 	{
 		const auto& key_event = (wxKeyEvent&)event;
-		g_window_info.keydown[fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags())] = false;
+		uint32 keycode=fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags());
+		if(0<=keycode && keycode<256)
+			g_window_info.keydown[keycode] = false;
 	}
 
 	return wxApp::FilterEvent(event);

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -171,14 +171,14 @@ int CemuApp::FilterEvent(wxEvent& event)
 		const auto& key_event = (wxKeyEvent&)event;
 		wxGetKeyState(wxKeyCode::WXK_F17);
 		uint32 keycode=fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags());
-		if(0<=keycode && keycode<256)
+		if(keycode<256)
 			g_window_info.keydown[keycode] = true;
 	}
 	else if(event.GetEventType() == wxEVT_KEY_UP)
 	{
 		const auto& key_event = (wxKeyEvent&)event;
 		uint32 keycode=fix_raw_keycode(key_event.GetRawKeyCode(), key_event.GetRawKeyFlags());
-		if(0<=keycode && keycode<256)
+		if(keycode<256)
 			g_window_info.keydown[keycode] = false;
 	}
 


### PR DESCRIPTION
According to the [wxWidgets documentation](https://docs.wxwidgets.org/3.0/classwx_key_event.html#a6fddcd170d05b0852a7eb2a0cb730795) :
> Under GTK, the raw key code is the keyval field of the corresponding GDK event.

And some keyevents have a raw key code that is greater than 256, which leads to undefined behavior.
In some cases, it crashes the app. For example, when I press the fn+F12 to increase the volume, which has a keyval value of 0x1008ff13 (according to the [GTK source code](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdkkeysyms.h)), the app crashes.