### PR TITLE
service: nfp: Fix corruption, correct structs and use write counters

### DIFF
--- a/src/Cafe/OS/libs/nn_nfp/AmiiboCrypto.h
+++ b/src/Cafe/OS/libs/nn_nfp/AmiiboCrypto.h
@@ -261,7 +261,7 @@ void amiiboEncrypt(AmiiboRawNFCData* nfcOutput)
 	amiiboCrypto_internalToNfcFormat(&internalCopy, nfcOutput);
 
 	// restore NFC values that aren't part of the internal representation
-	memcpy(nfcOutput->lockBytes, nfp_data.amiiboNFCData.lockBytes, 4);
+	memcpy(nfcOutput->dynamicLock, nfp_data.amiiboNFCData.dynamicLock, 4);
 	memcpy(nfcOutput->cfg0, nfp_data.amiiboNFCData.cfg0, 4);
 	memcpy(nfcOutput->cfg1, nfp_data.amiiboNFCData.cfg1, 4);
 }


### PR DESCRIPTION
Improves the amiibo implementation by correcting the NFC structs, fixing the corrupted bytes of `dynamic lock` and incrementing/reporting the write counters.

With this change amiibos should be compatible with yuzu. Some games that reported `different amiibo detected` after writing or deleting some data should be fixed as well.