### PR TITLE
Fix a small regression when building in Macos

### DIFF
--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -467,7 +467,7 @@ add_library(CemuCafe
 )
 
 if(APPLE)
-	target_sources(CemuCafe"HW/Latte/Renderer/Vulkan/CocoaSurface.mm")
+	target_sources(CemuCafe PRIVATE "HW/Latte/Renderer/Vulkan/CocoaSurface.mm")
 endif()
 
 set_property(TARGET CemuCafe PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
fixes the regression brought in by #249 by adding the scope option that is required by target_sources