### PR TITLE
Remove libpng dependency from wxwidgets for linux platform.

### DIFF
--- a/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
@@ -17,7 +17,10 @@
       "platform": "!windows & !osx"
     },
     "expat",
-    "libpng",
+    {
+      "name": "libpng",
+      "platform": "!linux"
+    },
     "tiff",
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
After #381 cemu was still linking libpng statically but this fixes it.