### PR TITLE
Added Native Pretendo and custom URLs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ bin/Cemu_*.ilk
 bin/Cemu.exe.backup
 bin/mlc01/*
 bin/settings.xml
+bin/network_services.xml
 bin/title_list_cache.xml
 bin/debugger/*
 bin/sdcard/*

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -498,7 +498,7 @@ namespace iosu
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, task_header_callback);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &(*it));
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0x3C);
-		if (GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() == Custom || ActiveSettings::GetNetworkService() == Pretendo){ //Remove Pretendo Function once SSL is in the Service
+		if (GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() == NetworkService::Custom || ActiveSettings::GetNetworkService() == NetworkService::Pretendo){ //Remove Pretendo Function once SSL is in the Service
 			curl_easy_setopt(curl,CURLOPT_SSL_VERIFYPEER,0L);
 		} else {
 		curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, task_sslctx_function);
@@ -568,13 +568,13 @@ namespace iosu
 			strncpy(boss_code, (char*)&it->task_settings.settings[TaskSetting::kBossCode], TaskSetting::kBossCodeLen);
 			switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				sprintf(url, NintendoURLs::BOSSURL.append("/%s/%s/%s?c=%s&l=%s").c_str(), "1", boss_code, it->task_id, countryCode, languageCode);
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				sprintf(url, PretendoURLs::BOSSURL.append("/%s/%s/%s?c=%s&l=%s").c_str(), "1", boss_code, it->task_id, countryCode, languageCode);
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				sprintf(url, GetNetworkConfig().urls.BOSS.GetValue().append("/%s/%s/%s?c=%s&l=%s").c_str(), "1", boss_code, it->task_id, countryCode, languageCode);
 				break;
 			default:

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -562,7 +562,11 @@ namespace iosu
 			char boss_code[0x20];
 			strncpy(boss_code, (char*)&it->task_settings.settings[TaskSetting::kBossCode], TaskSetting::kBossCodeLen);
 
+		if (ActiveSettings::GetNetworkService() == 0) {
 			sprintf(url, "https://npts.app.nintendo.net/p01/tasksheet/%s/%s/%s?c=%s&l=%s", "1", boss_code, it->task_id, countryCode, languageCode);
+		}else if (ActiveSettings::GetNetworkService() == 1) {
+			sprintf(url, "https://npts.app.pretendo.cc/p01/tasksheet/%s/%s/%s?c=%s&l=%s", "1", boss_code, it->task_id, countryCode, languageCode);
+		}
 		}
 
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list_headerParam);

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -497,9 +497,13 @@ namespace iosu
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, task_header_callback);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &(*it));
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0x3C);
+		if (ActiveSettings::IsSSLDisabled()){
+			curl_easy_setopt(curl,CURLOPT_SSL_VERIFYPEER,0L);
+		} else {
 		curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, task_sslctx_function);
 		curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, &it->task_settings);
 		curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0);
+		}
 
 		char url[512];
 		if(it->task_settings.taskType == kRawDlTaskSetting)

--- a/src/Cemu/napi/napi_ec.cpp
+++ b/src/Cemu/napi/napi_ec.cpp
@@ -9,7 +9,7 @@
 #include "util/crypto/md5.h"
 #include "config/LaunchSettings.h"
 #include "config/ActiveSettings.h"
-
+#include "config/NetworkSettings.h"
 #include "pugixml.hpp"
 #include <charconv>
 
@@ -27,20 +27,42 @@ namespace NAPI
 	{
 		if (!s_serviceURL_NusURL.empty())
 			return s_serviceURL_NusURL;
-		if (ActiveSettings::GetNetworkService() == 0)
-		return "https://nus.wup.shop.nintendo.net/nus/services/NetUpdateSOAP";
-		if  (ActiveSettings::GetNetworkService() == 1)
-		return "https://nus.c.shop.pretendo.cc/nus/services/NetUpdateSOAP";
+			switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				return NintendoURLs::NUSURL;
+				break;
+			case Pretendo:
+				return PretendoURLs::NUSURL;
+				break;
+			case Custom:
+				return GetNetworkConfig().urls.NUS;
+				break;
+			default:
+				return NintendoURLs::NUSURL;
+				break;
+			}
 	}
 
 	std::string _getIASUrl()
 	{
 		if (!s_serviceURL_IasURL.empty())
 			return s_serviceURL_IasURL;
-		if (ActiveSettings::GetNetworkService() == 0)
-		return "https://ias.wup.shop.nintendo.net/ias/services/IdentityAuthenticationSOAP";
-		if (ActiveSettings::GetNetworkService() == 1)
-		return "https://ias.c.shop.pretendo.cc/ias/services/IdentityAuthenticationSOAP";
+		switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				return NintendoURLs::IASURL;
+				break;
+			case Pretendo:
+				return PretendoURLs::IASURL;
+				break;
+			case Custom:
+				return GetNetworkConfig().urls.IAS;
+				break;
+			default:
+				return NintendoURLs::IASURL;
+				break;
+			}
 	}
 
 	std::string _getECSUrl()
@@ -55,20 +77,42 @@ namespace NAPI
 	{
 		if (!s_serviceURL_UncachedContentPrefixURL.empty())
 			return s_serviceURL_UncachedContentPrefixURL;
-		if (ActiveSettings::GetNetworkService() == 0)
-		return "https://ccs.wup.shop.nintendo.net/ccs/download";
-		if (ActiveSettings::GetNetworkService() == 1)
-		return "https://ccs.c.shop.pretendo.cc/ccs/download";
+		switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				return NintendoURLs::CCSUURL;
+				break;
+			case Pretendo:
+				return PretendoURLs::CCSUURL;
+				break;
+			case Custom:
+				return GetNetworkConfig().urls.CCSU;
+				break;
+			default:
+				return NintendoURLs::CCSUURL;
+				break;
+			}
 	}
 
 	std::string _getCCSUrl() // used for game data downloads
 	{
 		if (!s_serviceURL_ContentPrefixURL.empty())
 			return s_serviceURL_ContentPrefixURL;
-		if (ActiveSettings::GetNetworkService() == 0)
-		return "http://ccs.cdn.wup.shop.nintendo.net/ccs/download";
-		if (ActiveSettings::GetNetworkService() == 1)
-		return "http://ccs.cdn.c.shop.pretendo.cc/ccs/download";
+		switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				return NintendoURLs::CCSURL;
+				break;
+			case Pretendo:
+				return PretendoURLs::CCSURL;
+				break;
+			case Custom:
+				return GetNetworkConfig().urls.CCS;
+				break;
+			default:
+				return NintendoURLs::CCSURL;
+				break;
+			}
 	}
 
 	/* NUS */

--- a/src/Cemu/napi/napi_ec.cpp
+++ b/src/Cemu/napi/napi_ec.cpp
@@ -29,13 +29,13 @@ namespace NAPI
 			return s_serviceURL_NusURL;
 			switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				return NintendoURLs::NUSURL;
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				return PretendoURLs::NUSURL;
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				return GetNetworkConfig().urls.NUS;
 				break;
 			default:
@@ -50,13 +50,13 @@ namespace NAPI
 			return s_serviceURL_IasURL;
 		switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				return NintendoURLs::IASURL;
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				return PretendoURLs::IASURL;
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				return GetNetworkConfig().urls.IAS;
 				break;
 			default:
@@ -79,13 +79,13 @@ namespace NAPI
 			return s_serviceURL_UncachedContentPrefixURL;
 		switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				return NintendoURLs::CCSUURL;
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				return PretendoURLs::CCSUURL;
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				return GetNetworkConfig().urls.CCSU;
 				break;
 			default:
@@ -100,13 +100,13 @@ namespace NAPI
 			return s_serviceURL_ContentPrefixURL;
 		switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				return NintendoURLs::CCSURL;
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				return PretendoURLs::CCSURL;
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				return GetNetworkConfig().urls.CCS;
 				break;
 			default:

--- a/src/Cemu/napi/napi_ec.cpp
+++ b/src/Cemu/napi/napi_ec.cpp
@@ -8,6 +8,7 @@
 #include "Cemu/ncrypto/ncrypto.h"
 #include "util/crypto/md5.h"
 #include "config/LaunchSettings.h"
+#include "config/ActiveSettings.h"
 
 #include "pugixml.hpp"
 #include <charconv>
@@ -26,14 +27,20 @@ namespace NAPI
 	{
 		if (!s_serviceURL_NusURL.empty())
 			return s_serviceURL_NusURL;
+		if (ActiveSettings::GetNetworkService() == 0)
 		return "https://nus.wup.shop.nintendo.net/nus/services/NetUpdateSOAP";
+		if  (ActiveSettings::GetNetworkService() == 1)
+		return "https://nus.c.shop.pretendo.cc/nus/services/NetUpdateSOAP";
 	}
 
 	std::string _getIASUrl()
 	{
 		if (!s_serviceURL_IasURL.empty())
 			return s_serviceURL_IasURL;
+		if (ActiveSettings::GetNetworkService() == 0)
 		return "https://ias.wup.shop.nintendo.net/ias/services/IdentityAuthenticationSOAP";
+		if (ActiveSettings::GetNetworkService() == 1)
+		return "https://ias.c.shop.pretendo.cc/ias/services/IdentityAuthenticationSOAP";
 	}
 
 	std::string _getECSUrl()
@@ -48,14 +55,20 @@ namespace NAPI
 	{
 		if (!s_serviceURL_UncachedContentPrefixURL.empty())
 			return s_serviceURL_UncachedContentPrefixURL;
+		if (ActiveSettings::GetNetworkService() == 0)
 		return "https://ccs.wup.shop.nintendo.net/ccs/download";
+		if (ActiveSettings::GetNetworkService() == 1)
+		return "https://ccs.c.shop.pretendo.cc/ccs/download";
 	}
 
 	std::string _getCCSUrl() // used for game data downloads
 	{
 		if (!s_serviceURL_ContentPrefixURL.empty())
 			return s_serviceURL_ContentPrefixURL;
+		if (ActiveSettings::GetNetworkService() == 0)
 		return "http://ccs.cdn.wup.shop.nintendo.net/ccs/download";
+		if (ActiveSettings::GetNetworkService() == 1)
+		return "http://ccs.cdn.c.shop.pretendo.cc/ccs/download";
 	}
 
 	/* NUS */

--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -8,7 +8,8 @@
 #include "napi_helper.h"
 #include "util/highresolutiontimer/HighResolutionTimer.h"
 #include "config/ActiveSettings.h"
-
+#include "config/NetworkSettings.h"
+#include "config/LaunchSettings.h"
 #include "pugixml.hpp"
 #include <charconv>
 
@@ -98,7 +99,7 @@ void CurlRequestHelper::initate(std::string url, SERVER_SSL_CONTEXT sslContext)
 	curl_easy_setopt(m_curl, CURLOPT_TIMEOUT, 60);
 
 	// SSL
-	if (ActiveSettings::IsSSLDisabled()){
+	if (GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() == Custom || ActiveSettings::GetNetworkService() == Pretendo){ //Remove once Pretendo has SSL
 	curl_easy_setopt(m_curl, CURLOPT_SSL_VERIFYPEER, 0L);
 	}
 	else if (sslContext == SERVER_SSL_CONTEXT::ACT || sslContext == SERVER_SSL_CONTEXT::TAGAYA)
@@ -223,7 +224,7 @@ CurlSOAPHelper::CurlSOAPHelper()
 	curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
 
 	// SSL
-	if (!ActiveSettings::IsSSLDisabled()) {
+	if (!GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() != Pretendo  && ActiveSettings::GetNetworkService() != Custom) { //Remove once Pretendo has SSL
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_FUNCTION, _sslctx_function_SOAP);
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_DATA, NULL);
 	}

--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -99,7 +99,7 @@ void CurlRequestHelper::initate(std::string url, SERVER_SSL_CONTEXT sslContext)
 	curl_easy_setopt(m_curl, CURLOPT_TIMEOUT, 60);
 
 	// SSL
-	if (GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() == Custom || ActiveSettings::GetNetworkService() == Pretendo){ //Remove once Pretendo has SSL
+	if (GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() == NetworkService::Custom || ActiveSettings::GetNetworkService() == NetworkService::Pretendo){ //Remove once Pretendo has SSL
 	curl_easy_setopt(m_curl, CURLOPT_SSL_VERIFYPEER, 0L);
 	}
 	else if (sslContext == SERVER_SSL_CONTEXT::ACT || sslContext == SERVER_SSL_CONTEXT::TAGAYA)
@@ -224,7 +224,7 @@ CurlSOAPHelper::CurlSOAPHelper()
 	curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
 
 	// SSL
-	if (!GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() != Pretendo  && ActiveSettings::GetNetworkService() != Custom) { //Remove once Pretendo has SSL
+	if (!GetNetworkConfig().disablesslver.GetValue()  && ActiveSettings::GetNetworkService() != NetworkService::Pretendo  && ActiveSettings::GetNetworkService() != NetworkService::Custom) { //Remove once Pretendo has SSL
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_FUNCTION, _sslctx_function_SOAP);
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_DATA, NULL);
 	}

--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -7,6 +7,7 @@
 #include "Cemu/ncrypto/ncrypto.h"
 #include "napi_helper.h"
 #include "util/highresolutiontimer/HighResolutionTimer.h"
+#include "config/ActiveSettings.h"
 
 #include "pugixml.hpp"
 #include <charconv>
@@ -97,7 +98,10 @@ void CurlRequestHelper::initate(std::string url, SERVER_SSL_CONTEXT sslContext)
 	curl_easy_setopt(m_curl, CURLOPT_TIMEOUT, 60);
 
 	// SSL
-	if (sslContext == SERVER_SSL_CONTEXT::ACT || sslContext == SERVER_SSL_CONTEXT::TAGAYA)
+	if (ActiveSettings::IsSSLDisabled()){
+	curl_easy_setopt(m_curl, CURLOPT_SSL_VERIFYPEER, 0L);
+	}
+	else if (sslContext == SERVER_SSL_CONTEXT::ACT || sslContext == SERVER_SSL_CONTEXT::TAGAYA)
 	{
 		curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_FUNCTION, _sslctx_function_NUS);
 		curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_DATA, NULL);
@@ -219,9 +223,10 @@ CurlSOAPHelper::CurlSOAPHelper()
 	curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
 
 	// SSL
+	if (!ActiveSettings::IsSSLDisabled()) {
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_FUNCTION, _sslctx_function_SOAP);
 	curl_easy_setopt(m_curl, CURLOPT_SSL_CTX_DATA, NULL);
-	
+	}
 	if(GetConfig().proxy_server.GetValue() != "")
 	{
 		curl_easy_setopt(m_curl, CURLOPT_PROXY, GetConfig().proxy_server.GetValue().c_str());

--- a/src/Cemu/napi/napi_idbe.cpp
+++ b/src/Cemu/napi/napi_idbe.cpp
@@ -59,13 +59,13 @@ namespace NAPI
 		CurlRequestHelper req;
 	switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				req.initate(fmt::format(fmt::runtime(PretendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				req.initate(fmt::format(fmt::runtime(GetNetworkConfig().urls.IDBE.GetValue() + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
 			default:
@@ -102,13 +102,13 @@ namespace NAPI
 		CurlRequestHelper req;
 		switch (ActiveSettings::GetNetworkService())
 			{
-			case Nintendo:
+			case NetworkService::Nintendo:
 				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
-			case Pretendo:
+			case NetworkService::Pretendo:
 				req.initate(fmt::format(fmt::runtime(PretendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
-			case Custom:
+			case NetworkService::Custom:
 				req.initate(fmt::format(fmt::runtime(GetNetworkConfig().urls.IDBE.GetValue() + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
 				break;
 			default:

--- a/src/Cemu/napi/napi_idbe.cpp
+++ b/src/Cemu/napi/napi_idbe.cpp
@@ -10,6 +10,7 @@
 #include "openssl/sha.h"
 #include "util/crypto/aes128.h"
 #include "util/helpers/StringHelpers.h"
+#include "config/ActiveSettings.h"
 
 namespace NAPI
 {
@@ -55,7 +56,11 @@ namespace NAPI
 	std::vector<uint8> IDBE_RequestRawEncrypted(uint64 titleId)
 	{
 		CurlRequestHelper req;
+		if (ActiveSettings::GetNetworkService() == 0) {
 		req.initate(fmt::format("https://idbe-wup.cdn.nintendo.net/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+		}else if (ActiveSettings::GetNetworkService() == 1) {
+		req.initate(fmt::format("https://idbe-wup.cdn.pretendo.cc/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+		}
 		if (!req.submitRequest(false))
 		{
 			cemuLog_log(LogType::Force, fmt::format("Failed to request IDBE icon for title {0:016X}", titleId));
@@ -84,7 +89,12 @@ namespace NAPI
 		}
 
 		CurlRequestHelper req;
+		if (ActiveSettings::GetNetworkService() == 0) {
 		req.initate(fmt::format("https://idbe-wup.cdn.nintendo.net/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+		}else if (ActiveSettings::GetNetworkService() == 1) {
+		req.initate(fmt::format("https://idbe-wup.cdn.pretendo.cc/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+		}
+
 		if (!req.submitRequest(false))
 		{
 			cemuLog_log(LogType::Force, fmt::format("Failed to request IDBE icon for title {0:016X}", titleId));

--- a/src/Cemu/napi/napi_idbe.cpp
+++ b/src/Cemu/napi/napi_idbe.cpp
@@ -11,6 +11,7 @@
 #include "util/crypto/aes128.h"
 #include "util/helpers/StringHelpers.h"
 #include "config/ActiveSettings.h"
+#include "config/NetworkSettings.h"
 
 namespace NAPI
 {
@@ -56,11 +57,21 @@ namespace NAPI
 	std::vector<uint8> IDBE_RequestRawEncrypted(uint64 titleId)
 	{
 		CurlRequestHelper req;
-		if (ActiveSettings::GetNetworkService() == 0) {
-		req.initate(fmt::format("https://idbe-wup.cdn.nintendo.net/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
-		}else if (ActiveSettings::GetNetworkService() == 1) {
-		req.initate(fmt::format("https://idbe-wup.cdn.pretendo.cc/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
-		}
+	switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			case Pretendo:
+				req.initate(fmt::format(fmt::runtime(PretendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			case Custom:
+				req.initate(fmt::format(fmt::runtime(GetNetworkConfig().urls.IDBE.GetValue() + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			default:
+				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			}
 		if (!req.submitRequest(false))
 		{
 			cemuLog_log(LogType::Force, fmt::format("Failed to request IDBE icon for title {0:016X}", titleId));
@@ -89,11 +100,21 @@ namespace NAPI
 		}
 
 		CurlRequestHelper req;
-		if (ActiveSettings::GetNetworkService() == 0) {
-		req.initate(fmt::format("https://idbe-wup.cdn.nintendo.net/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
-		}else if (ActiveSettings::GetNetworkService() == 1) {
-		req.initate(fmt::format("https://idbe-wup.cdn.pretendo.cc/icondata/{0:02X}/{1:016X}.idbe", (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
-		}
+		switch (ActiveSettings::GetNetworkService())
+			{
+			case Nintendo:
+				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			case Pretendo:
+				req.initate(fmt::format(fmt::runtime(PretendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			case Custom:
+				req.initate(fmt::format(fmt::runtime(GetNetworkConfig().urls.IDBE.GetValue() + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			default:
+				req.initate(fmt::format(fmt::runtime(NintendoURLs::IDBEURL + "/{0:02X}/{1:016X}.idbe"), (uint32)((titleId >> 8) & 0xFF), titleId), CurlRequestHelper::SERVER_SSL_CONTEXT::IDBE);
+				break;
+			}
 
 		if (!req.submitRequest(false))
 		{

--- a/src/Cemu/napi/napi_version.cpp
+++ b/src/Cemu/napi/napi_version.cpp
@@ -8,6 +8,7 @@
 #include "Cemu/ncrypto/ncrypto.h"
 #include <charconv>
 #include "config/ActiveSettings.h"
+#include "config/NetworkSettings.h"
 
 namespace NAPI
 {
@@ -15,10 +16,20 @@ namespace NAPI
 	{
 		NAPI_VersionListVersion_Result result;
 		CurlRequestHelper req;
-		if (ActiveSettings::GetNetworkService() == 0) {
-		req.initate(fmt::format("https://tagaya.wup.shop.nintendo.net/tagaya/versionlist/{}/{}/latest_version", NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
-		}else if (ActiveSettings::GetNetworkService() == 1) {
-		req.initate(fmt::format("https://tagaya.wup.shop.pretendo.cc/tagaya/versionlist/{}/{}/latest_version", NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+		switch (ActiveSettings::GetNetworkService())
+		{
+		case NetworkService::Nintendo:
+			req.initate(fmt::format(fmt::runtime(NintendoURLs::TAGAYAURL + "/{}/{}/latest_version"), NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+			break;
+		case NetworkService::Pretendo:
+			req.initate(fmt::format(fmt::runtime(PretendoURLs::TAGAYAURL + "/{}/{}/latest_version"), NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+			break;
+		case NetworkService::Custom:
+			req.initate(fmt::format(fmt::runtime(GetNetworkConfig().urls.TAGAYA.GetValue() + "/{}/{}/latest_version"), NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+			break;
+		default:
+		req.initate(fmt::format(fmt::runtime(NintendoURLs::TAGAYAURL + "/{}/{}/latest_version"), NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+			break;
 		}
 
 		if (!req.submitRequest(false))

--- a/src/Cemu/napi/napi_version.cpp
+++ b/src/Cemu/napi/napi_version.cpp
@@ -7,6 +7,7 @@
 
 #include "Cemu/ncrypto/ncrypto.h"
 #include <charconv>
+#include "config/ActiveSettings.h"
 
 namespace NAPI
 {
@@ -14,7 +15,12 @@ namespace NAPI
 	{
 		NAPI_VersionListVersion_Result result;
 		CurlRequestHelper req;
+		if (ActiveSettings::GetNetworkService() == 0) {
 		req.initate(fmt::format("https://tagaya.wup.shop.nintendo.net/tagaya/versionlist/{}/{}/latest_version", NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+		}else if (ActiveSettings::GetNetworkService() == 1) {
+		req.initate(fmt::format("https://tagaya.wup.shop.pretendo.cc/tagaya/versionlist/{}/{}/latest_version", NCrypto::GetRegionAsString(authInfo.region), authInfo.country), CurlRequestHelper::SERVER_SSL_CONTEXT::TAGAYA);
+		}
+
 		if (!req.submitRequest(false))
 		{
 			cemuLog_log(LogType::Force, fmt::format("Failed to request version of update list"));

--- a/src/config/ActiveSettings.cpp
+++ b/src/config/ActiveSettings.cpp
@@ -125,10 +125,6 @@ int ActiveSettings::GetNetworkService() {
 	return GetConfig().account.active_service;
 }
 
-bool ActiveSettings::IsSSLDisabled() {
-	return GetConfig().account.disable_ssl;
-}
-
 bool ActiveSettings::DumpShadersEnabled()
 {
 	return s_dump_shaders;

--- a/src/config/ActiveSettings.cpp
+++ b/src/config/ActiveSettings.cpp
@@ -121,8 +121,8 @@ bool ActiveSettings::HasRequiredOnlineFiles()
 	return s_has_required_online_files;
 }
 
-int ActiveSettings::GetNetworkService() {
-	return GetConfig().account.active_service;
+NetworkService ActiveSettings::GetNetworkService() {
+	return static_cast<NetworkService>(GetConfig().account.active_service.GetValue());
 }
 
 bool ActiveSettings::DumpShadersEnabled()

--- a/src/config/ActiveSettings.cpp
+++ b/src/config/ActiveSettings.cpp
@@ -20,7 +20,7 @@ void ActiveSettings::LoadOnce()
 
 	g_config.SetFilename(GetPath("settings.xml").generic_wstring());
 	g_config.Load();
-
+	LaunchSettings::ChangeNetworkServiceURL(GetConfig().account.active_service);
 	std::wstring additionalErrorInfo;
 	s_has_required_online_files = iosuCrypt_checkRequirementsForOnlineMode(additionalErrorInfo) == IOS_CRYPTO_ONLINE_REQ_OK;
 }
@@ -119,6 +119,10 @@ bool ActiveSettings::IsOnlineEnabled()
 bool ActiveSettings::HasRequiredOnlineFiles()
 {
 	return s_has_required_online_files;
+}
+
+int ActiveSettings::GetNetworkService() {
+	return GetConfig().account.active_service;
 }
 
 bool ActiveSettings::DumpShadersEnabled()

--- a/src/config/ActiveSettings.cpp
+++ b/src/config/ActiveSettings.cpp
@@ -125,6 +125,10 @@ int ActiveSettings::GetNetworkService() {
 	return GetConfig().account.active_service;
 }
 
+bool ActiveSettings::IsSSLDisabled() {
+	return GetConfig().account.disable_ssl;
+}
+
 bool ActiveSettings::DumpShadersEnabled()
 {
 	return s_dump_shaders;

--- a/src/config/ActiveSettings.h
+++ b/src/config/ActiveSettings.h
@@ -93,7 +93,6 @@ public:
 	[[nodiscard]] static bool IsOnlineEnabled();
 	[[nodiscard]] static bool HasRequiredOnlineFiles();
 	[[nodiscard]] static int GetNetworkService();
-	[[nodiscard]] static bool IsSSLDisabled();
 	// dump options
 	[[nodiscard]] static bool DumpShadersEnabled();
 	[[nodiscard]] static bool DumpTexturesEnabled();

--- a/src/config/ActiveSettings.h
+++ b/src/config/ActiveSettings.h
@@ -93,6 +93,7 @@ public:
 	[[nodiscard]] static bool IsOnlineEnabled();
 	[[nodiscard]] static bool HasRequiredOnlineFiles();
 	[[nodiscard]] static int GetNetworkService();
+	[[nodiscard]] static bool IsSSLDisabled();
 	// dump options
 	[[nodiscard]] static bool DumpShadersEnabled();
 	[[nodiscard]] static bool DumpTexturesEnabled();

--- a/src/config/ActiveSettings.h
+++ b/src/config/ActiveSettings.h
@@ -92,7 +92,7 @@ public:
 	[[nodiscard]] static uint32 GetPersistentId();
 	[[nodiscard]] static bool IsOnlineEnabled();
 	[[nodiscard]] static bool HasRequiredOnlineFiles();
-
+	[[nodiscard]] static int GetNetworkService();
 	// dump options
 	[[nodiscard]] static bool DumpShadersEnabled();
 	[[nodiscard]] static bool DumpTexturesEnabled();

--- a/src/config/ActiveSettings.h
+++ b/src/config/ActiveSettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/CemuConfig.h"
+#include "config/NetworkSettings.h"
 
 // global active settings for fast access (reflects settings from command line and game profile)
 class ActiveSettings
@@ -92,7 +93,7 @@ public:
 	[[nodiscard]] static uint32 GetPersistentId();
 	[[nodiscard]] static bool IsOnlineEnabled();
 	[[nodiscard]] static bool HasRequiredOnlineFiles();
-	[[nodiscard]] static int GetNetworkService();
+	[[nodiscard]] static NetworkService GetNetworkService();
 	// dump options
 	[[nodiscard]] static bool DumpShadersEnabled();
 	[[nodiscard]] static bool DumpTexturesEnabled();

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(CemuConfig
     ConfigValue.h
     LaunchSettings.cpp
     LaunchSettings.h
+    NetworkSettings.cpp
+    NetworkSettings.h
     PermanentConfig.cpp
     PermanentConfig.h
     PermanentStorage.cpp

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -313,7 +313,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	auto acc = parser.get("Account");
 	account.m_persistent_id = acc.get("PersistentId", account.m_persistent_id);
 	account.online_enabled = acc.get("OnlineEnabled", account.online_enabled);
-
+	account.active_service = acc.get("ActiveService",account.active_service);
 	// debug
 	auto debug = parser.get("Debug");
 	crash_dump = debug.get("CrashDump", crash_dump);
@@ -484,7 +484,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	auto acc = config.set("Account");
 	acc.set("PersistentId", account.m_persistent_id.GetValue());
 	acc.set("OnlineEnabled", account.online_enabled.GetValue());
-
+	acc.set("ActiveService",account.active_service.GetValue());
 	// debug
 	auto debug = config.set("Debug");
 	debug.set("CrashDump", crash_dump.GetValue());

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -314,7 +314,6 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	account.m_persistent_id = acc.get("PersistentId", account.m_persistent_id);
 	account.online_enabled = acc.get("OnlineEnabled", account.online_enabled);
 	account.active_service = acc.get("ActiveService",account.active_service);
-	account.disable_ssl = acc.get("DisableSSLVerification",account.disable_ssl);
 	// debug
 	auto debug = parser.get("Debug");
 	crash_dump = debug.get("CrashDump", crash_dump);
@@ -486,7 +485,6 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	acc.set("PersistentId", account.m_persistent_id.GetValue());
 	acc.set("OnlineEnabled", account.online_enabled.GetValue());
 	acc.set("ActiveService",account.active_service.GetValue());
-	acc.set("DisableSSLVerification",account.disable_ssl.GetValue());
 	// debug
 	auto debug = config.set("Debug");
 	debug.set("CrashDump", crash_dump.GetValue());

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -314,6 +314,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	account.m_persistent_id = acc.get("PersistentId", account.m_persistent_id);
 	account.online_enabled = acc.get("OnlineEnabled", account.online_enabled);
 	account.active_service = acc.get("ActiveService",account.active_service);
+	account.disable_ssl = acc.get("DisableSSLVerification",account.disable_ssl);
 	// debug
 	auto debug = parser.get("Debug");
 	crash_dump = debug.get("CrashDump", crash_dump);
@@ -485,6 +486,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	acc.set("PersistentId", account.m_persistent_id.GetValue());
 	acc.set("OnlineEnabled", account.online_enabled.GetValue());
 	acc.set("ActiveService",account.active_service.GetValue());
+	acc.set("DisableSSLVerification",account.disable_ssl.GetValue());
 	// debug
 	auto debug = config.set("Debug");
 	debug.set("CrashDump", crash_dump.GetValue());

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -430,6 +430,7 @@ struct CemuConfig
 		ConfigValueBounds<uint32> m_persistent_id{ Account::kMinPersistendId, Account::kMinPersistendId, 0xFFFFFFFF };
 		ConfigValue<bool> online_enabled{false};
 		ConfigValue<int> active_service{1};
+		ConfigValue<bool> disable_ssl{false};
 	}account{};
 
 	// input

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -429,6 +429,7 @@ struct CemuConfig
 	{
 		ConfigValueBounds<uint32> m_persistent_id{ Account::kMinPersistendId, Account::kMinPersistendId, 0xFFFFFFFF };
 		ConfigValue<bool> online_enabled{false};
+		ConfigValue<int> active_service{1};
 	}account{};
 
 	// input

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -430,7 +430,6 @@ struct CemuConfig
 		ConfigValueBounds<uint32> m_persistent_id{ Account::kMinPersistendId, Account::kMinPersistendId, 0xFFFFFFFF };
 		ConfigValue<bool> online_enabled{false};
 		ConfigValue<int> active_service{0};
-		ConfigValue<bool> disable_ssl{false};
 	}account{};
 
 	// input

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -429,7 +429,7 @@ struct CemuConfig
 	{
 		ConfigValueBounds<uint32> m_persistent_id{ Account::kMinPersistendId, Account::kMinPersistendId, 0xFFFFFFFF };
 		ConfigValue<bool> online_enabled{false};
-		ConfigValue<int> active_service{1};
+		ConfigValue<int> active_service{0};
 		ConfigValue<bool> disable_ssl{false};
 	}account{};
 

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -9,6 +9,7 @@
 #include <wx/msgdlg.h>
 
 #include "config/ActiveSettings.h"
+#include "config/NetworkSettings.h"
 #include "util/crypto/aes128.h"
 
 #include "Cafe/Filesystem/FST/FST.h"
@@ -266,14 +267,24 @@ bool LaunchSettings::ExtractorTool(std::wstring_view wud_path, std::string_view 
 
 
 void LaunchSettings::ChangeNetworkServiceURL(int ID){
-	if (ID == 0){
-		//Nintendo so change URLs
+	switch (ID)
+	{
+	case Nintendo:
 		serviceURL_ACT = "https://account.nintendo.net";
 	 	serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
-	}
-	else if (ID == 1) {
-		//Pretendo so change URLs
+		break;
+	case Pretendo:
 		serviceURL_ACT = "https://account.pretendo.cc";
 	 	serviceURL_ECS = "https://ecs.wup.shop.pretendo.cc/ecs/services/ECommerceSOAP";
+		break;
+	case Custom:
+		serviceURL_ACT = GetNetworkConfig().urls.ACT.GetValue();
+	 	serviceURL_ECS = GetNetworkConfig().urls.ECS.GetValue();
+		break;
+	default:
+		serviceURL_ACT = "https://account.nintendo.net";
+	 	serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
+		break;
 	}
+
 }

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -265,3 +265,15 @@ bool LaunchSettings::ExtractorTool(std::wstring_view wud_path, std::string_view 
 }
 
 
+void LaunchSettings::ChangeNetworkServiceURL(int ID){
+	if (ID == 0){
+		//Nintendo so change URLs
+		serviceURL_ACT = "https://account.nintendo.net";
+	 	serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
+	}
+	else if (ID == 1) {
+		//Pretendo so change URLs
+		serviceURL_ACT = "https://account.pretendo.cc";
+	 	serviceURL_ECS = "https://ecs.wup.shop.pretendo.cc/ecs/services/ECommerceSOAP";
+	}
+}

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -267,23 +267,24 @@ bool LaunchSettings::ExtractorTool(std::wstring_view wud_path, std::string_view 
 
 
 void LaunchSettings::ChangeNetworkServiceURL(int ID){
-	switch (ID)
+	NetworkService Network = static_cast<NetworkService>(ID);
+	switch (Network)
 	{
-	case Nintendo:
-		serviceURL_ACT = "https://account.nintendo.net";
-	 	serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
+	case NetworkService::Nintendo:
+		serviceURL_ACT = NintendoURLs::ACTURL;
+	 	serviceURL_ECS = NintendoURLs::ECSURL;
 		break;
-	case Pretendo:
-		serviceURL_ACT = "https://account.pretendo.cc";
-	 	serviceURL_ECS = "https://ecs.wup.shop.pretendo.cc/ecs/services/ECommerceSOAP";
+	case NetworkService::Pretendo:
+		serviceURL_ACT = PretendoURLs::ACTURL;
+	 	serviceURL_ECS = PretendoURLs::ECSURL;
 		break;
-	case Custom:
+	case NetworkService::Custom:
 		serviceURL_ACT = GetNetworkConfig().urls.ACT.GetValue();
 	 	serviceURL_ECS = GetNetworkConfig().urls.ECS.GetValue();
 		break;
 	default:
-		serviceURL_ACT = "https://account.nintendo.net";
-	 	serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
+		serviceURL_ACT = NintendoURLs::ACTURL;
+	 	serviceURL_ECS = NintendoURLs::ECSURL;
 		break;
 	}
 

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -30,6 +30,7 @@ public:
 
 	static std::string GetActURLPrefix() { return serviceURL_ACT; }
 	static std::string GetServiceURL_ecs() { return serviceURL_ECS; }
+	static void ChangeNetworkServiceURL(int ID);
 
 private:
 	inline static std::optional<fs::path> s_load_game_file{};

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -47,8 +47,8 @@ private:
 	inline static std::optional<uint32> s_persistent_id{};
 
 	// service URLS
-	inline static std::string serviceURL_ACT = "https://account.nintendo.net";
-	inline static std::string serviceURL_ECS = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
+	inline static std::string serviceURL_ACT;
+	inline static std::string serviceURL_ECS;
 	// todo - npts and other boss urls
 
 

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -34,8 +34,10 @@ void NetworkConfig::Load(XMLConfigParser& parser){
 }
 bool NetworkConfig::XMLExists() {
     if (!fs::exists(GetPath("network_services.xml"))) {
-     LaunchSettings::ChangeNetworkServiceURL(0);
-     GetConfig().account.active_service = 0;
+         if (static_cast<NetworkService>(GetConfig().account.active_service.GetValue()) == NetworkService::Custom) {
+         LaunchSettings::ChangeNetworkServiceURL(0);
+         GetConfig().account.active_service = 0;
+         }
    return false;
     } else {return true;}
 }

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -1,0 +1,41 @@
+#include "NetworkSettings.h"
+#include "LaunchSettings.h"
+#include "CemuConfig.h"
+#include <boost/dll/runtime_symbol_info.hpp>
+#include "Common/FileStream.h"
+XMLNetworkConfig_t n_config(L"network_services.xml");
+
+void NetworkConfig::LoadOnce() {
+    s_full_path = boost::dll::program_location().generic_wstring();
+	s_path = s_full_path.parent_path();
+   n_config.SetFilename(GetPath("network_services.xml").generic_wstring());
+   if(XMLExists()) {
+   n_config.Load();
+   }
+}
+
+void NetworkConfig::Load(XMLConfigParser& parser){
+    auto config = parser.get("content");
+    networkname = config.get("networkname",networkname);
+    disablesslver = config.get("disablesslverification",disablesslver);
+    auto u = config.get("urls");
+    urls.ACT = u.get("act","https://account.nintendo.net");
+    urls.ECS = u.get("ecs","https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP");
+    urls.NUS = u.get("nus",NintendoURLs::NUSURL);
+    urls.IAS = u.get("ias",NintendoURLs::IASURL);
+    urls.CCSU = u.get("ccsu",NintendoURLs::CCSUURL);
+    urls.CCS = u.get("ccs",NintendoURLs::CCSURL);
+    urls.IDBE = u.get("idbe",NintendoURLs::IDBEURL);
+    urls.BOSS = u.get("boss",NintendoURLs::BOSSURL);
+    if (GetConfig().account.active_service == Custom) {
+        LaunchSettings::ChangeNetworkServiceURL(2);
+    }
+}
+bool NetworkConfig::XMLExists() {
+    FileStream* fs = FileStream::openFile(GetPath("network_services.xml").c_str());
+    if (fs == nullptr) {
+     LaunchSettings::ChangeNetworkServiceURL(0);
+     GetConfig().account.active_service = 0;
+   return false;
+    } else {return true;}
+}

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -27,7 +27,7 @@ void NetworkConfig::Load(XMLConfigParser& parser){
     urls.CCS = u.get("ccs",NintendoURLs::CCSURL);
     urls.IDBE = u.get("idbe",NintendoURLs::IDBEURL);
     urls.BOSS = u.get("boss",NintendoURLs::BOSSURL);
-    if (GetConfig().account.active_service == Custom) {
+    if (static_cast<NetworkService>(GetConfig().account.active_service.GetValue()) == NetworkService::Custom) {
         LaunchSettings::ChangeNetworkServiceURL(2);
     }
 }

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -19,14 +19,15 @@ void NetworkConfig::Load(XMLConfigParser& parser){
     networkname = config.get("networkname","[Nintendo]");
     disablesslver = config.get("disablesslverification",disablesslver);
     auto u = config.get("urls");
-    urls.ACT = u.get("act","https://account.nintendo.net");
-    urls.ECS = u.get("ecs","https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP");
+    urls.ACT = u.get("act",NintendoURLs::ACTURL);
+    urls.ECS = u.get("ecs",NintendoURLs::ECSURL);
     urls.NUS = u.get("nus",NintendoURLs::NUSURL);
     urls.IAS = u.get("ias",NintendoURLs::IASURL);
     urls.CCSU = u.get("ccsu",NintendoURLs::CCSUURL);
     urls.CCS = u.get("ccs",NintendoURLs::CCSURL);
     urls.IDBE = u.get("idbe",NintendoURLs::IDBEURL);
     urls.BOSS = u.get("boss",NintendoURLs::BOSSURL);
+    urls.TAGAYA = u.get("tagaya",NintendoURLs::TAGAYAURL);
     if (static_cast<NetworkService>(GetConfig().account.active_service.GetValue()) == NetworkService::Custom) {
         LaunchSettings::ChangeNetworkServiceURL(2);
     }

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -16,7 +16,7 @@ void NetworkConfig::LoadOnce() {
 
 void NetworkConfig::Load(XMLConfigParser& parser){
     auto config = parser.get("content");
-    networkname = config.get("networkname",networkname);
+    networkname = config.get("networkname","[Nintendo]");
     disablesslver = config.get("disablesslverification",disablesslver);
     auto u = config.get("urls");
     urls.ACT = u.get("act","https://account.nintendo.net");

--- a/src/config/NetworkSettings.cpp
+++ b/src/config/NetworkSettings.cpp
@@ -33,8 +33,7 @@ void NetworkConfig::Load(XMLConfigParser& parser){
     }
 }
 bool NetworkConfig::XMLExists() {
-    FileStream* fs = FileStream::openFile(GetPath("network_services.xml").c_str());
-    if (fs == nullptr) {
+    if (!fs::exists(GetPath("network_services.xml"))) {
      LaunchSettings::ChangeNetworkServiceURL(0);
      GetConfig().account.active_service = 0;
    return false;

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -29,6 +29,7 @@ struct NetworkConfig {
          ConfigValue<std::string> CCS;
          ConfigValue<std::string> IDBE;
          ConfigValue<std::string> BOSS;
+         ConfigValue<std::string> TAGAYA;
 	}urls{};
 
     public:
@@ -48,21 +49,27 @@ struct NetworkConfig {
 };
 
 struct NintendoURLs {
+   inline static std::string ACTURL = "https://account.nintendo.net";
+   inline static std::string ECSURL = "https://ecs.wup.shop.nintendo.net/ecs/services/ECommerceSOAP";
    inline static std::string NUSURL = "https://nus.wup.shop.nintendo.net/nus/services/NetUpdateSOAP";
    inline static std::string IASURL = "https://ias.wup.shop.nintendo.net/ias/services/IdentityAuthenticationSOAP";
    inline static std::string CCSUURL = "https://ccs.wup.shop.nintendo.net/ccs/download";
    inline static std::string CCSURL = "http://ccs.cdn.wup.shop.nintendo.net/ccs/download";
    inline static std::string IDBEURL = "https://idbe-wup.cdn.nintendo.net/icondata";
    inline static std::string BOSSURL = "https://npts.app.nintendo.net/p01/tasksheet";
+   inline static std::string TAGAYAURL = "https://tagaya.wup.shop.nintendo.net/tagaya/versionlist";
 };
 
 struct PretendoURLs {
+   inline static std::string ACTURL =  "https://account.pretendo.cc";
+   inline static std::string ECSURL = "https://ecs.wup.shop.pretendo.cc/ecs/services/ECommerceSOAP";
    inline static std::string NUSURL = "https://nus.c.shop.pretendo.cc/nus/services/NetUpdateSOAP";
    inline static std::string IASURL = "https://ias.c.shop.pretendo.cc/ias/services/IdentityAuthenticationSOAP";
    inline static std::string CCSUURL = "https://ccs.c.shop.pretendo.cc/ccs/download";
    inline static std::string CCSURL = "http://ccs.cdn.c.shop.pretendo.cc/ccs/download";
    inline static std::string IDBEURL = "https://idbe-wup.cdn.pretendo.cc/icondata";
    inline static std::string BOSSURL = "https://npts.app.pretendo.cc/p01/tasksheet";
+   inline static std::string TAGAYAURL = "https://tagaya.wup.shop.pretendo.cc/tagaya/versionlist";
 };
 
 typedef XMLDataConfig<NetworkConfig, &NetworkConfig::Load, &NetworkConfig::Save> XMLNetworkConfig_t;

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "ConfigValue.h"
+#include "XMLConfig.h"
+
+
+enum NetworkService {
+Nintendo = 0,
+Pretendo = 1,
+Custom = 2
+};
+struct NetworkConfig {
+    NetworkConfig()
+	{
+
+	};
+
+	NetworkConfig(const NetworkConfig&) = delete;
+
+    ConfigValue<std::string> networkname = "[Nintendo]";
+    ConfigValue<bool> disablesslver = false;
+    struct
+	{
+		 ConfigValue<std::string> ACT;
+		 ConfigValue<std::string> ECS;
+		 ConfigValue<std::string> NUS;
+         ConfigValue<std::string> IAS;
+         ConfigValue<std::string> CCSU;
+         ConfigValue<std::string> CCS;
+         ConfigValue<std::string> IDBE;
+         ConfigValue<std::string> BOSS;
+	}urls{};
+
+    public:
+    static void LoadOnce();
+    void Load(XMLConfigParser& parser);
+    void Save(XMLConfigParser& parser);
+    
+    inline static bool XMLExists();
+    private:
+    inline static fs::path s_path;
+    inline static fs::path s_full_path;
+    [[nodiscard]] static fs::path GetPath(std::string_view p) 
+	{
+		std::basic_string_view<char8_t> s((const char8_t*)p.data(), p.size());
+		return s_path / fs::path(s);
+	}
+};
+
+struct NintendoURLs {
+   inline static std::string NUSURL = "https://nus.wup.shop.nintendo.net/nus/services/NetUpdateSOAP";
+   inline static std::string IASURL = "https://ias.wup.shop.nintendo.net/ias/services/IdentityAuthenticationSOAP";
+   inline static std::string CCSUURL = "https://ccs.wup.shop.nintendo.net/ccs/download";
+   inline static std::string CCSURL = "http://ccs.cdn.wup.shop.nintendo.net/ccs/download";
+   inline static std::string IDBEURL = "https://idbe-wup.cdn.nintendo.net/icondata";
+   inline static std::string BOSSURL = "https://npts.app.nintendo.net/p01/tasksheet";
+};
+
+struct PretendoURLs {
+   inline static std::string NUSURL = "https://nus.c.shop.pretendo.cc/nus/services/NetUpdateSOAP";
+   inline static std::string IASURL = "https://ias.c.shop.pretendo.cc/ias/services/IdentityAuthenticationSOAP";
+   inline static std::string CCSUURL = "https://ccs.c.shop.pretendo.cc/ccs/download";
+   inline static std::string CCSURL = "http://ccs.cdn.c.shop.pretendo.cc/ccs/download";
+   inline static std::string IDBEURL = "https://idbe-wup.cdn.pretendo.cc/icondata";
+   inline static std::string BOSSURL = "https://npts.app.pretendo.cc/p01/tasksheet";
+};
+
+typedef XMLDataConfig<NetworkConfig, &NetworkConfig::Load, &NetworkConfig::Save> XMLNetworkConfig_t;
+extern XMLNetworkConfig_t n_config;
+inline NetworkConfig& GetNetworkConfig() { return n_config.data();};

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -37,7 +37,7 @@ struct NetworkConfig {
     void Load(XMLConfigParser& parser);
     void Save(XMLConfigParser& parser);
     
-    inline static bool XMLExists();
+    static bool XMLExists();
     private:
     inline static fs::path s_path;
     inline static fs::path s_full_path;

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -17,7 +17,7 @@ struct NetworkConfig {
 
 	NetworkConfig(const NetworkConfig&) = delete;
 
-    ConfigValue<std::string> networkname = "[Nintendo]";
+    ConfigValue<std::string> networkname;
     ConfigValue<bool> disablesslver = false;
     struct
 	{

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -4,10 +4,10 @@
 #include "XMLConfig.h"
 
 
-enum NetworkService {
-Nintendo = 0,
-Pretendo = 1,
-Custom = 2
+enum class NetworkService {
+Nintendo,
+Pretendo,
+Custom,
 };
 struct NetworkConfig {
     NetworkConfig()

--- a/src/config/NetworkSettings.h
+++ b/src/config/NetworkSettings.h
@@ -24,12 +24,12 @@ struct NetworkConfig {
 		 ConfigValue<std::string> ACT;
 		 ConfigValue<std::string> ECS;
 		 ConfigValue<std::string> NUS;
-         ConfigValue<std::string> IAS;
-         ConfigValue<std::string> CCSU;
-         ConfigValue<std::string> CCS;
-         ConfigValue<std::string> IDBE;
-         ConfigValue<std::string> BOSS;
-         ConfigValue<std::string> TAGAYA;
+		 ConfigValue<std::string> IAS;
+		 ConfigValue<std::string> CCSU;
+		 ConfigValue<std::string> CCS;
+		 ConfigValue<std::string> IDBE;
+		 ConfigValue<std::string> BOSS;
+		 ConfigValue<std::string> TAGAYA;
 	}urls{};
 
     public:

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -604,6 +604,11 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		content->Add(m_delete_account, 0, wxEXPAND | wxALL | wxALIGN_RIGHT, 5);
 		m_delete_account->Bind(wxEVT_BUTTON, &GeneralSettings2::OnAccountDelete, this);
 
+		const wxString choices[] = { _("Nintendo"), _("Pretendo") };
+		m_active_service=new wxRadioBox(online_panel, wxID_ANY, _("Network Service"), wxDefaultPosition, wxDefaultSize, std::size(choices), choices, 2, wxRA_SPECIFY_COLS);
+		m_active_service->SetToolTip(_("Connect to which Network Service"));
+		m_active_service->Bind(wxEVT_RADIOBOX, &GeneralSettings2::OnAccountServiceChanged,this);
+		content->Add(m_active_service, 0, wxEXPAND | wxALL, 5);
 		box_sizer->Add(content, 1, wxEXPAND, 5);
 
 		online_panel_sizer->Add(box_sizer, 0, wxEXPAND | wxALL, 5);
@@ -613,6 +618,7 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 			m_active_account->Enable(false);
 			m_create_account->Enable(false);
 			m_delete_account->Enable(false);
+			m_active_service->Enable(false);
 		}
 	}
 	
@@ -911,6 +917,7 @@ void GeneralSettings2::StoreConfig()
 		config.account.m_persistent_id = dynamic_cast<wxAccountData*>(m_active_account->GetClientObject(active_account))->GetAccount().GetPersistentId();
 
 	config.account.online_enabled = m_online_enabled->GetValue();
+	config.account.active_service = m_active_service->GetSelection();
 
 	// debug
 	config.crash_dump = (CrashDump)m_crash_dump->GetSelection();
@@ -1480,6 +1487,7 @@ void GeneralSettings2::ApplyConfig()
 	}
 	
 	m_online_enabled->SetValue(config.account.online_enabled);
+	m_active_service->SetSelection(config.account.active_service);
 	UpdateAccountInformation();
 
 	// debug
@@ -1712,6 +1720,13 @@ void GeneralSettings2::OnActiveAccountChanged(wxCommandEvent& event)
 {
 	UpdateAccountInformation();
 	m_has_account_change = true;
+}
+
+void GeneralSettings2::OnAccountServiceChanged(wxCommandEvent& event)
+{
+	LaunchSettings::ChangeNetworkServiceURL(m_active_service->GetSelection());
+
+	UpdateAccountInformation();
 }
 
 void GeneralSettings2::OnMLCPathSelect(wxCommandEvent& event)

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -609,8 +609,6 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		m_active_service->SetToolTip(_("Connect to which Network Service"));
 		m_active_service->Bind(wxEVT_RADIOBOX, &GeneralSettings2::OnAccountServiceChanged,this);
 		content->Add(m_active_service, 0, wxEXPAND | wxALL, 5);
-		m_disable_ssl = new wxCheckBox(box, wxID_ANY, _("Disable SSL Verification"));
-		box_sizer->Add(m_disable_ssl, 0, wxEXPAND | wxALL, 5);
 
 		box_sizer->Add(content, 1, wxEXPAND, 5);
 
@@ -622,7 +620,6 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 			m_create_account->Enable(false);
 			m_delete_account->Enable(false);
 			m_active_service->Enable(false);
-			m_disable_ssl->Enable(false);
 		}
 	}
 	
@@ -922,7 +919,6 @@ void GeneralSettings2::StoreConfig()
 
 	config.account.online_enabled = m_online_enabled->GetValue();
 	config.account.active_service = m_active_service->GetSelection();
-	config.account.disable_ssl = m_disable_ssl->GetValue();
 
 	// debug
 	config.crash_dump = (CrashDump)m_crash_dump->GetSelection();
@@ -1493,7 +1489,6 @@ void GeneralSettings2::ApplyConfig()
 	
 	m_online_enabled->SetValue(config.account.online_enabled);
 	m_active_service->SetSelection(config.account.active_service);
-	m_disable_ssl->SetValue(config.account.disable_ssl);
 	UpdateAccountInformation();
 
 	// debug

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -609,6 +609,9 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		m_active_service->SetToolTip(_("Connect to which Network Service"));
 		m_active_service->Bind(wxEVT_RADIOBOX, &GeneralSettings2::OnAccountServiceChanged,this);
 		content->Add(m_active_service, 0, wxEXPAND | wxALL, 5);
+		m_disable_ssl = new wxCheckBox(box, wxID_ANY, _("Disable SSL Verification"));
+		box_sizer->Add(m_disable_ssl, 0, wxEXPAND | wxALL, 5);
+
 		box_sizer->Add(content, 1, wxEXPAND, 5);
 
 		online_panel_sizer->Add(box_sizer, 0, wxEXPAND | wxALL, 5);
@@ -619,6 +622,7 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 			m_create_account->Enable(false);
 			m_delete_account->Enable(false);
 			m_active_service->Enable(false);
+			m_disable_ssl->Enable(false);
 		}
 	}
 	
@@ -918,6 +922,7 @@ void GeneralSettings2::StoreConfig()
 
 	config.account.online_enabled = m_online_enabled->GetValue();
 	config.account.active_service = m_active_service->GetSelection();
+	config.account.disable_ssl = m_disable_ssl->GetValue();
 
 	// debug
 	config.crash_dump = (CrashDump)m_crash_dump->GetSelection();
@@ -1488,6 +1493,7 @@ void GeneralSettings2::ApplyConfig()
 	
 	m_online_enabled->SetValue(config.account.online_enabled);
 	m_active_service->SetSelection(config.account.active_service);
+	m_disable_ssl->SetValue(config.account.disable_ssl);
 	UpdateAccountInformation();
 
 	// debug

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -14,6 +14,7 @@
 #include <wx/hyperlink.h>
 
 #include "config/CemuConfig.h"
+#include "config/NetworkSettings.h"
 
 #include "audio/IAudioAPI.h"
 #if BOOST_OS_WINDOWS
@@ -604,8 +605,14 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		content->Add(m_delete_account, 0, wxEXPAND | wxALL | wxALIGN_RIGHT, 5);
 		m_delete_account->Bind(wxEVT_BUTTON, &GeneralSettings2::OnAccountDelete, this);
 
-		const wxString choices[] = { _("Nintendo"), _("Pretendo") };
-		m_active_service=new wxRadioBox(online_panel, wxID_ANY, _("Network Service"), wxDefaultPosition, wxDefaultSize, std::size(choices), choices, 2, wxRA_SPECIFY_COLS);
+		if (NetworkConfig::XMLExists()) {
+			wxString choices[] = { _("Nintendo"), _("Pretendo"), _("Custom") };
+			m_active_service= new wxRadioBox(online_panel, wxID_ANY, _("Network Service"), wxDefaultPosition, wxDefaultSize, std::size(choices), choices, 3, wxRA_SPECIFY_COLS);
+		}
+		else {
+			wxString choices[] = { _("Nintendo"), _("Pretendo") };
+			m_active_service= new wxRadioBox(online_panel, wxID_ANY, _("Network Service"), wxDefaultPosition, wxDefaultSize, std::size(choices), choices, 2, wxRA_SPECIFY_COLS);
+		}
 		m_active_service->SetToolTip(_("Connect to which Network Service"));
 		m_active_service->Bind(wxEVT_RADIOBOX, &GeneralSettings2::OnAccountServiceChanged,this);
 		content->Add(m_active_service, 0, wxEXPAND | wxALL, 5);

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -65,6 +65,7 @@ private:
 	// Account
 	wxButton* m_create_account, * m_delete_account;
 	wxChoice* m_active_account;
+	wxRadioBox* m_active_service;
 	wxCheckBox* m_online_enabled;
 	wxCollapsiblePane* m_account_information;
 	wxPropertyGrid* m_account_grid;
@@ -93,6 +94,7 @@ private:
 	void OnMLCPathChar(wxKeyEvent& event);
 	void OnShowOnlineValidator(wxCommandEvent& event);
 	void OnOnlineEnable(wxCommandEvent& event);
+	void OnAccountServiceChanged(wxCommandEvent& event);
 
 	// updates cemu audio devices
 	void UpdateAudioDevice();

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -66,6 +66,7 @@ private:
 	wxButton* m_create_account, * m_delete_account;
 	wxChoice* m_active_account;
 	wxRadioBox* m_active_service;
+	wxCheckBox* m_disable_ssl;
 	wxCheckBox* m_online_enabled;
 	wxCollapsiblePane* m_account_information;
 	wxPropertyGrid* m_account_grid;

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -66,7 +66,6 @@ private:
 	wxButton* m_create_account, * m_delete_account;
 	wxChoice* m_active_account;
 	wxRadioBox* m_active_service;
-	wxCheckBox* m_disable_ssl;
 	wxCheckBox* m_online_enabled;
 	wxCollapsiblePane* m_account_information;
 	wxPropertyGrid* m_account_grid;

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -96,9 +96,15 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 	const uint64 titleId = CafeSystem::GetForegroundTitleId();
     windowText.append(fmt::format(" - FPS: {:.2f} {} {} [TitleId: {:08x}-{:08x}]", (double)fps, renderer, graphicMode, (uint32)(titleId >> 32), (uint32)(titleId & 0xFFFFFFFF)));
 
-    if (ActiveSettings::IsOnlineEnabled())
+    if (ActiveSettings::IsOnlineEnabled()){
         windowText.append(" [Online]");
-
+	if (ActiveSettings::GetNetworkService() == 0) {
+		 windowText.append("[Nintendo]");
+	}
+	else if (ActiveSettings::GetNetworkService() == 1) {
+		 windowText.append("[Pretendo]");
+	}
+	}
     windowText.append(" ");
 	windowText.append(CafeSystem::GetForegroundTitleName());
 	// append region

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -99,14 +99,14 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 
     if (ActiveSettings::IsOnlineEnabled()){
         windowText.append(" [Online]");
-	if (ActiveSettings::GetNetworkService() == Nintendo) {
+	if (ActiveSettings::GetNetworkService() == NetworkService::Nintendo) {
 		 windowText.append("[Nintendo]");
 	}
-	else if (ActiveSettings::GetNetworkService() == Pretendo) {
+	else if (ActiveSettings::GetNetworkService() == NetworkService::Pretendo) {
 		 windowText.append("[Pretendo]");
 	}
-	else if (ActiveSettings::GetNetworkService() == Custom) {
-		 windowText.append(GetNetworkConfig().networkname);
+	else if (ActiveSettings::GetNetworkService() == NetworkService::Custom) {
+		 windowText.append("[" + GetNetworkConfig().networkname.GetValue() + "]");
 	}
 	}
     windowText.append(" ");

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -5,6 +5,7 @@
 #include "gui/debugger/DebuggerWindow2.h"
 #include "Cafe/HW/Latte/Core/Latte.h"
 #include "config/ActiveSettings.h"
+#include "config/NetworkSettings.h"
 #include "config/CemuConfig.h"
 #include "Cafe/HW/Latte/Renderer/Renderer.h"
 #include "Cafe/CafeSystem.h"
@@ -98,11 +99,14 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 
     if (ActiveSettings::IsOnlineEnabled()){
         windowText.append(" [Online]");
-	if (ActiveSettings::GetNetworkService() == 0) {
+	if (ActiveSettings::GetNetworkService() == Nintendo) {
 		 windowText.append("[Nintendo]");
 	}
-	else if (ActiveSettings::GetNetworkService() == 1) {
+	else if (ActiveSettings::GetNetworkService() == Pretendo) {
 		 windowText.append("[Pretendo]");
+	}
+	else if (ActiveSettings::GetNetworkService() == Custom) {
+		 windowText.append(GetNetworkConfig().networkname);
 	}
 	}
     windowText.append(" ");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -348,6 +348,7 @@ int wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ L
 	if (!LaunchSettings::HandleCommandline(lpCmdLine))
 		return 0;
 	ActiveSettings::LoadOnce();
+	NetworkConfig::LoadOnce();
 	HandlePostUpdate();
 	return mainEmulatorHLE();
 }
@@ -375,7 +376,7 @@ int main(int argc, char *argv[])
 		return 0;
 
 	ActiveSettings::LoadOnce();
-
+	NetworkConfig::LoadOnce();
 	HandlePostUpdate();
 	return mainEmulatorHLE();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "Cafe/GameProfile/GameProfile.h"
 #include "Cafe/GraphicPack/GraphicPack2.h"
 #include "config/CemuConfig.h"
+#include "config/NetworkSettings.h"
 #include "gui/CemuApp.h"
 #include "Cafe/HW/Latte/Core/LatteOverlay.h"
 #include "config/LaunchSettings.h"
@@ -216,6 +217,8 @@ void mainEmulatorCommonInit()
     ExceptionHandler_init();
 	// read config
 	g_config.Load();
+	if (NetworkConfig::XMLExists())
+	n_config.Load();
 	// symbol storage
 	rplSymbolStorage_init();
 	// static initialization
@@ -356,6 +359,7 @@ int main(int argc, char* argv[])
 	if (!LaunchSettings::HandleCommandline(argc, argv))
 		return 0;
 	ActiveSettings::LoadOnce();
+	NetworkConfig::LoadOnce();
 	HandlePostUpdate();
 	return mainEmulatorHLE();
 }


### PR DESCRIPTION
This PR adds support for third party servers (currently Pretendo only but can be expanded later) support natively and Indication on top of which Network Service the user is using.

This also Adds an option to disable SSL Verification checkbox if third party servers do not have SSL (like Pretendo atm).