### PR TITLE
Change handling of PUBLIC_RELEASE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
       if: ${{ inputs.deploymode == 'release' }}
       run: |
         echo "BUILD_MODE=release" >> $GITHUB_ENV
-        echo "BUILD_FLAGS=-DPUBLIC_RELEASE=ON" >> $GITHUB_ENV
         echo "Build mode is release"
     - name: Setup debug mode parameters (for continous build)
       if: ${{ inputs.deploymode != 'release' }}
@@ -99,7 +98,6 @@ jobs:
       if: ${{ inputs.deploymode == 'release' }}
       run: |
         echo "BUILD_MODE=release" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-        echo "BUILD_FLAGS=-DPUBLIC_RELEASE=ON" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         echo "Build mode is release"
         
     - name: Setup debug mode parameters (for continous build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.21.1)
 
-option(PUBLIC_RELEASE "Compile with debug asserts disabled and no console" OFF)
 option(ENABLE_VCPKG "Enable the vcpkg package manager" ON)
 set(EXPERIMENTAL_VERSION "" CACHE STRING "") # used by CI script to set experimental version
 
@@ -29,7 +28,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if (PUBLIC_RELEASE)
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
 	add_compile_definitions(PUBLIC_RELEASE)
 	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE) # enable LTO
 endif()
@@ -48,7 +47,7 @@ if (MSVC)
   	else()
 	  add_compile_options(/GT)
 	endif()
-	if (PUBLIC_RELEASE)
+	if (CMAKE_BUILD_TYPE STREQUAL "Release")
 		message(STATUS "Using additional optimization flags for MSVC")
 		add_compile_options(/Oi /Ot) # enable intrinsic functions, favor speed
 	endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,22 +54,11 @@ add_subdirectory(imgui)
 add_subdirectory(resource)
 add_subdirectory(asm)
 
-if(PUBLIC_RELEASE)
-	add_executable(CemuBin WIN32
-		main.cpp
-		mainLLE.cpp
-	)
-else()
-	add_executable(CemuBin
-		main.cpp
-		mainLLE.cpp
-	)
-endif()
+add_executable(CemuBin main.cpp mainLLE.cpp)
 
-if(WIN32)
-	target_sources(CemuBin PRIVATE
-	resource/cemu.rc
-)
+if (WIN32)
+	target_sources(CemuBin PRIVATE resource/cemu.rc)
+	set_target_properties(CemuBin PROPERTIES WIN32_EXECUTABLE TRUE)
 endif()
 
 set_property(TARGET CemuBin PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
No reason to have a "release" and a "public release". Release and Debug are all we need. Also helps significantly in refactoring the CI due to the `BUILD_FLAGS` stuff.