### PR TITLE
Fix 1x1 symbols in debugger window + Load icons from headers on all platforms

### DIFF
--- a/src/gui/debugger/DebuggerWindow2.cpp
+++ b/src/gui/debugger/DebuggerWindow2.cpp
@@ -19,9 +19,7 @@
 #include "gui/debugger/ModuleWindow.h"
 #include "util/helpers/helpers.h"
 
-#if BOOST_OS_LINUX
 #include "resource/embedded/resources.h"
-#endif
 
 enum
 {
@@ -219,26 +217,27 @@ void DebuggerModuleStorage::Save(XMLConfigParser& parser)
 void DebuggerWindow2::CreateToolBar() 
 {
 	m_toolbar = wxFrame::CreateToolBar(wxTB_HORIZONTAL, wxID_ANY);
-	m_toolbar->SetToolBitmapSize(wxSize(1, 1));
+	m_toolbar->SetToolBitmapSize(wxSize(16, 16));
 
-	m_toolbar->AddTool(TOOL_ID_GOTO, wxEmptyString, wxBITMAP_PNG(DEBUGGER_GOTO), wxNullBitmap, wxITEM_NORMAL, _("GoTo (CTRL + G)"), "test", NULL);
+	m_toolbar->AddTool(TOOL_ID_GOTO, wxEmptyString, wxBITMAP_PNG_FROM_DATA(DEBUGGER_GOTO), wxNullBitmap, wxITEM_NORMAL, _("GoTo (CTRL + G)"), "test", NULL);
 	m_toolbar->AddSeparator();
 
-	m_toolbar->AddTool(TOOL_ID_BP, wxEmptyString, wxBITMAP_PNG(DEBUGGER_BP_RED), wxNullBitmap, wxITEM_NORMAL, _("Toggle Breakpoint (F9)"), wxEmptyString, NULL);
+	m_toolbar->AddTool(TOOL_ID_BP, wxEmptyString, wxBITMAP_PNG_FROM_DATA(DEBUGGER_BP_RED), wxNullBitmap, wxITEM_NORMAL, _("Toggle Breakpoint (F9)"), wxEmptyString, NULL);
 	m_toolbar->AddSeparator();
 
-	m_pause = wxBITMAP_PNG(DEBUGGER_PAUSE);
-	m_run = wxBITMAP_PNG(DEBUGGER_PLAY);
+	m_pause = wxBITMAP_PNG_FROM_DATA(DEBUGGER_PAUSE);
+	m_run = wxBITMAP_PNG_FROM_DATA(DEBUGGER_PLAY);
 	m_toolbar->AddTool(TOOL_ID_PAUSE, wxEmptyString, m_pause, wxNullBitmap, wxITEM_NORMAL, _("Break (F5)"), wxEmptyString, NULL);
 	
-	m_toolbar->AddTool(TOOL_ID_STEP_INTO, wxEmptyString, wxBITMAP_PNG(DEBUGGER_STEP_INTO), wxNullBitmap, wxITEM_NORMAL, _("Step Into (F11)"), wxEmptyString, NULL);
-	m_toolbar->AddTool(TOOL_ID_STEP_OVER, wxEmptyString, wxBITMAP_PNG(DEBUGGER_STEP_OVER), wxNullBitmap, wxITEM_NORMAL, _("Step Over (F10)"), wxEmptyString, NULL);
+	m_toolbar->AddTool(TOOL_ID_STEP_INTO, wxEmptyString, wxBITMAP_PNG_FROM_DATA(DEBUGGER_STEP_INTO), wxNullBitmap, wxITEM_NORMAL, _("Step Into (F11)"), wxEmptyString, NULL);
+	m_toolbar->AddTool(TOOL_ID_STEP_OVER, wxEmptyString, wxBITMAP_PNG_FROM_DATA(DEBUGGER_STEP_OVER), wxNullBitmap, wxITEM_NORMAL, _("Step Over (F10)"), wxEmptyString, NULL);
 	m_toolbar->AddSeparator();
 
 	m_toolbar->Realize();
 
 	m_toolbar->EnableTool(TOOL_ID_STEP_INTO, false);
 	m_toolbar->EnableTool(TOOL_ID_STEP_OVER, false);
+
 }
 
 void DebuggerWindow2::SaveModuleStorage(const RPLModule* module, bool delete_breakpoints)

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -29,9 +29,7 @@
 #include "gui/input/settings/WiimoteControllerSettings.h"
 #include "util/EventService.h"
 
-#if BOOST_OS_LINUX
 #include "resource/embedded/resources.h"
-#endif
 
 bool g_inputConfigWindowHasFocus = false;
 
@@ -70,9 +68,9 @@ InputSettings2::InputSettings2(wxWindow* parent)
 
 	g_inputConfigWindowHasFocus = true;
 
-	m_connected = wxBITMAP_PNG(INPUT_CONNECTED);
-	m_disconnected = wxBITMAP_PNG(INPUT_DISCONNECTED);
-	m_low_battery = wxBITMAP_PNG(INPUT_LOW_BATTERY);
+	m_connected = wxBITMAP_PNG_FROM_DATA(INPUT_CONNECTED);
+	m_disconnected = wxBITMAP_PNG_FROM_DATA(INPUT_DISCONNECTED);
+	m_low_battery = wxBITMAP_PNG_FROM_DATA(INPUT_LOW_BATTERY);
 
 	auto* sizer = new wxBoxSizer(wxVERTICAL);
 

--- a/src/resource/cemu.rc
+++ b/src/resource/cemu.rc
@@ -109,36 +109,6 @@ END
 // RCDATA
 //
 
-DEBUGGER_BP             RCDATA                  "resource\\debugger\\icons8-full-moon-filled-50.png"
-
-DEBUGGER_BP_RED         RCDATA                  "resource\\debugger\\icons8-full-moon-filled-50-red.png"
-
-DEBUGGER_PAUSE          RCDATA                  "resource\\debugger\\icons8-pause-filled-50.png"
-
-DEBUGGER_PLAY           RCDATA                  "resource\\debugger\\icons8-play-filled-50.png"
-
-DEBUGGER_STEP_INTO      RCDATA                  "resource\\debugger\\icons8-step-into-50.png"
-
-DEBUGGER_STEP_OUT       RCDATA                  "resource\\debugger\\icons8-step-out-50.png"
-
-DEBUGGER_STEP_OVER      RCDATA                  "resource\\debugger\\icons8-step-over-50.png"
-
-DEBUGGER_GOTO           RCDATA                  "resource\\debugger\\icons8-drop-down-50.png"
-
-INPUT_CONNECTED         RCDATA                  "resource\\input\\icons8-connected-50.png"
-
-INPUT_DISCONNECTED      RCDATA                  "resource\\input\\icons8-disconnected-50.png"
-
-INPUT_LOW_BATTERY       RCDATA                  "resource\\input\\icons8-low-battery-30.png"
-
-PNG_HELP                RCDATA                 "resource\\icons8-help-24.png"
-
-PNG_REFRESH             RCDATA                 "resource\\icons8-refresh-32.png"
-
-PNG_ERROR               RCDATA                 "resource\\icons8-error-32.png"
-
-PNG_CHECK_YES           RCDATA                 "resource\\icons8-checkmark-yes-32.png"
-
 IDR_FONTAWESOME         RCDATA                  "resource\\fontawesome-webfont.ttf"
 
 #endif    // Neutral (Default) (unknown sub-lang: 0x8) resources


### PR DESCRIPTION
- Fixed an issue where the toolbar icons for the debugger were resized to 1x1
- On Windows we now load the PNG UI icons from the header-embedded pngs (`resource/embedded`) instead of via `cemu.rc` to match behavior of other platforms