### PR TITLE
Fixes the CRC errors

### DIFF
--- a/src/util/crypto/crc32.cpp
+++ b/src/util/crypto/crc32.cpp
@@ -322,7 +322,7 @@ unsigned int crc32_calc_slice_by_8(unsigned int previousCrc32, const void* data,
 	// process eight bytes at once (Slicing-by-8)
 	while (length >= 8)
 	{
-		if (std::endian::native == std::endian::big){
+		if constexpr (std::endian::native == std::endian::big){
 			uint32_t one = *current++ ^ swap(crc);
 			uint32_t two = *current++;
 			crc = Crc32Lookup[0][two & 0xFF] ^
@@ -334,7 +334,7 @@ unsigned int crc32_calc_slice_by_8(unsigned int previousCrc32, const void* data,
 				  Crc32Lookup[6][(one >> 16) & 0xFF] ^
 				  Crc32Lookup[7][(one >> 24) & 0xFF];
 		}
-		else if (std::endian::native == std::endian::little)
+		else if constexpr (std::endian::native == std::endian::little)
 		{
 			uint32_t one = *current++ ^ crc;
 			uint32_t two = *current++;

--- a/src/util/crypto/crc32.cpp
+++ b/src/util/crypto/crc32.cpp
@@ -322,7 +322,7 @@ unsigned int crc32_calc_slice_by_8(unsigned int previousCrc32, const void* data,
 	// process eight bytes at once (Slicing-by-8)
 	while (length >= 8)
 	{
-#if __BYTE_ORDER == __BIG_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 		uint32_t one = *current++ ^ swap(crc);
 		uint32_t two = *current++;
 		crc = Crc32Lookup[0][two & 0xFF] ^

--- a/src/util/crypto/crc32.cpp
+++ b/src/util/crypto/crc32.cpp
@@ -322,29 +322,34 @@ unsigned int crc32_calc_slice_by_8(unsigned int previousCrc32, const void* data,
 	// process eight bytes at once (Slicing-by-8)
 	while (length >= 8)
 	{
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-		uint32_t one = *current++ ^ swap(crc);
-		uint32_t two = *current++;
-		crc = Crc32Lookup[0][two & 0xFF] ^
-			Crc32Lookup[1][(two >> 8) & 0xFF] ^
-			Crc32Lookup[2][(two >> 16) & 0xFF] ^
-			Crc32Lookup[3][(two >> 24) & 0xFF] ^
-			Crc32Lookup[4][one & 0xFF] ^
-			Crc32Lookup[5][(one >> 8) & 0xFF] ^
-			Crc32Lookup[6][(one >> 16) & 0xFF] ^
-			Crc32Lookup[7][(one >> 24) & 0xFF];
-#else
-		uint32_t one = *current++ ^ crc;
-		uint32_t two = *current++;
-		crc = Crc32Lookup[0][(two >> 24) & 0xFF] ^
-			Crc32Lookup[1][(two >> 16) & 0xFF] ^
-			Crc32Lookup[2][(two >> 8) & 0xFF] ^
-			Crc32Lookup[3][two & 0xFF] ^
-			Crc32Lookup[4][(one >> 24) & 0xFF] ^
-			Crc32Lookup[5][(one >> 16) & 0xFF] ^
-			Crc32Lookup[6][(one >> 8) & 0xFF] ^
-			Crc32Lookup[7][one & 0xFF];
-#endif
+		if (std::endian::native == std::endian::big){
+			uint32_t one = *current++ ^ swap(crc);
+			uint32_t two = *current++;
+			crc = Crc32Lookup[0][two & 0xFF] ^
+				  Crc32Lookup[1][(two >> 8) & 0xFF] ^
+				  Crc32Lookup[2][(two >> 16) & 0xFF] ^
+				  Crc32Lookup[3][(two >> 24) & 0xFF] ^
+				  Crc32Lookup[4][one & 0xFF] ^
+				  Crc32Lookup[5][(one >> 8) & 0xFF] ^
+				  Crc32Lookup[6][(one >> 16) & 0xFF] ^
+				  Crc32Lookup[7][(one >> 24) & 0xFF];
+		}
+		else if (std::endian::native == std::endian::little)
+		{
+			uint32_t one = *current++ ^ crc;
+			uint32_t two = *current++;
+			crc = Crc32Lookup[0][(two >> 24) & 0xFF] ^
+				  Crc32Lookup[1][(two >> 16) & 0xFF] ^
+				  Crc32Lookup[2][(two >> 8) & 0xFF] ^
+				  Crc32Lookup[3][two & 0xFF] ^
+				  Crc32Lookup[4][(one >> 24) & 0xFF] ^
+				  Crc32Lookup[5][(one >> 16) & 0xFF] ^
+				  Crc32Lookup[6][(one >> 8) & 0xFF] ^
+				  Crc32Lookup[7][one & 0xFF];
+		}
+		else {
+			cemu_assert(false);
+		}
 
 		length -= 8;
 	}


### PR DESCRIPTION
The logs saying CRC mismatch on macOS is fixed. ~~I searched for the "\_\_BYTE\_ORDER" macro [here](https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html) but found "\_\_BYTE_ORDER\_\_"~~
Now using [std::endian](https://en.cppreference.com/w/cpp/types/endian) and handle mixed endian