### PR TITLE
bugfix: title manager doesn't update when clearing MLC path in settings.

### DIFF
--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -366,22 +366,28 @@ bool CemuApp::SelectMLCPath(wxWindow* parent)
 		default_path = config.mlc_path.GetValue();
 
 	// try until users selects a valid path or aborts
-	retry:
-	wxDirDialog path_dialog(parent, _("Select a mlc directory"), default_path, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
-	if (path_dialog.ShowModal() != wxID_OK || path_dialog.GetPath().empty())
-		return false;
-
-	const auto path = path_dialog.GetPath().ToStdWstring();
-	if (!TrySelectMLCPath(path))
+	while(true)
 	{
-		const auto result = wxMessageBox(_("Cemu can't write to the selected mlc path!\nDo you want to select another path?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
-		if (result == wxYES)
-			goto retry;
-		else
+		wxDirDialog path_dialog(parent, _("Select a mlc directory"), default_path, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+		if (path_dialog.ShowModal() != wxID_OK || path_dialog.GetPath().empty())
 			return false;
+
+		const auto path = path_dialog.GetPath().ToStdWstring();
+
+		if (!TrySelectMLCPath(path))
+		{
+			const auto result = wxMessageBox(
+					_("Cemu can't write to the selected mlc path!") + "\n" + _("Do you want to select another path?"),
+					_("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
+			if (result == wxYES)
+				continue;
+			break;
+		}
+
+		return true;
 	}
 
-	return true;
+	return false;
 }
 
 wxString CemuApp::GetCemuPath()

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -376,11 +376,10 @@ bool CemuApp::SelectMLCPath(wxWindow* parent)
 
 		if (!TrySelectMLCPath(path))
 		{
-			const auto result = wxMessageBox(
-					_("Cemu can't write to the selected mlc path!") + "\n" + _("Do you want to select another path?"),
-					_("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
+			const auto result = wxMessageBox(_("Cemu can't write to the selected mlc path!\nDo you want to select another path?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
 			if (result == wxYES)
 				continue;
+
 			break;
 		}
 

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -338,8 +338,11 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 }
 
 
-bool CemuApp::TrySelectMLCPath(const std::wstring& path)
+bool CemuApp::TrySelectMLCPath(std::wstring path)
 {
+	if (path.empty())
+		path = ActiveSettings::GetDefaultMLCPath().wstring();
+
 	if (!TestWriteAccess(fs::path{ path }))
 		return false;
 

--- a/src/gui/CemuApp.h
+++ b/src/gui/CemuApp.h
@@ -17,7 +17,7 @@ public:
 	static std::vector<const wxLanguageInfo*> GetAvailableLanguages();
 
 	static void CreateDefaultFiles(bool first_start = false);
-	static bool TrySelectMLCPath(const std::wstring &path);
+	static bool TrySelectMLCPath(std::wstring path);
 	static bool SelectMLCPath(wxWindow* parent = nullptr);
 
 	static wxString GetCemuPath();

--- a/src/gui/CemuApp.h
+++ b/src/gui/CemuApp.h
@@ -17,6 +17,7 @@ public:
 	static std::vector<const wxLanguageInfo*> GetAvailableLanguages();
 
 	static void CreateDefaultFiles(bool first_start = false);
+	static bool TrySelectMLCPath(const std::wstring &path);
 	static bool SelectMLCPath(wxWindow* parent = nullptr);
 
 	static wxString GetCemuPath();

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1742,8 +1742,7 @@ void GeneralSettings2::OnMLCPathChar(wxKeyEvent& event)
 		std::wstring newPath = L"";
 		if(!CemuApp::TrySelectMLCPath(newPath))
 		{
-			const auto res = wxMessageBox(_("The default MLC path is inaccessible.") + "\n"
-				+ _("Do you want to select another path?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
+			const auto res = wxMessageBox(_("The default MLC path is inaccessible.\nDo you want to select a different path?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
 			if (res == wxYES && CemuApp::SelectMLCPath(this))
 				newPath = ActiveSettings::GetMlcPath().wstring();
 			else

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1730,7 +1730,6 @@ void GeneralSettings2::OnMLCPathSelect(wxCommandEvent& event)
 	m_mlc_path->SetValue(ActiveSettings::GetMlcPath().generic_string());
 	m_reload_gamelist = true;
 	m_mlc_modified = true;
-	CemuApp::CreateDefaultFiles();
 }
 
 void GeneralSettings2::OnMLCPathChar(wxKeyEvent& event)
@@ -1740,14 +1739,16 @@ void GeneralSettings2::OnMLCPathChar(wxKeyEvent& event)
 
 	if(event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_BACK)
 	{
+		auto defaultPath = ActiveSettings::GetDefaultMLCPath().wstring();
+		if(!CemuApp::TrySelectMLCPath(defaultPath))
+		{
+			wxMessageBox(_("Cemu can't write to the default MLC path: ") + "\"" + defaultPath + "\"!\n"
+			+ _("Please pick a folder using button instead."), _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
+			return;
+		}
 		m_mlc_path->SetValue(wxEmptyString);
 		m_reload_gamelist = true;
-
-		GetConfig().mlc_path = L"";
-		g_config.Save();
 		m_mlc_modified = true;
-		
-		CemuApp::CreateDefaultFiles();
 	}
 }
 

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1739,14 +1739,17 @@ void GeneralSettings2::OnMLCPathChar(wxKeyEvent& event)
 
 	if(event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_BACK)
 	{
-		auto defaultPath = ActiveSettings::GetDefaultMLCPath().wstring();
-		if(!CemuApp::TrySelectMLCPath(defaultPath))
+		std::wstring newPath = L"";
+		if(!CemuApp::TrySelectMLCPath(newPath))
 		{
-			wxMessageBox(_("Cemu can't write to the default MLC path: ") + "\"" + defaultPath + "\"!\n"
-			+ _("Please pick a folder using button instead."), _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
-			return;
+			const auto res = wxMessageBox(_("The default MLC path is inaccessible.") + "\n"
+				+ _("Would you like to pick a different folder?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
+			if (res == wxYES && CemuApp::SelectMLCPath(this))
+				newPath = ActiveSettings::GetMlcPath().wstring();
+			else
+				return;
 		}
-		m_mlc_path->SetValue(wxEmptyString);
+		m_mlc_path->SetValue(newPath);
 		m_reload_gamelist = true;
 		m_mlc_modified = true;
 	}

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1743,7 +1743,7 @@ void GeneralSettings2::OnMLCPathChar(wxKeyEvent& event)
 		if(!CemuApp::TrySelectMLCPath(newPath))
 		{
 			const auto res = wxMessageBox(_("The default MLC path is inaccessible.") + "\n"
-				+ _("Would you like to pick a different folder?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
+				+ _("Do you want to select another path?"), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR);
 			if (res == wxYES && CemuApp::SelectMLCPath(this))
 				newPath = ActiveSettings::GetMlcPath().wstring();
 			else

--- a/src/util/helpers/helpers.cpp
+++ b/src/util/helpers/helpers.cpp
@@ -280,15 +280,16 @@ uint32_t GetPhysicalCoreCount()
 
 bool TestWriteAccess(const fs::path& p)
 {
+	std::error_code ec;
 	// must be path and must exist
-	if (!fs::exists(p) || !fs::is_directory(p))
+	if (!fs::exists(p, ec) || !fs::is_directory(p, ec))
 		return false;
 
 	// retry 3 times
 	for (int i = 0; i < 3; ++i)
 	{
 		const auto filename = p / fmt::format("_{}.tmp", GenerateRandomString(8));
-		if (fs::exists(filename))
+		if (fs::exists(filename, ec))
 			continue;
 
 		std::ofstream file(filename);
@@ -297,7 +298,6 @@ bool TestWriteAccess(const fs::path& p)
 		
 		file.close();
 
-		std::error_code ec;
 		fs::remove(filename, ec);
 		return true;
 	}


### PR DESCRIPTION
- Update title manager when you clear the mlc path in settings and show a message when it's not accessible.
- Make sure TestWriteAccess never throws an exception
- Rewrote the infinite loop in SelectMLCPath using a goto which I know might be controversial. It can be changed back if needed but I think the code makes more sense like this.