### PR TITLE
Auto update game title name when Language is changed and fallback to English name if not available

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -68,6 +68,7 @@
 
 std::string _pathToExecutable;
 std::string _pathToBaseExecutable;
+std::string applicationName;
 
 RPLModule* applicationRPX = nullptr;
 uint32 currentBaseApplicationHash = 0;
@@ -705,7 +706,12 @@ namespace CafeSystem
 	{
 		if (sLaunchModeIsStandalone)
 			return "Unknown Game";
-		return sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(GetConfig().console_language);
+		applicationName = sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(GetConfig().console_language);
+		if (applicationName.empty())
+			applicationName = sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(CafeConsoleLanguage::EN);
+		if (applicationName.empty())
+			applicationName = "Unkown Game";
+		return applicationName;
 	}
 
 	std::string GetForegroundTitleArgStr()

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -68,7 +68,6 @@
 
 std::string _pathToExecutable;
 std::string _pathToBaseExecutable;
-std::string applicationName;
 
 RPLModule* applicationRPX = nullptr;
 uint32 currentBaseApplicationHash = 0;
@@ -706,10 +705,11 @@ namespace CafeSystem
 	{
 		if (sLaunchModeIsStandalone)
 			return "Unknown Game";
+		std::string applicationName;
 		applicationName = sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(GetConfig().console_language);
-		if (applicationName.empty())
+		if (applicationName.empty()) //Try to get the English Title
 			applicationName = sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(CafeConsoleLanguage::EN);
-		if (applicationName.empty())
+		if (applicationName.empty()) //Unknown Game
 			applicationName = "Unknown Game";
 		return applicationName;
 	}

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -710,7 +710,7 @@ namespace CafeSystem
 		if (applicationName.empty())
 			applicationName = sGameInfo_ForegroundTitle.GetBase().GetMetaInfo()->GetShortName(CafeConsoleLanguage::EN);
 		if (applicationName.empty())
-			applicationName = "Unkown Game";
+			applicationName = "Unknown Game";
 		return applicationName;
 	}
 

--- a/src/Cafe/TitleList/TitleInfo.cpp
+++ b/src/Cafe/TitleList/TitleInfo.cpp
@@ -9,8 +9,6 @@
 #include <zarchive/zarchivereader.h>
 #include "config/ActiveSettings.h"
 
-std::string titleNameCfgLanguage;
-
 // detect format by reading file header/footer
 CafeTitleFileType DetermineCafeSystemFileType(fs::path filePath)
 {
@@ -591,12 +589,15 @@ std::string TitleInfo::GetTitleName() const
 {
 	cemu_assert_debug(m_isValid);
 	if (m_parsedMetaXml)
+	{
+		std::string titleNameCfgLanguage;
 		titleNameCfgLanguage = m_parsedMetaXml->GetShortName(GetConfig().console_language);
-		if (titleNameCfgLanguage.empty())
+		if (titleNameCfgLanguage.empty()) //Get English Title
 			titleNameCfgLanguage = m_parsedMetaXml->GetShortName(CafeConsoleLanguage::EN);
-		if (titleNameCfgLanguage.empty())
-		titleNameCfgLanguage = "Unknown Title";
+		if (titleNameCfgLanguage.empty()) //Unknown Title
+			titleNameCfgLanguage = "Unknown Title";
 		return titleNameCfgLanguage;
+	}
 	if (m_cachedInfo)
 		return m_cachedInfo->titleName;
 	cemu_assert_suspicious();

--- a/src/Cafe/TitleList/TitleInfo.cpp
+++ b/src/Cafe/TitleList/TitleInfo.cpp
@@ -9,6 +9,8 @@
 #include <zarchive/zarchivereader.h>
 #include "config/ActiveSettings.h"
 
+std::string titleNameCfgLanguage;
+
 // detect format by reading file header/footer
 CafeTitleFileType DetermineCafeSystemFileType(fs::path filePath)
 {
@@ -589,7 +591,12 @@ std::string TitleInfo::GetTitleName() const
 {
 	cemu_assert_debug(m_isValid);
 	if (m_parsedMetaXml)
-		return m_parsedMetaXml->GetShortName(CafeConsoleLanguage::EN);
+		titleNameCfgLanguage = m_parsedMetaXml->GetShortName(GetConfig().console_language);
+		if (titleNameCfgLanguage.empty())
+			titleNameCfgLanguage = m_parsedMetaXml->GetShortName(CafeConsoleLanguage::EN);
+		if (titleNameCfgLanguage.empty())
+		titleNameCfgLanguage = "Unknown Title";
+		return titleNameCfgLanguage;
 	if (m_cachedInfo)
 		return m_cachedInfo->titleName;
 	cemu_assert_suspicious();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -931,6 +931,8 @@ void MainWindow::OnConsoleLanguage(wxCommandEvent& event)
 	default:
 		cemu_assert_debug(false);
 	}
+	m_game_list->DeleteCachedStrings();
+	m_game_list->ReloadGameEntries(false);
 	g_config.Save();
 }
 

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1139,3 +1139,8 @@ bool wxGameList::QueryIconForTitle(TitleId titleId, int& icon, int& iconSmall)
 	m_icon_cache_mtx.unlock();
 	return true;
 }
+
+void wxGameList::DeleteCachedStrings() 
+{
+	m_name_cache.clear();
+}

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -50,6 +50,7 @@ public:
 	bool IsVisible(long item) const; // only available in wxwidgets 3.1.3
 
 	void ReloadGameEntries(bool cached = false);
+	void DeleteCachedStrings();
 
 	long FindListItemByTitleId(uint64 title_id) const;
 	void OnClose(wxCloseEvent& event);


### PR DESCRIPTION
This PR updates the short name of the titles in the title list when the user switches language without requiring a restart to update.


This PR also updates the Window/Discord Name by having it fallback to the English Strings if there is not an available string in the selected language.