### PR TITLE
Fix Super Smash Bros. SD-card access.

### DIFF
--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -609,7 +609,10 @@ namespace iosu
 #ifndef PUBLIC_RELEASE
 			cemuLog_force("FSAProcessCmd_appendFile(): size 0x{:08x} count 0x{:08x} (todo)\n", _swapEndianU32(cmd->cmdAppendFile.size), _swapEndianU32(cmd->cmdAppendFile.count));
 #endif
-			return _swapEndianU32(cmd->cmdAppendFile.size) * _swapEndianU32(cmd->cmdAppendFile.count);
+			MPTR destOffset = _swapEndianU32(cmd->cmdDefault.destBufferMPTR);
+			void* destPtr = memory_getPointerFromVirtualOffset(destOffset);
+			fsc_setFileSeek(fscFile, fsc_getFileSize(fscFile));
+			return fsc_writeFile(fscFile, destPtr, cmd->cmdAppendFile.count);
 		}
 
 		FSStatus FSAProcessCmd_truncateFile(FSAClient* client, FSAIpcCommand* cmd)

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -83,11 +83,14 @@ namespace coreinit
 		fsCmdBlock->data.mount_it++;
 		
 		// SD
-		if (mountSourceType == MOUNT_TYPE::SD && fsCmdBlock->data.mount_it == 1)
+		if (mountSourceType == MOUNT_TYPE::SD)
 		{
-			mountSourceInfo->sourceType = 0;
-			strcpy(mountSourceInfo->path, "/sd");
-			return FS_RESULT::SUCCESS;
+			if (fsCmdBlock->data.mount_it == 1 || fsCmdBlock->data.mount_it == 2)
+			{
+				mountSourceInfo->sourceType = 0;
+				strcpy(mountSourceInfo->path, "/sd");
+				return FS_RESULT::SUCCESS;
+			}
 		}
 
 		return FS_RESULT::END_ITERATION;


### PR DESCRIPTION
Append function was not implemented and FSGetMountSourceNext wasn't returning the right data.
Append behaviour is probably incorrect like this. I have no idea how I would even begin to find out what is correct.
I also have no clue what anything in the FSGetMountSourceNext function means. I just saw the number was mismatched when Smash Bros. was calling it.