### PR TITLE
Fix some issues with building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ if (MSVC)
 	endif()
 endif()
 
+if (APPLE)
+    enable_language(OBJC OBJCXX)
+endif()
+
 option(ENABLE_OPENGL "Enables the OpenGL backend" ON)
 option(ENABLE_VULKAN "Enables the Vulkan backend" ON)
 option(ENABLE_DISCORD_RPC "Enables the Discord Rich Presence feature" ON)

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -39,9 +39,7 @@
 #include "config/ActiveSettings.h"
 #include "gui/helpers/wxHelpers.h"
 
-#if BOOST_OS_LINUX || BOOST_OS_MACOS
 #include "resource/embedded/resources.h"
-#endif
 
 #include "Cafe/CafeSystem.h"
 #include "Cemu/ncrypto/ncrypto.h"
@@ -630,7 +628,7 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		row->SetFlexibleDirection(wxBOTH);
 		row->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 		
-		const wxImage tmp = wxBITMAP_PNG(PNG_ERROR).ConvertToImage();
+		const wxImage tmp = wxBITMAP_PNG_FROM_DATA(PNG_ERROR).ConvertToImage();
 		m_validate_online = new wxBitmapButton(box, wxID_ANY, tmp.Scale(16, 16));
 		m_validate_online->Bind(wxEVT_BUTTON, &GeneralSettings2::OnShowOnlineValidator, this);
 		row->Add(m_validate_online, 0, wxEXPAND | wxALL, 5);
@@ -1220,7 +1218,7 @@ void GeneralSettings2::UpdateAccountInformation()
 	const auto selection = m_active_account->GetSelection();
 	if(selection == wxNOT_FOUND)
 	{
-		m_validate_online->SetBitmap(wxBITMAP_PNG(PNG_ERROR).ConvertToImage().Scale(16, 16));
+		m_validate_online->SetBitmap(wxBITMAP_PNG_FROM_DATA(PNG_ERROR).ConvertToImage().Scale(16, 16));
 		m_validate_online->SetWindowStyleFlag(m_validate_online->GetWindowStyleFlag() & ~wxBORDER_NONE);
 		ResetAccountInformation();
 		return;
@@ -1253,12 +1251,12 @@ void GeneralSettings2::UpdateAccountInformation()
 	{
 		
 		m_online_status->SetLabel(_("Your account is a valid online account"));
-		m_validate_online->SetBitmap(wxBITMAP_PNG(PNG_CHECK_YES).ConvertToImage().Scale(16, 16));
+		m_validate_online->SetBitmap(wxBITMAP_PNG_FROM_DATA(PNG_CHECK_YES).ConvertToImage().Scale(16, 16));
 		m_validate_online->SetWindowStyleFlag(m_validate_online->GetWindowStyleFlag() | wxBORDER_NONE);
 	}
 	else
 	{
-		m_validate_online->SetBitmap(wxBITMAP_PNG(PNG_ERROR).ConvertToImage().Scale(16, 16));
+		m_validate_online->SetBitmap(wxBITMAP_PNG_FROM_DATA(PNG_ERROR).ConvertToImage().Scale(16, 16));
 		m_validate_online->SetWindowStyleFlag(m_validate_online->GetWindowStyleFlag() & ~wxBORDER_NONE);
 	}
 	

--- a/src/gui/TitleManager.cpp
+++ b/src/gui/TitleManager.cpp
@@ -39,9 +39,8 @@
 
 #include "Cafe/TitleList/TitleList.h"
 
-#if BOOST_OS_LINUX || BOOST_OS_MACOS
 #include "resource/embedded/resources.h"
-#endif
+
 #include "Cafe/TitleList/SaveList.h"
 
 wxDEFINE_EVENT(wxEVT_TITLE_FOUND, wxCommandEvent);

--- a/src/gui/TitleManager.cpp
+++ b/src/gui/TitleManager.cpp
@@ -63,14 +63,14 @@ wxPanel* TitleManager::CreateTitleManagerPage()
 		m_filter->Bind(wxEVT_TEXT, &TitleManager::OnFilterChanged, this);
 		row->Add(m_filter, 1, wxALL | wxEXPAND, 5);
 
-		const wxImage refresh = wxBITMAP_PNG(PNG_REFRESH).ConvertToImage();
+		const wxImage refresh = wxBITMAP_PNG_FROM_DATA(PNG_REFRESH).ConvertToImage();
 		m_refresh_button = new wxBitmapButton(panel, wxID_ANY, refresh.Scale(16, 16));
 		m_refresh_button->Disable();
 		m_refresh_button->Bind(wxEVT_BUTTON, &TitleManager::OnRefreshButton, this);
 		m_refresh_button->SetToolTip(_("Refresh"));
 		row->Add(m_refresh_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-		auto* help_button = new wxStaticBitmap(panel, wxID_ANY, wxBITMAP_PNG(PNG_HELP));
+		auto* help_button = new wxStaticBitmap(panel, wxID_ANY, wxBITMAP_PNG_FROM_DATA(PNG_HELP));
 		help_button->SetToolTip(wxStringFormat2(_("The following prefixes are supported:\n{0}\n{1}\n{2}\n{3}\n{4}"),
 			"titleid:", "name:", "type:", "version:", "region:"));
 		row->Add(help_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -302,12 +302,12 @@ void wxGameList::UpdateItemColors(sint32 startIndex)
 	}
 }
 
-static inline int strongorder_to_int(const std::strong_ordering &wo)
+static inline int order_to_int(const std::weak_ordering &wo)
 {
 	// no easy conversion seems to exists in C++20
-	if (wo < 0)
+	if (wo == std::weak_ordering::less)
 		return -1;
-	else if (wo > 0)
+	else if (wo == std::weak_ordering::greater)
 		return 1;
 	return 0;
 }
@@ -320,9 +320,9 @@ int wxGameList::SortComparator(uint64 titleId1, uint64 titleId2, SortData* sortD
 	const auto& name2 = GetNameByTitleId(titleId2);
 
 	if(sortData->dir > 0)
-		return strongorder_to_int(std::tie(isFavoriteB, name1) <=> std::tie(isFavoriteA, name2));
+		return order_to_int(std::tie(isFavoriteB, name1) <=> std::tie(isFavoriteA, name2));
 	else
-		return strongorder_to_int(std::tie(isFavoriteB, name2) <=> std::tie(isFavoriteA, name1));
+		return order_to_int(std::tie(isFavoriteB, name2) <=> std::tie(isFavoriteA, name1));
 }
 
 int wxGameList::SortFunction(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -3,12 +3,10 @@ add_library(CemuResource)
 set_property(TARGET CemuResource PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # icon resources
-if(UNIX)
-	target_sources(CemuResource PRIVATE
-	embedded/resources.cpp
-	embedded/resources.h
-	)
-endif()
+target_sources(CemuResource PRIVATE
+embedded/resources.cpp
+embedded/resources.h
+)
 
 target_sources(CemuResource PRIVATE CafeDefaultFont.cpp)
 


### PR DESCRIPTION
This fixes some issues when building on macOS and for macOS

Reasoning behind changes
1. For some reason when building on macOS, OBJC and OBJCXX need to be explicitly enabled else an error involving [precompiled.h](https://github.com/cemu-project/Cemu/tree/main/src/Common) occurs. Is only enabled on macOS, no side effects. Credits to OatmealDome
2. changing strong ordering to weak ordering. There exists implicit conversion from strong to weak and in our case it shouldn't produce any side effects. Three way comparison on strings produces weak_ordering which can't be converted to strong_ordering. Functionality in all cases should be kept the same while adding support for macOS.
3. Uses the raw PNG bytes found in [resources/embedded](https://github.com/cemu-project/Cemu/tree/main/src/resource/embedded). Was tested and produces no side effects on Windows and Linux

To Do list for a separate PR 
1. Some string encoding issues involving boost::iequals
2. GitHub workflow for macOS