### PR TITLE
More l10n improvements and add workflow to generate POT file

### DIFF
--- a/.github/workflows/generate_pot.yml
+++ b/.github/workflows/generate_pot.yml
@@ -1,0 +1,42 @@
+name: Generate translation template
+
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    paths-ignore:
+      - "*.md"
+    branches:
+      - main
+
+jobs:
+  generate-pot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v3
+
+      - name: "Install gettext"
+        run: |
+          sudo apt update -qq
+          sudo apt install -y gettext
+
+      - name: "Generate POT file using xgettext"
+        run: >
+          find src -name *.cpp -o -name *.hpp -o -name *.h | 
+          xargs xgettext --from-code=utf-8
+          -k_ -kwxTRANSLATE -w 100
+          --check=space-ellipsis --omit-header
+          -o cemu.pot
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: POT file
+          path: ./cemu.pot
+          if-no-files-found: error

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -290,7 +290,8 @@ void wxTitleManagerList::OnConvertToCompressedFormat(uint64 titleId)
 		}
 	}
 
-	std::string msg = wxHelper::MakeUTF8(_("The following content will be converted to a compressed Wii U archive file (.wua):\n \n"));
+	std::string msg = wxHelper::MakeUTF8(_("The following content will be converted to a compressed Wii U archive file (.wua):"));
+	msg.append("\n \n");
 	
 	if (titleInfo_base.IsValid())
 		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("Base game: {}"))), _pathToUtf8(titleInfo_base.GetPath())));

--- a/src/gui/debugger/RegisterWindow.cpp
+++ b/src/gui/debugger/RegisterWindow.cpp
@@ -28,7 +28,7 @@ enum
 };
 
 RegisterWindow::RegisterWindow(DebuggerWindow2& parent, const wxPoint& main_position, const wxSize& main_size)
-	: wxFrame(&parent, wxID_ANY, _("Register View"), wxDefaultPosition, wxSize(400, 975), wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxFRAME_FLOAT_ON_PARENT),
+	: wxFrame(&parent, wxID_ANY, _("Registers"), wxDefaultPosition, wxSize(400, 975), wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxFRAME_FLOAT_ON_PARENT),
 	m_prev_snapshot({}), m_show_double_values(true), m_context_ctrl(nullptr)
 {
 	SetSizeHints(wxDefaultSize, wxDefaultSize);

--- a/src/gui/debugger/SymbolWindow.cpp
+++ b/src/gui/debugger/SymbolWindow.cpp
@@ -13,7 +13,7 @@ enum ItemColumns
 };
 
 SymbolWindow::SymbolWindow(DebuggerWindow2& parent, const wxPoint& main_position, const wxSize& main_size)
-	: wxFrame(&parent, wxID_ANY, _("Symbol Window"), wxDefaultPosition, wxSize(600, 250), wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxFRAME_FLOAT_ON_PARENT)
+	: wxFrame(&parent, wxID_ANY, _("Symbols"), wxDefaultPosition, wxSize(600, 250), wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxFRAME_FLOAT_ON_PARENT)
 {
 	this->wxWindowBase::SetBackgroundColour(*wxWHITE);
 

--- a/src/gui/input/panels/ClassicControllerInputPanel.cpp
+++ b/src/gui/input/panels/ClassicControllerInputPanel.cpp
@@ -29,16 +29,7 @@ ClassicControllerInputPanel::ClassicControllerInputPanel(wxWindow* parent)
 	for (const auto& id : g_kFirstColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ClassicController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData(reinterpret_cast<void*>(id));
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -55,16 +46,7 @@ ClassicControllerInputPanel::ClassicControllerInputPanel(wxWindow* parent)
 	for (const auto& id : g_kSecondColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ClassicController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData(reinterpret_cast<void*>(id));
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -87,16 +69,7 @@ ClassicControllerInputPanel::ClassicControllerInputPanel(wxWindow* parent)
 	for (const auto& id : g_kThirdColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ClassicController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData(reinterpret_cast<void*>(id));
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -119,21 +92,27 @@ ClassicControllerInputPanel::ClassicControllerInputPanel(wxWindow* parent)
 	for (auto id : g_kFourthRowItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ClassicController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData(reinterpret_cast<void*>(id));
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	//////////////////////////////////////////////////////////////////
 
-	
 	SetSizer(main_sizer);
 	Layout();
+}
+
+void ClassicControllerInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const ClassicController::ButtonId &button_id) {
+	sizer->Add(
+		new wxStaticText(this, wxID_ANY, wxGetTranslation(to_wxString(ClassicController::get_button_name(button_id)))),
+		wxGBPosition(row, column),
+		wxDefaultSpan,
+		wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
+	text_ctrl->SetClientData(reinterpret_cast<void*>(button_id));
+	text_ctrl->SetMinSize(wxSize(150, -1));
+	text_ctrl->SetEditable(false);
+	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
+	bind_hotkey_events(text_ctrl);
+	sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
 }

--- a/src/gui/input/panels/ClassicControllerInputPanel.h
+++ b/src/gui/input/panels/ClassicControllerInputPanel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <wx/gbsizer.h>
+#include "input/emulated/ClassicController.h"
 #include "gui/input/panels/InputPanel.h"
 
 class wxInputDraw;
@@ -11,5 +13,7 @@ public:
 
 private:
 	wxInputDraw* m_left_draw, * m_right_draw;
+
+	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const ClassicController::ButtonId &button_id);
 };
 

--- a/src/gui/input/panels/ProControllerInputPanel.cpp
+++ b/src/gui/input/panels/ProControllerInputPanel.cpp
@@ -96,10 +96,7 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 
 	//////////////////////////////////////////////////////////////////
 
-	// LoadController(controller);
-
 	SetSizerAndFit(main_sizer);
-	//wxWindow::Show(show);
 }
 
 void ProControllerInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const ProController::ButtonId &button_id) {

--- a/src/gui/input/panels/ProControllerInputPanel.cpp
+++ b/src/gui/input/panels/ProControllerInputPanel.cpp
@@ -4,9 +4,7 @@
 #include <wx/stattext.h>
 #include <wx/statline.h>
 #include <wx/textctrl.h>
-#include <wx/slider.h>
 
-#include "gui/helpers/wxControlObject.h"
 #include "input/emulated/ProController.h"
 #include "gui/helpers/wxHelpers.h"
 #include "gui/components/wxInputDraw.h"
@@ -30,16 +28,7 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 	for (auto id : g_kFirstColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ProController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -56,16 +45,7 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 	for (auto id : g_kSecondColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ProController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -88,16 +68,7 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 	for (auto id : g_kThirdColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ProController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -120,16 +91,7 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 	for (auto id : g_kFourthRowItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(ProController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -138,6 +100,22 @@ ProControllerInputPanel::ProControllerInputPanel(wxWindow* parent)
 
 	SetSizerAndFit(main_sizer);
 	//wxWindow::Show(show);
+}
+
+void ProControllerInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const ProController::ButtonId &button_id) {
+	sizer->Add(
+		new wxStaticText(this, wxID_ANY, wxGetTranslation(to_wxString(ProController::get_button_name(button_id)))),
+		wxGBPosition(row, column),
+		wxDefaultSpan,
+		wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
+	text_ctrl->SetClientData((void*)button_id);
+	text_ctrl->SetMinSize(wxSize(150, -1));
+	text_ctrl->SetEditable(false);
+	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
+	bind_hotkey_events(text_ctrl);
+	sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
 }
 
 void ProControllerInputPanel::on_timer(const EmulatedControllerPtr& emulated_controller,

--- a/src/gui/input/panels/ProControllerInputPanel.h
+++ b/src/gui/input/panels/ProControllerInputPanel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <wx/gbsizer.h>
+#include "input/emulated/ProController.h"
 #include "gui/input/panels/InputPanel.h"
 #include "gui/components/wxInputDraw.h"
 
@@ -12,4 +14,6 @@ public:
 
 private:
 	wxInputDraw* m_left_draw, * m_right_draw;
+
+	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const ProController::ButtonId &button_id);
 };

--- a/src/gui/input/panels/VPADInputPanel.cpp
+++ b/src/gui/input/panels/VPADInputPanel.cpp
@@ -139,13 +139,8 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	//////////////////////////////////////////////////////////////////
 
-	//LoadController(controller);
-
 	SetSizer(main_sizer);
 	Layout();
-
-	//SetSizerAndFit(main_sizer);
-	//wxWindow::Show(show);
 }
 
 void VPADInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id) {

--- a/src/gui/input/panels/VPADInputPanel.cpp
+++ b/src/gui/input/panels/VPADInputPanel.cpp
@@ -48,16 +48,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 	for (const auto& id : g_kFirstColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(VPADController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -74,16 +65,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 	for (const auto& id : g_kSecondColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(VPADController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -106,16 +88,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 	for (const auto& id : g_kThirdColumnItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(VPADController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	row++;
@@ -154,40 +127,15 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 	for (const auto& id : g_kFourthRowItems)
 	{
 		row++;
-
-		main_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(VPADController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(main_sizer, row, column, id);
 	}
 
 	// Blow Mic
 	row = 9;
-	main_sizer->Add(new wxStaticText(this, wxID_ANY, _("blow mic")), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-	auto text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-	text_ctrl->SetClientData((void*)VPADController::kButtonId_Mic);
-	text_ctrl->SetMinSize(wxSize(150, -1));
-	text_ctrl->SetEditable(false);
-	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-	bind_hotkey_events(text_ctrl);
-	main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+	add_button_row(main_sizer, row, column, VPADController::kButtonId_Mic, _("blow mic"));
 	row++;
 
-	main_sizer->Add(new wxStaticText(this, wxID_ANY, _("show screen")), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-	text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-	text_ctrl->SetClientData((void*)VPADController::kButtonId_Screen);
-	text_ctrl->SetMinSize(wxSize(150, -1));
-	text_ctrl->SetEditable(false);
-	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-	bind_hotkey_events(text_ctrl);
-	main_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+	add_button_row(main_sizer, row, column, VPADController::kButtonId_Screen, _("show screen"));
 
 	//////////////////////////////////////////////////////////////////
 
@@ -198,6 +146,27 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	//SetSizerAndFit(main_sizer);
 	//wxWindow::Show(show);
+}
+
+void VPADInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id) {
+	add_button_row(sizer, row, column, button_id, wxGetTranslation(to_wxString(VPADController::get_button_name(button_id))));
+}
+
+void VPADInputPanel::add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column,
+                                    const VPADController::ButtonId &button_id, const wxString &label) {
+	sizer->Add(
+		new wxStaticText(this, wxID_ANY, label),
+		wxGBPosition(row, column),
+		wxDefaultSpan,
+		wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
+	text_ctrl->SetClientData((void*)button_id);
+	text_ctrl->SetMinSize(wxSize(150, -1));
+	text_ctrl->SetEditable(false);
+	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
+	bind_hotkey_events(text_ctrl);
+	sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
 }
 
 void VPADInputPanel::on_timer(const EmulatedControllerPtr& emulated_controller, const ControllerPtr& controller_base)

--- a/src/gui/input/panels/VPADInputPanel.h
+++ b/src/gui/input/panels/VPADInputPanel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <wx/gbsizer.h>
 #include "gui/input/panels/InputPanel.h"
 
 class wxInputDraw;
@@ -15,4 +16,7 @@ private:
 	void OnVolumeChange(wxCommandEvent& event);
 
 	wxInputDraw* m_left_draw, * m_right_draw;
+
+	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id);
+	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id, const wxString &label);
 };

--- a/src/gui/input/panels/WiimoteInputPanel.cpp
+++ b/src/gui/input/panels/WiimoteInputPanel.cpp
@@ -64,16 +64,7 @@ WiimoteInputPanel::WiimoteInputPanel(wxWindow* parent)
 	for (const auto& id : g_kFirstColumnItems)
 	{
 		row++;
-
-		m_item_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(WiimoteController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		m_item_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(row, column, id);
 	}
 
 	m_item_sizer->Add(new wxStaticLine(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVERTICAL), wxGBPosition(0, column + 2), wxGBSpan(11, 1), wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
@@ -90,16 +81,7 @@ WiimoteInputPanel::WiimoteInputPanel(wxWindow* parent)
 	for (const auto& id : g_kSecondColumnItems)
 	{
 		row++;
-
-		m_item_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(WiimoteController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
-		text_ctrl->SetClientData((void*)id);
-		text_ctrl->SetMinSize(wxSize(150, -1));
-		text_ctrl->SetEditable(false);
-		text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
-		bind_hotkey_events(text_ctrl);
-		m_item_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
+		add_button_row(row, column, id);
 	}
 
 	row = 8;
@@ -135,7 +117,11 @@ WiimoteInputPanel::WiimoteInputPanel(wxWindow* parent)
 		if (id == WiimoteController::kButtonId_None)
 			continue;
 
-		m_item_sizer->Add(new wxStaticText(this, wxID_ANY, to_wxString(WiimoteController::get_button_name(id))), wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+		m_item_sizer->Add(
+			new wxStaticText(this, wxID_ANY, wxGetTranslation(to_wxString(WiimoteController::get_button_name(id)))),
+			wxGBPosition(row, column),
+			wxDefaultSpan,
+			wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
 		auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
 		text_ctrl->SetClientData((void*)id);
@@ -164,6 +150,22 @@ WiimoteInputPanel::WiimoteInputPanel(wxWindow* parent)
 	
 	SetSizer(main_sizer);
 	Layout();
+}
+
+void WiimoteInputPanel::add_button_row(sint32 row, sint32 column, const WiimoteController::ButtonId &button_id) {
+	m_item_sizer->Add(
+		new wxStaticText(this, wxID_ANY, wxGetTranslation(to_wxString(WiimoteController::get_button_name(button_id)))),
+		wxGBPosition(row, column),
+		wxDefaultSpan,
+		wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+	auto* text_ctrl = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxTE_PROCESS_ENTER | wxTE_PROCESS_TAB);
+	text_ctrl->SetClientData((void*)button_id);
+	text_ctrl->SetMinSize(wxSize(150, -1));
+	text_ctrl->SetEditable(false);
+	text_ctrl->SetBackgroundColour(kKeyColourNormalMode);
+	bind_hotkey_events(text_ctrl);
+	m_item_sizer->Add(text_ctrl, wxGBPosition(row, column + 1), wxDefaultSpan, wxALL | wxEXPAND, 5);
 }
 
 void WiimoteInputPanel::set_active_device_type(WPADDeviceType type)

--- a/src/gui/input/panels/WiimoteInputPanel.cpp
+++ b/src/gui/input/panels/WiimoteInputPanel.cpp
@@ -211,9 +211,6 @@ void WiimoteInputPanel::on_volume_change(wxCommandEvent& event)
 
 void WiimoteInputPanel::on_extension_change(wxCommandEvent& event)
 {
-	const auto obj = dynamic_cast<wxCheckBox*>(event.GetEventObject());
-	wxASSERT(obj);
-
 	if(m_motion_plus->GetValue() && m_nunchuck->GetValue())
 		set_active_device_type(kWAPDevMPLSFreeStyle);
 	else if(m_motion_plus->GetValue() && m_classic->GetValue())

--- a/src/gui/input/panels/WiimoteInputPanel.h
+++ b/src/gui/input/panels/WiimoteInputPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gui/input/panels/InputPanel.h"
+#include "input/emulated/WiimoteController.h"
 #include <wx/slider.h>
 
 class wxCheckBox;
@@ -33,7 +34,8 @@ private:
 	wxSlider* m_volume;
 
 	std::vector<wxWindow*> m_nunchuck_items;
-	bool m_extensions_changed;
+
+	void add_button_row(sint32 row, sint32 column, const WiimoteController::ButtonId &button_id);
 };
 
 

--- a/src/input/emulated/ClassicController.cpp
+++ b/src/input/emulated/ClassicController.cpp
@@ -3,6 +3,7 @@
 #include "input/api/Controller.h"
 #include "input/api/SDL/SDLController.h"
 
+#include <wx/intl.h>
 
 ClassicController::ClassicController(size_t player_index)
 	: WPADController(player_index, kDataFormat_CLASSIC)
@@ -69,22 +70,22 @@ std::string_view ClassicController::get_button_name(ButtonId id)
 
 	case kButtonId_Plus: return "+";
 	case kButtonId_Minus: return "-";
-	case kButtonId_Home: return "home";
+	case kButtonId_Home: return wxTRANSLATE("home");
 
-	case kButtonId_Up: return "up";
-	case kButtonId_Down: return "down";
-	case kButtonId_Left: return "left";
-	case kButtonId_Right: return "right";
+	case kButtonId_Up: return wxTRANSLATE("up");
+	case kButtonId_Down: return wxTRANSLATE("down");
+	case kButtonId_Left: return wxTRANSLATE("left");
+	case kButtonId_Right: return wxTRANSLATE("right");
 
-	case kButtonId_StickL_Up: return "up";
-	case kButtonId_StickL_Down: return "down";
-	case kButtonId_StickL_Left: return "left";
-	case kButtonId_StickL_Right: return "right";
+	case kButtonId_StickL_Up: return wxTRANSLATE("up");
+	case kButtonId_StickL_Down: return wxTRANSLATE("down");
+	case kButtonId_StickL_Left: return wxTRANSLATE("left");
+	case kButtonId_StickL_Right: return wxTRANSLATE("right");
 
-	case kButtonId_StickR_Up: return "up";
-	case kButtonId_StickR_Down: return "down";
-	case kButtonId_StickR_Left: return "left";
-	case kButtonId_StickR_Right: return "right";
+	case kButtonId_StickR_Up: return wxTRANSLATE("up");
+	case kButtonId_StickR_Down: return wxTRANSLATE("down");
+	case kButtonId_StickR_Left: return wxTRANSLATE("left");
+	case kButtonId_StickR_Right: return wxTRANSLATE("right");
 
 	default:
 		return "";

--- a/src/input/emulated/ProController.cpp
+++ b/src/input/emulated/ProController.cpp
@@ -3,6 +3,8 @@
 #include "input/api/Controller.h"
 #include "input/api/SDL/SDLController.h"
 
+#include <wx/intl.h>
+
 ProController::ProController(size_t player_index)
 	: WPADController(player_index, kDataFormat_URCC)
 {
@@ -73,21 +75,21 @@ std::string_view ProController::get_button_name(ButtonId id)
 	case kButtonId_ZR: return "ZR";
 	case kButtonId_Plus: return "+";
 	case kButtonId_Minus: return "-";
-	case kButtonId_Up: return "up";
-	case kButtonId_Down: return "down";
-	case kButtonId_Left: return "left";
-	case kButtonId_Right: return "right";
-	case kButtonId_StickL: return "click";
-	case kButtonId_StickR: return "click";
-	case kButtonId_StickL_Up: return "up";
-	case kButtonId_StickL_Down: return "down";
-	case kButtonId_StickL_Left: return "left";
-	case kButtonId_StickL_Right: return "right";
-	case kButtonId_StickR_Up: return "up";
-	case kButtonId_StickR_Down: return "down";
-	case kButtonId_StickR_Left: return "left";
-	case kButtonId_StickR_Right: return "right";
-	case kButtonId_Home: return "home";
+	case kButtonId_Up: return wxTRANSLATE("up");
+	case kButtonId_Down: return wxTRANSLATE("down");
+	case kButtonId_Left: return wxTRANSLATE("left");
+	case kButtonId_Right: return wxTRANSLATE("right");
+	case kButtonId_StickL: return wxTRANSLATE("click");
+	case kButtonId_StickR: return wxTRANSLATE("click");
+	case kButtonId_StickL_Up: return wxTRANSLATE("up");
+	case kButtonId_StickL_Down: return wxTRANSLATE("down");
+	case kButtonId_StickL_Left: return wxTRANSLATE("left");
+	case kButtonId_StickL_Right: return wxTRANSLATE("right");
+	case kButtonId_StickR_Up: return wxTRANSLATE("up");
+	case kButtonId_StickR_Down: return wxTRANSLATE("down");
+	case kButtonId_StickR_Left: return wxTRANSLATE("left");
+	case kButtonId_StickR_Right: return wxTRANSLATE("right");
+	case kButtonId_Home: return wxTRANSLATE("home");
 	default:
 		cemu_assert_debug(false);
 		return "";

--- a/src/input/emulated/VPADController.cpp
+++ b/src/input/emulated/VPADController.cpp
@@ -5,6 +5,7 @@
 #include "input/InputManager.h"
 #include "Cafe/HW/Latte/Core/Latte.h"
 #include "Cafe/CafeSystem.h"
+#include <wx/intl.h>
 
 enum ControllerVPADMapping2 : uint32
 {
@@ -366,21 +367,21 @@ std::string_view VPADController::get_button_name(ButtonId id)
 	case kButtonId_ZR: return "ZR";
 	case kButtonId_Plus: return "+";
 	case kButtonId_Minus: return "-";
-	case kButtonId_Up: return "up";
-	case kButtonId_Down: return "down";
-	case kButtonId_Left: return "left";
-	case kButtonId_Right: return "right";
-	case kButtonId_StickL: return "click";
-	case kButtonId_StickR: return "click";
-	case kButtonId_StickL_Up: return "up";
-	case kButtonId_StickL_Down: return "down";
-	case kButtonId_StickL_Left: return "left";
-	case kButtonId_StickL_Right: return "right";
-	case kButtonId_StickR_Up: return "up";
-	case kButtonId_StickR_Down: return "down";
-	case kButtonId_StickR_Left: return "left";
-	case kButtonId_StickR_Right: return "right";
-	case kButtonId_Home: return "home";
+	case kButtonId_Up: return wxTRANSLATE("up");
+	case kButtonId_Down: return wxTRANSLATE("down");
+	case kButtonId_Left: return wxTRANSLATE("left");
+	case kButtonId_Right: return wxTRANSLATE("right");
+	case kButtonId_StickL: return wxTRANSLATE("click");
+	case kButtonId_StickR: return wxTRANSLATE("click");
+	case kButtonId_StickL_Up: return wxTRANSLATE("up");
+	case kButtonId_StickL_Down: return wxTRANSLATE("down");
+	case kButtonId_StickL_Left: return wxTRANSLATE("left");
+	case kButtonId_StickL_Right: return wxTRANSLATE("right");
+	case kButtonId_StickR_Up: return wxTRANSLATE("up");
+	case kButtonId_StickR_Down: return wxTRANSLATE("down");
+	case kButtonId_StickR_Left: return wxTRANSLATE("left");
+	case kButtonId_StickR_Right: return wxTRANSLATE("right");
+	case kButtonId_Home: return wxTRANSLATE("home");
 	default:
 		cemu_assert_debug(false);
 		return "";

--- a/src/input/emulated/WiimoteController.cpp
+++ b/src/input/emulated/WiimoteController.cpp
@@ -2,7 +2,7 @@
 
 #include "input/api/Controller.h"
 #include "input/api/Wiimote/NativeWiimoteController.h"
-
+#include <wx/intl.h>
 
 WiimoteController::WiimoteController(size_t player_index)
 	: WPADController(player_index, kDataFormat_CORE_ACC_DPD)
@@ -159,22 +159,22 @@ std::string_view WiimoteController::get_button_name(ButtonId id)
 	case kButtonId_1: return "1";
 	case kButtonId_2: return "2";
 
-	case kButtonId_Home: return "home";
+	case kButtonId_Home: return wxTRANSLATE("home");
 	case kButtonId_Plus: return "+";
 	case kButtonId_Minus: return "-";
 
-	case kButtonId_Up: return "up";
-	case kButtonId_Down: return "down";
-	case kButtonId_Left: return "left";
-	case kButtonId_Right: return "right";
+	case kButtonId_Up: return wxTRANSLATE("up");
+	case kButtonId_Down: return wxTRANSLATE("down");
+	case kButtonId_Left: return wxTRANSLATE("left");
+	case kButtonId_Right: return wxTRANSLATE("right");
 
 	case kButtonId_Nunchuck_Z: return "Z";
 	case kButtonId_Nunchuck_C: return "C";
 
-	case kButtonId_Nunchuck_Up: return "up";
-	case kButtonId_Nunchuck_Down: return "down";
-	case kButtonId_Nunchuck_Left: return "left";
-	case kButtonId_Nunchuck_Right: return "right";
+	case kButtonId_Nunchuck_Up: return wxTRANSLATE("up");
+	case kButtonId_Nunchuck_Down: return wxTRANSLATE("down");
+	case kButtonId_Nunchuck_Left: return wxTRANSLATE("left");
+	case kButtonId_Nunchuck_Right: return wxTRANSLATE("right");
 
 	default:
 		return "";

--- a/src/input/emulated/WiimoteController.h
+++ b/src/input/emulated/WiimoteController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "input/emulated/WPADController.h"
-#include "gui/input/panels/WiimoteInputPanel.h"
 
 class WiimoteController : public WPADController
 {


### PR DESCRIPTION
In addition to a few small UI strings improvements, this PR makes the gamepad button names translatable (home, left, right, click), except A, B, X, Y etc. which are always the same in all languages.
To accomplish that, I've used the [wxTRANSLATE](https://docs.wxwidgets.org/3.2/group__group__funcmacro__string.html#gab8862de0f74049708bfea75ae9e14c45) macro to mark button names as translatable (so that they get included in the POT file) and then called [wxGetTranslation](https://docs.wxwidgets.org/3.2/group__group__funcmacro__string.html#ga49dcdc17d82a627b7a50d401f1a37d69) in the GUI (actually, in the `InputPanel`s) to retrieve the translated names.
While I was at it, I've deduplicated a lot of the code that creates the input fields for each controller button in `InputPanel` classes. 

Last but not least, I've added a new GH Actions workflow that generates the .pot file using the `xgettext` command. You can refer to its [man page](https://linux.die.net/man/1/xgettext) to find out what the parameters do, I'm too lazy to explain all of them here rn. :sweat_smile:
The generated POT can be uploaded to the Cemu-Language repo as-is.