### PR TITLE
CI: Fix Windows build running out of disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,35 +114,6 @@ jobs:
         echo "[INFO] Experimental version ${{ inputs.experimentalversion }}"
         echo "BUILD_FLAGS=${{ env.BUILD_FLAGS }} -DEXPERIMENTAL_VERSION=${{ inputs.experimentalversion }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
     
-    - name: Workaround
-      run: |
-        Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-        $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-        $componentsToRemove= @(
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ARM"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ARM.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ARM64"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ARM64.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.x86.x64"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.x86.x64.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL.ARM"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL.ARM.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL.ARM64"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.ATL.ARM64.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC.ARM"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC.ARM.Spectre"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC.ARM64"
-          "Microsoft.VisualStudio.Component.VC.14.32.17.2.MFC.ARM64.Spectre"
-        )
-        [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-        $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-        # should be run twice
-        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
     - name: Configure MSVC
       uses: ilammy/msvc-dev-cmd@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         cd build
         echo "[INFO] BUILD_FLAGS: ${{ env.BUILD_FLAGS }}"
         echo "[INFO] BUILD_MODE: ${{ env.BUILD_MODE }}"
-        cmake .. ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }}
+        cmake .. ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} -DVCPKG_INSTALL_OPTIONS="--clean-after-build"
         
     - name: "Build Cemu"
       run: |


### PR DESCRIPTION
When building vcpkg packages from scratch, the Windows CI can sometimes run out of disk space. Running vcpkg with `--clean-after-build` should fix this as it cleans up some of the temporary data that is generated during package building.

I also removed the MSVC workaround which is no longer necessary ([relevant issue](https://github.com/actions/runner-images/issues/6091)).