### PR TITLE
Linux/MacOS: Greatly improve performance

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
@@ -1005,8 +1005,67 @@ void LatteBufferCache_getStats(uint32& heapSize, uint32& allocationSize, uint32&
 }
 
 FSpinlock g_spinlockDCFlushQueue;
-std::unordered_set<uint32>* g_DCFlushQueue = new std::unordered_set<uint32>(); // queued pages
-std::unordered_set<uint32>* g_DCFlushQueueAlternate = new std::unordered_set<uint32>();
+
+class SparseBitset
+{
+	static inline constexpr size_t TABLE_MASK = 0xFF;
+
+public:
+	bool Empty() const
+	{
+		return m_numNonEmptyVectors == 0;
+	}
+
+	void Set(uint32 index)
+	{
+		auto& v = m_bits[index & TABLE_MASK];
+		if (std::find(v.cbegin(), v.cend(), index) != v.end())
+			return;
+		if (v.empty())
+		{
+			m_nonEmptyVectors[m_numNonEmptyVectors] = &v;
+			m_numNonEmptyVectors++;
+		}
+		v.emplace_back(index);
+	}
+
+	template<typename TFunc>
+	void ForAllAndClear(TFunc callbackFunc)
+	{
+		auto vCurrent = m_nonEmptyVectors + 0;
+		auto vEnd = m_nonEmptyVectors + m_numNonEmptyVectors;
+		while (vCurrent < vEnd)
+		{
+			std::vector<uint32>* vec = *vCurrent;
+			vCurrent++;
+			for (const auto& it : *vec)
+				callbackFunc(it);
+			vec->clear();
+		}
+		m_numNonEmptyVectors = 0;
+	}
+
+	void Clear()
+	{
+		auto vCurrent = m_nonEmptyVectors + 0;
+		auto vEnd = m_nonEmptyVectors + m_numNonEmptyVectors;
+		while (vCurrent < vEnd)
+		{
+			std::vector<uint32>* vec = *vCurrent;
+			vCurrent++;
+			vec->clear();
+		}
+		m_numNonEmptyVectors = 0;
+	}
+
+private:
+	std::vector<uint32> m_bits[TABLE_MASK + 1];
+	std::vector<uint32>* m_nonEmptyVectors[TABLE_MASK + 1];
+	size_t m_numNonEmptyVectors{ 0 };
+};
+
+SparseBitset* s_DCFlushQueue = new SparseBitset();
+SparseBitset* s_DCFlushQueueAlternate = new SparseBitset();
 
 void LatteBufferCache_notifyDCFlush(MPTR address, uint32 size)
 {
@@ -1017,20 +1076,18 @@ void LatteBufferCache_notifyDCFlush(MPTR address, uint32 size)
 	uint32 lastPage = (address + size - 1) / CACHE_PAGE_SIZE;
 	g_spinlockDCFlushQueue.acquire();
 	for (uint32 i = firstPage; i <= lastPage; i++)
-		g_DCFlushQueue->emplace(i);
+		s_DCFlushQueue->Set(i);
 	g_spinlockDCFlushQueue.release();
 }
 
 void LatteBufferCache_processDCFlushQueue()
 {
-	if (g_DCFlushQueue->empty()) // accessing this outside of the lock is technically undefined/unsafe behavior but on all known implementations this is fine and we can avoid the spinlock
+	if (s_DCFlushQueue->Empty()) // quick check to avoid locking if there is no work to do
 		return;
 	g_spinlockDCFlushQueue.acquire();
-	std::swap(g_DCFlushQueue, g_DCFlushQueueAlternate);
+	std::swap(s_DCFlushQueue, s_DCFlushQueueAlternate);
 	g_spinlockDCFlushQueue.release();
-	for (auto& itr : *g_DCFlushQueueAlternate)
-		LatteBufferCache_invalidatePage(itr * CACHE_PAGE_SIZE);
-	g_DCFlushQueueAlternate->clear();
+	s_DCFlushQueueAlternate->ForAllAndClear([](uint32 index) {LatteBufferCache_invalidatePage(index * CACHE_PAGE_SIZE); });
 }
 
 void LatteBufferCache_notifyDrawDone()


### PR DESCRIPTION
This PR replaces `std::unordered_set` in LatteBufferCache with a custom high-performance sparse bitset implementation.

Benchmark from my Steam Deck. Before:
![image](https://user-images.githubusercontent.com/13877693/195829084-dcc796ac-390f-4221-9c5b-c34eaa48e8b7.png)

With these new changes I get a 60% improvement in FPS:
![image](https://user-images.githubusercontent.com/13877693/195829137-c53c4a6a-8549-497a-b4f0-27c563972c7e.png)

The FPS boost will not be the same for each game as different workloads have different bottlenecks, but at least some improvement should be seen across the board. It also does not increase performance on Windows noticeably because MSVC's implementation of unordered_set already behaved in just the way we needed for good performance.

In depth technical explanation:
Seems like `std::unordered_set` cannot be blindly trusted for performance critical code. The performance characteristics differ based on which STL is used as each one comes with a different underlying algorithm. `libstdc++` seems to implement unordered_set as flat hashtable and consequentially .clear() is generally pretty expensive since it invokes `memset` on the entire table, while on MSVC it's much lower cost due to being implemented as a bucketed hashtable. Our render backend calls `.clear()` frequently so we rely on this operation being very fast.

This isn't to say that one implementation is superior over the other. It's just that we have to be careful with certain assumptions about performance for STL containers since they may not hold true on all platforms. When in doubt and high performance is of critical importance, it's better to use boost (same implementation for all platforms) or robin_hood, or any of the many other optimized container implementations.

Anyway, after benchmarking `std::unordered_set` vs `boost::unordered_set` vs `robin_hood::unordered_set` I came to the conclusion that none of them are perfectly suitable for simulating a sparse bitset of invalidated pages. I ended up writing a custom SparseBitset container that performs a bit better than the previous best case of using MSVC's `std::unordered_set`