### PR TITLE
Further workaround for pixel format issue on MacOS

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2618,15 +2618,29 @@ void VulkanRenderer::GetTextureFormatInfoVK(Latte::E_GX2SURFFMT format, bool isD
 			formatInfoOut->decoder = TextureDecoder_R5_G6_B5_swappedRB::getInstance();
 			break;
 		case Latte::E_GX2SURFFMT::R5_G5_B5_A1_UNORM:
+#if BOOST_OS_MACOS
+			// On Molten-VK, this pixel format isn't supported,
+			// replaced with generic format
+			formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_UNORM;
+			formatInfoOut->decoder = TextureDecoder_R8_G8_B8_A8::getInstance();
+#else
 			// used in Super Mario 3D World for the hidden Luigi sprites
 			// since order of channels is reversed in Vulkan compared to GX2 the format we need is A1B5G5R5
 			formatInfoOut->vkImageFormat = VK_FORMAT_A1R5G5B5_UNORM_PACK16;
 			formatInfoOut->decoder = TextureDecoder_R5_G5_B5_A1_UNORM_swappedRB::getInstance();
+#endif
 			break;
 		case Latte::E_GX2SURFFMT::A1_B5_G5_R5_UNORM:
+#if BOOST_OS_MACOS
+			// On Molten-VK, this pixel format isn't supported,
+			// replaced with generic format
+			formatInfoOut->vkImageFormat = VK_FORMAT_R8G8B8A8_UNORM;
+			formatInfoOut->decoder = TextureDecoder_R8_G8_B8_A8::getInstance();
+#else
 			// used by VC64 (e.g. Ocarina of Time)
 			formatInfoOut->vkImageFormat = VK_FORMAT_A1R5G5B5_UNORM_PACK16; // A 15 R 10..14, G 5..9 B 0..4
 			formatInfoOut->decoder = TextureDecoder_A1_B5_G5_R5_UNORM_vulkan::getInstance();
+#endif
 			break;
 		case Latte::E_GX2SURFFMT::R11_G11_B10_FLOAT:
 			formatInfoOut->vkImageFormat = VK_FORMAT_B10G11R11_UFLOAT_PACK32; // verify if order of channels is still the same as GX2


### PR DESCRIPTION
Workaround for pixel format on MacOS, VK_FORMAT_A1R5G5B5_UNORM_PACK16 not supported on Molten-VK. This fixes Super Mario 3D World, and should fix OOT on VC. I cannot test OOT as I don't own it but it should be okay.