### PR TITLE
Workaround for the h264 video crash on macOS

### DIFF
--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,7 +194,7 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
-			size += alignment - (size % alignment);
+			size += ((size % alignment) == 0) ? 0 : alignment - (size % alignment);
 			return aligned_alloc(alignment, size);
 #endif
 		}

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -823,11 +823,11 @@ namespace H264
 	H264DEC_STATUS H264DECEnd(void* workMemory)
 	{
 		H264Context* ctx = (H264Context*)workMemory;
-        if (!ctx)
-        {
-            cemuLog_log(LogType::Force, "H264DECEnd(): Invalid context");
-            return H264DEC_STATUS::SUCCESS;
-        }
+		if (!ctx)
+		{
+			cemuLog_log(LogType::Force, "H264DECEnd(): Invalid context");
+			return H264DEC_STATUS::SUCCESS;
+		}
 		H264AVCDecoder* session = _AcquireDecoderSession(ctx->sessionHandle);
 		if (!session)
 		{

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,6 +194,7 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
+            size += alignment - (size%alignment);
 			return aligned_alloc(alignment, size);
 #endif
 		}
@@ -823,11 +824,6 @@ namespace H264
 	H264DEC_STATUS H264DECEnd(void* workMemory)
 	{
 		H264Context* ctx = (H264Context*)workMemory;
-		if (!ctx)
-		{
-			cemuLog_log(LogType::Force, "H264DECEnd(): Invalid context");
-			return H264DEC_STATUS::SUCCESS;
-		}
 		H264AVCDecoder* session = _AcquireDecoderSession(ctx->sessionHandle);
 		if (!session)
 		{

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,7 +194,7 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
-            size += alignment - (size%alignment);
+			size += alignment - (size % alignment);
 			return aligned_alloc(alignment, size);
 #endif
 		}

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -823,6 +823,11 @@ namespace H264
 	H264DEC_STATUS H264DECEnd(void* workMemory)
 	{
 		H264Context* ctx = (H264Context*)workMemory;
+        if (!ctx)
+        {
+            cemuLog_log(LogType::Force, "H264DECEnd(): Invalid context");
+            return H264DEC_STATUS::SUCCESS;
+        }
 		H264AVCDecoder* session = _AcquireDecoderSession(ctx->sessionHandle);
 		if (!session)
 		{


### PR DESCRIPTION
fix the underlying issue of H264DECEnd() getting passed an nullptr instead of a valid ptr. Aligned_alloc needs size to be multiple of alignment