### PR TITLE
Linux: Always use libpng from system

### DIFF
--- a/src/input/api/DSU/DSUMessages.cpp
+++ b/src/input/api/DSU/DSUMessages.cpp
@@ -1,6 +1,5 @@
 #include "input/api/DSU/DSUMessages.h"
-
-#include <boost/crc.hpp>
+#include "util/crypto/crc32.h"
 
 constexpr uint32_t kMagicClient = 'CUSD';
 constexpr uint32_t kMagicServer = 'SUSD';
@@ -17,15 +16,7 @@ void MessageHeader::Finalize(size_t size)
 
 uint32_t MessageHeader::CRC32(size_t size) const
 {
-	const auto tmp = m_crc32;
-	m_crc32 = 0;
-
-	boost::crc_32_type crc;
-	crc.process_bytes(this, size);
-	const auto result = crc.checksum();
-
-	m_crc32 = tmp;
-	return result;
+	return crc32_calc(this, size);
 }
 
 bool MessageHeader::IsClientMessage() const { return m_magic == kMagicClient; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,6 +234,7 @@ void ppcAsmTest();
 void gx2CopySurfaceTest();
 void ExpressionParser_test();
 void FSTVolumeTest();
+void CRCTest();
 
 void unitTests()
 {
@@ -241,6 +242,7 @@ void unitTests()
 	gx2CopySurfaceTest();
 	ppcAsmTest();
 	FSTVolumeTest();
+	CRCTest();
 }
 
 int mainEmulatorHLE()

--- a/src/util/crypto/crc32.cpp
+++ b/src/util/crypto/crc32.cpp
@@ -383,3 +383,12 @@ unsigned int crc32_calc(unsigned int c, const void* data, int length)
 	}
 	return ~c;
 }
+
+void CRCTest()
+{
+	std::vector<uint8> testData;
+	for (uint8 i = 0; i < 89; i++)
+		testData.emplace_back(i);
+	uint32 r = crc32_calc(0, testData.data(), testData.size());
+	cemu_assert(r == 0x3fc61683);
+}

--- a/src/util/crypto/crc32.h
+++ b/src/util/crypto/crc32.h
@@ -1,3 +1,8 @@
 #pragma once
 
 unsigned int crc32_calc(unsigned int c, const void* data, int length);
+
+inline unsigned int crc32_calc(const void* data, int length)
+{
+	return crc32_calc(0, data, length);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,8 +5,11 @@
   "dependencies": [
     "pugixml",
     "zlib",
-    "libpng",
 	"zstd",
+	{
+      "name": "libpng",
+      "platform": "!linux"
+    },
     {
       "name": "libzip",
       "default-features": false
@@ -23,7 +26,6 @@
     "boost-dll",
     "boost-optional",
     "boost-signals2",
-    "boost-crc",
     "boost-asio",
     "boost-ptr-container",
     "boost-property-tree",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,8 +5,8 @@
   "dependencies": [
     "pugixml",
     "zlib",
-	"zstd",
-	{
+    "zstd",
+    {
       "name": "libpng",
       "platform": "!linux"
     },


### PR DESCRIPTION
Since libpng is ubiquitous we should just link it dynamically on Linux. Solves the issues discussed in #376

I also removed the dependency on boost-crc used only in the DSU code since we already have a CRC implementation.