### PR TITLE
Linux: Print demangled symbols on backtrace

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,8 @@ elseif(UNIX)
 		add_compile_options(-Wno-ambiguous-reversed-operator)
 	endif()
 
+	add_link_options(-rdynamic)
+
     add_compile_options(-Wno-multichar -Wno-invalid-offsetof -Wno-switch -Wno-ignored-attributes -Wno-deprecated-enum-enum-conversion)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,9 @@ elseif(UNIX)
 		add_compile_options(-Wno-ambiguous-reversed-operator)
 	endif()
 
-	add_link_options(-rdynamic)
+	if(NOT APPLE)
+		add_link_options(-rdynamic)
+	endif()
 
     add_compile_options(-Wno-multichar -Wno-invalid-offsetof -Wno-switch -Wno-ignored-attributes -Wno-deprecated-enum-enum-conversion)
 endif()

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
@@ -15,9 +15,15 @@ extern bool g_vulkan_available;
 #endif
 
 #ifdef VKFUNC_DEFINE
+#if BOOST_OS_WINDOWS
 	#define VKFUNC(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
 	#define VKFUNC_INSTANCE(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
 	#define VKFUNC_DEVICE(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
+#else
+	#define VKFUNC(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
+	#define VKFUNC_INSTANCE(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
+	#define VKFUNC_DEVICE(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
+#endif
 #else
 	#if defined(VKFUNC_INIT)
 		#if BOOST_OS_WINDOWS

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
@@ -15,15 +15,9 @@ extern bool g_vulkan_available;
 #endif
 
 #ifdef VKFUNC_DEFINE
-#if BOOST_OS_WINDOWS
-	#define VKFUNC(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
-	#define VKFUNC_INSTANCE(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
-	#define VKFUNC_DEVICE(__FUNC__) PFN_##__FUNC__ __FUNC__ = nullptr
-#else
-	#define VKFUNC(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
-	#define VKFUNC_INSTANCE(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
-	#define VKFUNC_DEVICE(__FUNC__) __attribute__ ((visibility ("hidden"))) PFN_##__FUNC__ __FUNC__ = nullptr
-#endif
+	#define VKFUNC(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
+	#define VKFUNC_INSTANCE(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
+	#define VKFUNC_DEVICE(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
 #else
 	#if defined(VKFUNC_INIT)
 		#if BOOST_OS_WINDOWS

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -246,6 +246,12 @@ inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, 
     #error No definition for DLLEXPORT
 #endif
 
+#if BOOST_OS_WINDOWS
+	#define NOEXPORT
+#elif defined(__GNUC__)
+	#define NOEXPORT __attribute__ ((visibility ("hidden")))
+#endif
+
 #ifdef __GNUC__
 #include <cpuid.h>
 #endif


### PR DESCRIPTION
This PR does the following:
Crash backtraces go from looking like this:
![image](https://user-images.githubusercontent.com/7033575/192906435-ac9caa1d-b484-4700-991c-c456d9f315db.png)
To looking like this:
![image](https://user-images.githubusercontent.com/7033575/192906457-b7ef383d-585c-47f9-bcec-f575eb7ee413.png)

The PR also increases the amount of lines cemu tries to retrieve because I've encountered a situation where the backtrace was incomplete.

Caveats:
- For a process to be able to get symbol information from linux's backtrace functions the linker flag `-rdynamic` needs to be enabled. This increases Release executable size by 4.4 MiB.
- Symbols are exported implicitly.
- I'm not sure the addr2line tool supports de-mangled symbol names so people using it may run into trouble. This could be a problem if a bug is hard to reproduce and all they have is a stacktrace, though AFAIK that tool requires a debug build to function anyway and I don't think it'll be common for people to find hard to reproduce bugs while using a debug build because I expect most people to play games using release builds. Of course they'll still have some indication of the general area where the crash happens.