### PR TITLE
memory optimization, using posix_memalign

### DIFF
--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,8 +194,9 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
-			size += ((size % alignment) == 0) ? 0 : alignment - (size % alignment);
-			return aligned_alloc(alignment, size);
+			void* temp;
+			posix_memalign(&temp, (size_t)alignment, (size_t)size);
+			return temp;
 #endif
 		}
 

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,18 +194,18 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
-            // alignment is atleast sizeof(void*)
+			// alignment is atleast sizeof(void*)
 			alignment = std::max<WORD32>(alignment, sizeof(void*));
 
-            //smallest multiple of 2 at least as large as alignment
-            alignment--;
-            alignment |= alignment << 1;
-            alignment |= alignment >> 1;
-            alignment |= alignment >> 2;
-            alignment |= alignment >> 4;
-            alignment |= alignment >> 8;
-            alignment |= alignment >> 16;
-            alignment ^= (alignment >> 1);
+			//smallest multiple of 2 at least as large as alignment
+			alignment--;
+			alignment |= alignment << 1;
+			alignment |= alignment >> 1;
+			alignment |= alignment >> 2;
+			alignment |= alignment >> 4;
+			alignment |= alignment >> 8;
+			alignment |= alignment >> 16;
+			alignment ^= (alignment >> 1);
 
 			void* temp;
 			posix_memalign(&temp, (size_t)alignment, (size_t)size);

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,6 +194,7 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
+			alignment = std::max<WORD32>(alignment, sizeof(void*));
 			void* temp;
 			posix_memalign(&temp, (size_t)alignment, (size_t)size);
 			return temp;

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -194,7 +194,19 @@ namespace H264
 #ifdef _WIN32
 			return _aligned_malloc(size, alignment);
 #else
+            // alignment is atleast sizeof(void*)
 			alignment = std::max<WORD32>(alignment, sizeof(void*));
+
+            //smallest multiple of 2 at least as large as alignment
+            alignment--;
+            alignment |= alignment << 1;
+            alignment |= alignment >> 1;
+            alignment |= alignment >> 2;
+            alignment |= alignment >> 4;
+            alignment |= alignment >> 8;
+            alignment |= alignment >> 16;
+            alignment ^= (alignment >> 1);
+
 			void* temp;
 			posix_memalign(&temp, (size_t)alignment, (size_t)size);
 			return temp;


### PR DESCRIPTION
replace aligned_alloc with posix_memalign, no more allocating padding bytes.

Really sorry for the multiple PRs, I found this as the last one merged. 