### PR TITLE
Vulkan: Fix incorrect encoding for substituted R4G4 format

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
+++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.h
@@ -612,8 +612,8 @@ public:
 				uint8* blockData = LatteTextureLoader_GetInput(textureLoader, x, y);
 				sint32 pixelOffset = (x + yc * textureLoader->width) * 2;
 				uint8 v = (*(uint8*)(blockData + 0));
-				*(uint8*)(outputData + pixelOffset + 1) = 0;
-				*(uint8*)(outputData + pixelOffset + 0) = ((v >> 4) & 0xF) | ((v << 4) & 0xF0); // todo: Is this nibble swap correct?
+				*(uint8*)(outputData + pixelOffset + 0) = 0;
+				*(uint8*)(outputData + pixelOffset + 1) = v;
 			}
 		}
 	}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2571,7 +2571,7 @@ void VulkanRenderer::GetTextureFormatInfoVK(Latte::E_GX2SURFFMT format, bool isD
 			else
 			{
 				formatInfoOut->vkImageFormat = VK_FORMAT_R4G4_UNORM_PACK8;
-				formatInfoOut->decoder = TextureDecoder_R4_G4::getInstance(); // todo - verify if order of R/G matches between GX2/Vulkan
+				formatInfoOut->decoder = TextureDecoder_R4_G4::getInstance();
 			}
 			break;
 			// R formats


### PR DESCRIPTION
We normally map Latte's R4G4 texture format to `VK_FORMAT_R4G4_UNORM_PACK8`. But on some AMD and Intel GPUs this format is not available or has limited usage. In that case we fall back to `VK_FORMAT_R4G4B4A4_UNORM_PACK16` as a substitute format. This PR fixes the incorrect channel order we had in the conversion code.

Resolves a known problem where the rupee counter in Twilight Princess is invisible on affected GPUs. This may also fix other issues mentioned in #212 

Before:
![image](https://user-images.githubusercontent.com/13877693/192091044-5300d838-b810-4325-b078-bad0a7990136.png)
After:
![image](https://user-images.githubusercontent.com/13877693/192091049-1cf2a4d9-d6d5-4658-9e8f-aa9bcba3069a.png)