### PR TITLE
Generalised profile cleanup and corrections

### DIFF
--- a/bin/gameProfiles/default/0005000010101a00.ini
+++ b/bin/gameProfiles/default/0005000010101a00.ini
@@ -1,4 +1,1 @@
 # LEGO City Undercover (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010101a00.ini
+++ b/bin/gameProfiles/default/0005000010101a00.ini
@@ -1,7 +1,4 @@
 # LEGO City Undercover (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010101b00.ini
+++ b/bin/gameProfiles/default/0005000010101b00.ini
@@ -1,7 +1,4 @@
 # LEGO City Undercover (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010101b00.ini
+++ b/bin/gameProfiles/default/0005000010101b00.ini
@@ -1,4 +1,1 @@
 # LEGO City Undercover (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010104d00.ini
+++ b/bin/gameProfiles/default/0005000010104d00.ini
@@ -1,5 +1,4 @@
 # Monster Hunter 3(tri-)GHD Ver. (JPN)
 
 [Graphics]
-GPUBufferCacheAccuracy = 1
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010106100.ini
+++ b/bin/gameProfiles/default/0005000010106100.ini
@@ -1,7 +1,5 @@
 # Super Mario 3D World (JPN)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010106100.ini
+++ b/bin/gameProfiles/default/0005000010106100.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001010EB00.ini
+++ b/bin/gameProfiles/default/000500001010EB00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001010F900.ini
+++ b/bin/gameProfiles/default/000500001010F900.ini
@@ -1,4 +1,1 @@
 # Scribblenauts Unlimited (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010F900.ini
+++ b/bin/gameProfiles/default/000500001010F900.ini
@@ -1,7 +1,4 @@
 # Scribblenauts Unlimited (EUR)
 
-[General]
-loadSharedLibraries = true
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010ac00.ini
+++ b/bin/gameProfiles/default/000500001010ac00.ini
@@ -1,7 +1,4 @@
 # Ben 10 Omniverse (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010ac00.ini
+++ b/bin/gameProfiles/default/000500001010ac00.ini
@@ -1,4 +1,1 @@
 # Ben 10 Omniverse (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010b100.ini
+++ b/bin/gameProfiles/default/000500001010b100.ini
@@ -1,4 +1,1 @@
 # Rayman Legends (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010b200.ini
+++ b/bin/gameProfiles/default/000500001010b200.ini
@@ -1,7 +1,4 @@
 # Scribblenauts Unlimited (US)
 
-[General]
-loadSharedLibraries = true
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010b200.ini
+++ b/bin/gameProfiles/default/000500001010b200.ini
@@ -1,4 +1,1 @@
 # Scribblenauts Unlimited (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010dc00.ini
+++ b/bin/gameProfiles/default/000500001010dc00.ini
@@ -1,4 +1,1 @@
 # Mass Effect 3 Special Edition (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010dd00.ini
+++ b/bin/gameProfiles/default/000500001010dd00.ini
@@ -1,4 +1,1 @@
 # ZombiU (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010e600.ini
+++ b/bin/gameProfiles/default/000500001010e600.ini
@@ -1,4 +1,1 @@
 # 007 Legends (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010e700.ini
+++ b/bin/gameProfiles/default/000500001010e700.ini
@@ -1,7 +1,4 @@
 # Cabela's Dangerous Hunts 2013 (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010e700.ini
+++ b/bin/gameProfiles/default/000500001010e700.ini
@@ -1,4 +1,1 @@
 # Cabela's Dangerous Hunts 2013 (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010ec00.ini
+++ b/bin/gameProfiles/default/000500001010ec00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001010ed00.ini
+++ b/bin/gameProfiles/default/000500001010ed00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001010ef00.ini
+++ b/bin/gameProfiles/default/000500001010ef00.ini
@@ -1,4 +1,1 @@
 # ZombiU (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010f100.ini
+++ b/bin/gameProfiles/default/000500001010f100.ini
@@ -1,7 +1,4 @@
 # Rise of the Guardians: The Video Game (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010f100.ini
+++ b/bin/gameProfiles/default/000500001010f100.ini
@@ -1,4 +1,1 @@
 # Rise of the Guardians: The Video Game (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010f200.ini
+++ b/bin/gameProfiles/default/000500001010f200.ini
@@ -1,7 +1,4 @@
 # Rise of the Guardians: The Video Game (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010f200.ini
+++ b/bin/gameProfiles/default/000500001010f200.ini
@@ -1,4 +1,1 @@
 # Rise of the Guardians: The Video Game (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001010f500.ini
+++ b/bin/gameProfiles/default/000500001010f500.ini
@@ -1,4 +1,1 @@
 # Mass Effect 3 Special Edition (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001011000.ini
+++ b/bin/gameProfiles/default/000500001011000.ini
@@ -1,7 +1,4 @@
 # Ben 10 Omniverse (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001011000.ini
+++ b/bin/gameProfiles/default/000500001011000.ini
@@ -1,4 +1,1 @@
 # Ben 10 Omniverse (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010110100.ini
+++ b/bin/gameProfiles/default/0005000010110100.ini
@@ -1,4 +1,1 @@
 # Nano Assault Neo (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010110600.ini
+++ b/bin/gameProfiles/default/0005000010110600.ini
@@ -1,4 +1,1 @@
 # Nano Assault Neo (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010110700.ini
+++ b/bin/gameProfiles/default/0005000010110700.ini
@@ -1,4 +1,1 @@
 # 007 Legends (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010110E00.ini
+++ b/bin/gameProfiles/default/0005000010110E00.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 streamoutBufferCacheSize = 48
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010111400.ini
+++ b/bin/gameProfiles/default/0005000010111400.ini
@@ -1,4 +1,1 @@
 # Rayman Legends (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010111600.ini
+++ b/bin/gameProfiles/default/0005000010111600.ini
@@ -1,4 +1,1 @@
 # Fast And Furious Showdown (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010111600.ini
+++ b/bin/gameProfiles/default/0005000010111600.ini
@@ -1,7 +1,4 @@
 # Fast And Furious Showdown (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010112000.ini
+++ b/bin/gameProfiles/default/0005000010112000.ini
@@ -1,4 +1,1 @@
 # The Croods: Prehistoric Party! (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010112300.ini
+++ b/bin/gameProfiles/default/0005000010112300.ini
@@ -1,4 +1,1 @@
 # ZombiU (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010113000.ini
+++ b/bin/gameProfiles/default/0005000010113000.ini
@@ -1,4 +1,1 @@
 # Mass Effect 3 Special Edition (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010113300.ini
+++ b/bin/gameProfiles/default/0005000010113300.ini
@@ -1,4 +1,1 @@
 # The Smurfs 2 (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010113d00.ini
+++ b/bin/gameProfiles/default/0005000010113d00.ini
@@ -1,4 +1,1 @@
 # Rapala Pro Bass Fishing (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010115d00.ini
+++ b/bin/gameProfiles/default/0005000010115d00.ini
@@ -1,4 +1,1 @@
 # The Smurfs 2 (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010116100.ini
+++ b/bin/gameProfiles/default/0005000010116100.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010117200.ini
+++ b/bin/gameProfiles/default/0005000010117200.ini
@@ -1,5 +1,4 @@
 # Monster Hunter 3 Ultimate (EUR)
 
 [Graphics]
-GPUBufferCacheAccuracy = 1
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010118300.ini
+++ b/bin/gameProfiles/default/0005000010118300.ini
@@ -1,5 +1,4 @@
 # Monster Hunter 3 Ultimate (USA)
 
 [Graphics]
-GPUBufferCacheAccuracy = 1
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001011a600.ini
+++ b/bin/gameProfiles/default/000500001011a600.ini
@@ -1,7 +1,4 @@
 # Cabela's Dangerous Hunts 2013 (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001011a600.ini
+++ b/bin/gameProfiles/default/000500001011a600.ini
@@ -1,4 +1,1 @@
 # Cabela's Dangerous Hunts 2013 (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001011af00.ini
+++ b/bin/gameProfiles/default/000500001011af00.ini
@@ -1,4 +1,1 @@
 # BIT.TRIP Presents... Runner2: Future Legend of Rhythm Alien (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001011b200.ini
+++ b/bin/gameProfiles/default/000500001011b200.ini
@@ -1,7 +1,4 @@
 # Little Inferno (US)
 
-[CPU]
-extendedTextureReadback = true
-
 [Graphics]
-GPUBufferCacheAccuracy = 0
+extendedTextureReadback = true

--- a/bin/gameProfiles/default/0005000010128600.ini
+++ b/bin/gameProfiles/default/0005000010128600.ini
@@ -1,5 +1,4 @@
 # Little Inferno (EUR)
 
-[CPU]
+[Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010129000.ini
+++ b/bin/gameProfiles/default/0005000010129000.ini
@@ -4,5 +4,4 @@
 cpuMode = Singlecore-Recompiler
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010129200.ini
+++ b/bin/gameProfiles/default/0005000010129200.ini
@@ -4,5 +4,4 @@
 cpuMode = Singlecore-Recompiler
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001012BC00.ini
+++ b/bin/gameProfiles/default/000500001012BC00.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001012BC00.ini
+++ b/bin/gameProfiles/default/000500001012BC00.ini
@@ -1,8 +1,5 @@
 # Pikmin 3 (JPN)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001012BD00.ini
+++ b/bin/gameProfiles/default/000500001012BD00.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001012BD00.ini
+++ b/bin/gameProfiles/default/000500001012BD00.ini
@@ -1,8 +1,5 @@
 # Pikmin 3 (USA)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001012F000.ini
+++ b/bin/gameProfiles/default/000500001012F000.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/000500001012b200.ini
+++ b/bin/gameProfiles/default/000500001012b200.ini
@@ -4,6 +4,5 @@
 loadSharedLibraries = false
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 extendedTextureReadback = true
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001012ba00.ini
+++ b/bin/gameProfiles/default/000500001012ba00.ini
@@ -4,6 +4,5 @@
 loadSharedLibraries = false
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 extendedTextureReadback = true
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001012be00.ini
+++ b/bin/gameProfiles/default/000500001012be00.ini
@@ -1,7 +1,4 @@
 # Pikmin 3 (EU)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true

--- a/bin/gameProfiles/default/000500001012c500.ini
+++ b/bin/gameProfiles/default/000500001012c500.ini
@@ -1,4 +1,1 @@
 # The Croods: Prehistoric Party! (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001012da00.ini
+++ b/bin/gameProfiles/default/000500001012da00.ini
@@ -1,4 +1,1 @@
 # Fast And Furious Showdown (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001012da00.ini
+++ b/bin/gameProfiles/default/000500001012da00.ini
@@ -1,7 +1,4 @@
 # Fast And Furious Showdown (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010131F00.ini
+++ b/bin/gameProfiles/default/0005000010131F00.ini
@@ -1,4 +1,1 @@
 # Yoshi's Woolly World (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010132c00.ini
+++ b/bin/gameProfiles/default/0005000010132c00.ini
@@ -1,4 +1,1 @@
 # Scribblenauts Unmasked: A DC Comics Adventure (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010132d00.ini
+++ b/bin/gameProfiles/default/0005000010132d00.ini
@@ -1,4 +1,1 @@
 # Scribblenauts Unmasked: A DC Comics Adventure (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010133b00.ini
+++ b/bin/gameProfiles/default/0005000010133b00.ini
@@ -1,4 +1,1 @@
 # Sniper Elite V2 (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/0005000010134e00.ini
+++ b/bin/gameProfiles/default/0005000010134e00.ini
@@ -1,4 +1,1 @@
 # Sniper Elite V2 (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/0005000010135500.ini
+++ b/bin/gameProfiles/default/0005000010135500.ini
@@ -1,4 +1,1 @@
 # LEGO Batman 2: DC Super Heroes (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010135500.ini
+++ b/bin/gameProfiles/default/0005000010135500.ini
@@ -1,7 +1,4 @@
 # LEGO Batman 2: DC Super Heroes (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010135e00.ini
+++ b/bin/gameProfiles/default/0005000010135e00.ini
@@ -1,5 +1,4 @@
 # LEGO Batman 2: DC Super Heroes (USA)
 
-[General]
-loadSharedLibraries = false
+[Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010135e00.ini
+++ b/bin/gameProfiles/default/0005000010135e00.ini
@@ -1,4 +1,1 @@
 # LEGO Batman 2: DC Super Heroes (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010136300.ini
+++ b/bin/gameProfiles/default/0005000010136300.ini
@@ -1,4 +1,1 @@
 # BIT.TRIP Presents... Runner2: Future Legend of Rhythm Alien (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010136c00.ini
+++ b/bin/gameProfiles/default/0005000010136c00.ini
@@ -4,5 +4,4 @@
 cpuMode = Singlecore-Recompiler
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010137F00.ini
+++ b/bin/gameProfiles/default/0005000010137F00.ini
@@ -1,4 +1,1 @@
 # DKC: Tropical Freeze (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010137c00.ini
+++ b/bin/gameProfiles/default/0005000010137c00.ini
@@ -4,5 +4,4 @@
 cpuMode = Singlecore-Recompiler
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010138300.ini
+++ b/bin/gameProfiles/default/0005000010138300.ini
@@ -1,4 +1,1 @@
 # DKC: Tropical Freeze (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010138a00.ini
+++ b/bin/gameProfiles/default/0005000010138a00.ini
@@ -1,4 +1,1 @@
 # Angry Birds Trilogy  (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010138f00.ini
+++ b/bin/gameProfiles/default/0005000010138f00.ini
@@ -1,5 +1,4 @@
 # Devil's Third (JPN)
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010140000.ini
+++ b/bin/gameProfiles/default/0005000010140000.ini
@@ -1,4 +1,1 @@
 # Angry Birds Trilogy  (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010143200.ini
+++ b/bin/gameProfiles/default/0005000010143200.ini
@@ -1,4 +1,1 @@
 # Cabela's Big Game Hunter: Pro Hunts (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010143200.ini
+++ b/bin/gameProfiles/default/0005000010143200.ini
@@ -1,0 +1,4 @@
+# Cabela's Big Game Hunter: Pro Hunts (USA)
+
+[Graphics]
+GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010143500.ini
+++ b/bin/gameProfiles/default/0005000010143500.ini
@@ -1,4 +1,1 @@
 # TLoZ: Wind Waker HD (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010143500.ini
+++ b/bin/gameProfiles/default/0005000010143500.ini
@@ -1,6 +1,4 @@
 # TLoZ: Wind Waker HD (USA)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010143600.ini
+++ b/bin/gameProfiles/default/0005000010143600.ini
@@ -1,4 +1,1 @@
 # TLoZ: Wind Waker HD (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010143600.ini
+++ b/bin/gameProfiles/default/0005000010143600.ini
@@ -1,6 +1,4 @@
 # TLoZ: Wind Waker HD (EUR)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010144800.ini
+++ b/bin/gameProfiles/default/0005000010144800.ini
@@ -1,4 +1,1 @@
 # DKC: Tropical Freeze (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010144f00.ini
+++ b/bin/gameProfiles/default/0005000010144f00.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 streamoutBufferCacheSize = 48
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010145000.ini
+++ b/bin/gameProfiles/default/0005000010145000.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 streamoutBufferCacheSize = 48
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010145c00.ini
+++ b/bin/gameProfiles/default/0005000010145c00.ini
@@ -1,7 +1,4 @@
 # Super Mario 3D World (USA)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010145d00.ini
+++ b/bin/gameProfiles/default/0005000010145d00.ini
@@ -1,7 +1,4 @@
 # Super Mario 3D World (EUR)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010147e00.ini
+++ b/bin/gameProfiles/default/0005000010147e00.ini
@@ -1,4 +1,1 @@
 # Hello Kitty Kruisers (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001014c100.ini
+++ b/bin/gameProfiles/default/000500001014c100.ini
@@ -1,4 +1,1 @@
 # Transformers: Rise of the Dark Spark (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001014c600.ini
+++ b/bin/gameProfiles/default/000500001014c600.ini
@@ -1,4 +1,1 @@
 # Giana Sisters Twisted Dreams (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001014cb00.ini
+++ b/bin/gameProfiles/default/000500001014cb00.ini
@@ -1,4 +1,1 @@
 # Giana Sisters Twisted Dreams (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001014d900.ini
+++ b/bin/gameProfiles/default/000500001014d900.ini
@@ -1,4 +1,1 @@
 # PUYO PUYO TETRIS (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010154600.ini
+++ b/bin/gameProfiles/default/0005000010154600.ini
@@ -4,5 +4,4 @@
 cpuMode = Singlecore-Recompiler
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001015b200.ini
+++ b/bin/gameProfiles/default/000500001015b200.ini
@@ -1,4 +1,1 @@
 # Child of Light (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/0005000010161a00.ini
+++ b/bin/gameProfiles/default/0005000010161a00.ini
@@ -1,4 +1,1 @@
 # How to Train Your Dragon 2 (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010162200.ini
+++ b/bin/gameProfiles/default/0005000010162200.ini
@@ -1,4 +1,1 @@
 # Monkey Pirates (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010162a00.ini
+++ b/bin/gameProfiles/default/0005000010162a00.ini
@@ -1,4 +1,1 @@
 # How to Train Your Dragon 2 (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010162b00.ini
+++ b/bin/gameProfiles/default/0005000010162b00.ini
@@ -1,6 +1,4 @@
 # Splatoon (JPN)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010162b00.ini
+++ b/bin/gameProfiles/default/0005000010162b00.ini
@@ -1,4 +1,1 @@
 # Splatoon (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/000500001016a200.ini
+++ b/bin/gameProfiles/default/000500001016a200.ini
@@ -1,4 +1,1 @@
 # Bombing Bastards (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016ab00.ini
+++ b/bin/gameProfiles/default/000500001016ab00.ini
@@ -1,4 +1,1 @@
 # Bombing Bastards (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016b200.ini
+++ b/bin/gameProfiles/default/000500001016b200.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuTimer = cycleCounter
 cpuMode = Singlecore-Interpreter
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016d400.ini
+++ b/bin/gameProfiles/default/000500001016d400.ini
@@ -1,4 +1,1 @@
 # Stick It to the Man (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016d800.ini
+++ b/bin/gameProfiles/default/000500001016d800.ini
@@ -1,4 +1,1 @@
 # Child of Light (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016da00.ini
+++ b/bin/gameProfiles/default/000500001016da00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Interpreter
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016e000.ini
+++ b/bin/gameProfiles/default/000500001016e000.ini
@@ -1,4 +1,1 @@
 # Stick It to the Man (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016e800.ini
+++ b/bin/gameProfiles/default/000500001016e800.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuTimer = cycleCounter
 cpuMode = Singlecore-Interpreter
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001016ea00.ini
+++ b/bin/gameProfiles/default/000500001016ea00.ini
@@ -1,4 +1,1 @@
 # Child of Light (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/000500001016fc00.ini
+++ b/bin/gameProfiles/default/000500001016fc00.ini
@@ -1,5 +1,4 @@
 # Aqua Moto Racing Utopia (USA)
 
-[GPU]
-GPUBufferCacheAccuracy = 0
+[Graphics]
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010170100.ini
+++ b/bin/gameProfiles/default/0005000010170100.ini
@@ -1,4 +1,1 @@
 # Monkey Pirates (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010172900.ini
+++ b/bin/gameProfiles/default/0005000010172900.ini
@@ -1,5 +1,4 @@
 # Aqua Moto Racing Utopia (EUR)
 
-[GPU]
-GPUBufferCacheAccuracy = 0
+[Graphics]
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010173400.ini
+++ b/bin/gameProfiles/default/0005000010173400.ini
@@ -1,4 +1,1 @@
 # Transformers: Rise of the Dark Spark (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010176300.ini
+++ b/bin/gameProfiles/default/0005000010176300.ini
@@ -1,5 +1,4 @@
 # Little Inferno (JPN)
 
-[CPU]
+[Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010176900.ini
+++ b/bin/gameProfiles/default/0005000010176900.ini
@@ -1,4 +1,1 @@
 # Splatoon (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010176900.ini
+++ b/bin/gameProfiles/default/0005000010176900.ini
@@ -1,6 +1,4 @@
 # Splatoon (USA)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010176a00.ini
+++ b/bin/gameProfiles/default/0005000010176a00.ini
@@ -1,6 +1,4 @@
 # Splatoon (EUR)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010176a00.ini
+++ b/bin/gameProfiles/default/0005000010176a00.ini
@@ -1,4 +1,1 @@
 # Splatoon (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010177000.ini
+++ b/bin/gameProfiles/default/0005000010177000.ini
@@ -1,4 +1,1 @@
 # Hello Kitty Kruisers (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010177500.ini
+++ b/bin/gameProfiles/default/0005000010177500.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Interpreter
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010177600.ini
+++ b/bin/gameProfiles/default/0005000010177600.ini
@@ -1,5 +1,4 @@
 # Devil's Third (USA)
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010177700.ini
+++ b/bin/gameProfiles/default/0005000010177700.ini
@@ -1,5 +1,4 @@
 # Devil's Third (EUR)
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/000500001017da00.ini
+++ b/bin/gameProfiles/default/000500001017da00.ini
@@ -1,4 +1,1 @@
 # Costume Quest 2 (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001017e400.ini
+++ b/bin/gameProfiles/default/000500001017e400.ini
@@ -1,4 +1,1 @@
 # Chasing Dead (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010180500.ini
+++ b/bin/gameProfiles/default/0005000010180500.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010180500.ini
+++ b/bin/gameProfiles/default/0005000010180500.ini
@@ -1,7 +1,5 @@
 # Captain Toad: Treasure Tracker (JPN)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010180600.ini
+++ b/bin/gameProfiles/default/0005000010180600.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010180600.ini
+++ b/bin/gameProfiles/default/0005000010180600.ini
@@ -1,7 +1,5 @@
 # Captain Toad: Treasure Tracker (USA)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010180700.ini
+++ b/bin/gameProfiles/default/0005000010180700.ini
@@ -1,7 +1,5 @@
 # Captain Toad: Treasure Tracker (EUR)
 
-[CPU]
-
 [Graphics]
 accurateShaderMul = false
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010180700.ini
+++ b/bin/gameProfiles/default/0005000010180700.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010183000.ini
+++ b/bin/gameProfiles/default/0005000010183000.ini
@@ -1,4 +1,1 @@
 # Runbow (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010183000.ini
+++ b/bin/gameProfiles/default/0005000010183000.ini
@@ -1,7 +1,4 @@
 # Runbow (USA)
 
-
-
 [Graphics]
-
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010184900.ini
+++ b/bin/gameProfiles/default/0005000010184900.ini
@@ -1,4 +1,1 @@
 # Slender: The Arrival (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010184E00.ini
+++ b/bin/gameProfiles/default/0005000010184E00.ini
@@ -1,4 +1,1 @@
 # Yoshi's Woolly World (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010184E00.ini
+++ b/bin/gameProfiles/default/0005000010184E00.ini
@@ -1,6 +1,4 @@
 # Yoshi's Woolly World (EUR)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010184d00.ini
+++ b/bin/gameProfiles/default/0005000010184d00.ini
@@ -1,4 +1,1 @@
 # Yoshi's Woolly World (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010184d00.ini
+++ b/bin/gameProfiles/default/0005000010184d00.ini
@@ -1,6 +1,4 @@
 # Yoshi's Woolly World (USA)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010185400.ini
+++ b/bin/gameProfiles/default/0005000010185400.ini
@@ -1,4 +1,1 @@
 # TLoZ: Wind Waker HD (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010185400.ini
+++ b/bin/gameProfiles/default/0005000010185400.ini
@@ -1,6 +1,4 @@
 # TLoZ: Wind Waker HD (JPN)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000010189f00.ini
+++ b/bin/gameProfiles/default/0005000010189f00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuTimer = hostBased
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018ab00.ini
+++ b/bin/gameProfiles/default/000500001018ab00.ini
@@ -1,4 +1,1 @@
 # Affordable Space Adventures (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018d800.ini
+++ b/bin/gameProfiles/default/000500001018d800.ini
@@ -1,4 +1,1 @@
 # SteamWorld Dig (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018d900.ini
+++ b/bin/gameProfiles/default/000500001018d900.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018f100.ini
+++ b/bin/gameProfiles/default/000500001018f100.ini
@@ -1,4 +1,1 @@
 # SteamWorld Dig (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018f400.ini
+++ b/bin/gameProfiles/default/000500001018f400.ini
@@ -1,4 +1,1 @@
 # Angry Video Game Nerd Adventures (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001018fd00.ini
+++ b/bin/gameProfiles/default/000500001018fd00.ini
@@ -1,4 +1,1 @@
 # The Penguins of Madagascar (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010190300.ini
+++ b/bin/gameProfiles/default/0005000010190300.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuMode = Singlecore-Recompiler
 cpuTimer = cycleCounter
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/0005000010193f00.ini
+++ b/bin/gameProfiles/default/0005000010193f00.ini
@@ -1,4 +1,1 @@
 # The Penguins of Madagascar (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010195e00.ini
+++ b/bin/gameProfiles/default/0005000010195e00.ini
@@ -1,4 +1,1 @@
 # Rock Zombie (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010197300.ini
+++ b/bin/gameProfiles/default/0005000010197300.ini
@@ -1,4 +1,1 @@
 # Electronic Super Joy Groove City (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010197800.ini
+++ b/bin/gameProfiles/default/0005000010197800.ini
@@ -1,4 +1,1 @@
 # Costume Quest 2 (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010199e00.ini
+++ b/bin/gameProfiles/default/0005000010199e00.ini
@@ -1,4 +1,1 @@
 # High Strangeness (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019ab00.ini
+++ b/bin/gameProfiles/default/000500001019ab00.ini
@@ -1,4 +1,1 @@
 # High Strangeness (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019b000.ini
+++ b/bin/gameProfiles/default/000500001019b000.ini
@@ -1,4 +1,1 @@
 # Tachyon Project (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019b200.ini
+++ b/bin/gameProfiles/default/000500001019b200.ini
@@ -1,4 +1,1 @@
 # Tachyon Project (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019ca00.ini
+++ b/bin/gameProfiles/default/000500001019ca00.ini
@@ -1,4 +1,1 @@
 # Rock Zombie (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019e500.ini
+++ b/bin/gameProfiles/default/000500001019e500.ini
@@ -1,6 +1,4 @@
 # TLoZ: Twilight Princess (US)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019e500.ini
+++ b/bin/gameProfiles/default/000500001019e500.ini
@@ -1,4 +1,1 @@
 # TLoZ: Twilight Princess (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019e600.ini
+++ b/bin/gameProfiles/default/000500001019e600.ini
@@ -1,6 +1,4 @@
 # TLoZ: Twilight Princess (EU)
 
-[CPU]
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019e600.ini
+++ b/bin/gameProfiles/default/000500001019e600.ini
@@ -1,4 +1,1 @@
 # TLoZ: Twilight Princess (EU)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019ea00.ini
+++ b/bin/gameProfiles/default/000500001019ea00.ini
@@ -1,4 +1,1 @@
 # Zombeer (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001019ee00.ini
+++ b/bin/gameProfiles/default/000500001019ee00.ini
@@ -1,4 +1,1 @@
 # Zombie Defense (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101C9300.ini
+++ b/bin/gameProfiles/default/00050000101C9300.ini
@@ -3,4 +3,3 @@
 [Graphics]
 disableGPUFence = false
 accurateShaderMul = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/00050000101E4100.ini
+++ b/bin/gameProfiles/default/00050000101E4100.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101a1200.ini
+++ b/bin/gameProfiles/default/00050000101a1200.ini
@@ -1,5 +1,1 @@
 # Affordable Space Adventures (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0
-

--- a/bin/gameProfiles/default/00050000101a1800.ini
+++ b/bin/gameProfiles/default/00050000101a1800.ini
@@ -1,4 +1,1 @@
 # Zombie Defense (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a3b00.ini
+++ b/bin/gameProfiles/default/00050000101a3b00.ini
@@ -1,4 +1,1 @@
 # Life of Pixel (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a4300.ini
+++ b/bin/gameProfiles/default/00050000101a4300.ini
@@ -1,4 +1,1 @@
 # Beatbuddy (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a4800.ini
+++ b/bin/gameProfiles/default/00050000101a4800.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a4900.ini
+++ b/bin/gameProfiles/default/00050000101a4900.ini
@@ -1,4 +1,1 @@
 # Life of Pixel (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a7f00.ini
+++ b/bin/gameProfiles/default/00050000101a7f00.ini
@@ -1,4 +1,1 @@
 # Shiftlings (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a9c00.ini
+++ b/bin/gameProfiles/default/00050000101a9c00.ini
@@ -1,4 +1,1 @@
 # Chompy Chomp Chomp Party (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101a9e00.ini
+++ b/bin/gameProfiles/default/00050000101a9e00.ini
@@ -1,4 +1,1 @@
 # Chompy Chomp Chomp Party (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101acc00.ini
+++ b/bin/gameProfiles/default/00050000101acc00.ini
@@ -1,4 +1,1 @@
 # Shiftlings (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101b0100.ini
+++ b/bin/gameProfiles/default/00050000101b0100.ini
@@ -1,4 +1,1 @@
 # Funk of Titans (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101b4e00.ini
+++ b/bin/gameProfiles/default/00050000101b4e00.ini
@@ -1,4 +1,1 @@
 # Funk of Titans (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101b9900.ini
+++ b/bin/gameProfiles/default/00050000101b9900.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101bc300.ini
+++ b/bin/gameProfiles/default/00050000101bc300.ini
@@ -1,4 +1,1 @@
 # Beatbuddy (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c3100.ini
+++ b/bin/gameProfiles/default/00050000101c3100.ini
@@ -1,4 +1,1 @@
 # Freedom Planet (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c4200.ini
+++ b/bin/gameProfiles/default/00050000101c4200.ini
@@ -1,4 +1,1 @@
 # The Peanuts Movie: Snoopy's Grand Adventure (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c4300.ini
+++ b/bin/gameProfiles/default/00050000101c4300.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c4c00.ini
+++ b/bin/gameProfiles/default/00050000101c4c00.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/00050000101c4d00.ini
+++ b/bin/gameProfiles/default/00050000101c4d00.ini
@@ -5,4 +5,3 @@ cpuMode = Singlecore-Recompiler
 
 [Graphics]
 accurateShaderMul = false
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/00050000101c6c00.ini
+++ b/bin/gameProfiles/default/00050000101c6c00.ini
@@ -1,4 +1,1 @@
 # Typoman (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c7600.ini
+++ b/bin/gameProfiles/default/00050000101c7600.ini
@@ -1,4 +1,1 @@
 # Pumped BMX + (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c7b00.ini
+++ b/bin/gameProfiles/default/00050000101c7b00.ini
@@ -1,4 +1,1 @@
 # Chronicles of Teddy: Harmony of Exidus (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c7d00.ini
+++ b/bin/gameProfiles/default/00050000101c7d00.ini
@@ -1,4 +1,1 @@
 # Pumped BMX + (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101c9400.ini
+++ b/bin/gameProfiles/default/00050000101c9400.ini
@@ -3,4 +3,3 @@
 [Graphics]
 disableGPUFence = false
 accurateShaderMul = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/00050000101c9500.ini
+++ b/bin/gameProfiles/default/00050000101c9500.ini
@@ -3,4 +3,3 @@
 [Graphics]
 disableGPUFence = false
 accurateShaderMul = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/00050000101c9a00.ini
+++ b/bin/gameProfiles/default/00050000101c9a00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101cc900.ini
+++ b/bin/gameProfiles/default/00050000101cc900.ini
@@ -1,4 +1,1 @@
 # Freedom Planet (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ccf00.ini
+++ b/bin/gameProfiles/default/00050000101ccf00.ini
@@ -1,4 +1,1 @@
 # Never Alone (Kisima Ingitchuna) (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ce000.ini
+++ b/bin/gameProfiles/default/00050000101ce000.ini
@@ -1,4 +1,1 @@
 # Typoman (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ce800.ini
+++ b/bin/gameProfiles/default/00050000101ce800.ini
@@ -1,4 +1,1 @@
 # Never Alone (Kisima Ingitchuna) (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d2100.ini
+++ b/bin/gameProfiles/default/00050000101d2100.ini
@@ -1,5 +1,4 @@
 # Little Inferno (US)
 
-[CPU]
+[Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d4500.ini
+++ b/bin/gameProfiles/default/00050000101d4500.ini
@@ -1,4 +1,1 @@
 # Grumpy Reaper (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d4d00.ini
+++ b/bin/gameProfiles/default/00050000101d4d00.ini
@@ -1,4 +1,1 @@
 # Joe's Diner (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d5000.ini
+++ b/bin/gameProfiles/default/00050000101d5000.ini
@@ -1,4 +1,1 @@
 # The Peanuts Movie: Snoopy's Grand Adventure (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d5500.ini
+++ b/bin/gameProfiles/default/00050000101d5500.ini
@@ -1,4 +1,1 @@
 # Joe's Diner (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d6000.ini
+++ b/bin/gameProfiles/default/00050000101d6000.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuMode = Singlecore-Recompiler
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101d6d00.ini
+++ b/bin/gameProfiles/default/00050000101d6d00.ini
@@ -1,4 +1,1 @@
 # Runbow (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d6d00.ini
+++ b/bin/gameProfiles/default/00050000101d6d00.ini
@@ -1,7 +1,4 @@
 # Runbow (EUR)
 
-
-
 [Graphics]
-
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d7500.ini
+++ b/bin/gameProfiles/default/00050000101d7500.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d8900.ini
+++ b/bin/gameProfiles/default/00050000101d8900.ini
@@ -1,4 +1,1 @@
 # Slender: The Arrival (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101d8d00.ini
+++ b/bin/gameProfiles/default/00050000101d8d00.ini
@@ -1,4 +1,1 @@
 # Rock 'N Racing Off Road DX (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101d9600.ini
+++ b/bin/gameProfiles/default/00050000101d9600.ini
@@ -1,4 +1,1 @@
 # Rock 'N Racing Off Road DX (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101d9d00.ini
+++ b/bin/gameProfiles/default/00050000101d9d00.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dac00.ini
+++ b/bin/gameProfiles/default/00050000101dac00.ini
@@ -1,4 +1,1 @@
 # Swap Fire
-
-[GPU]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101daf00.ini
+++ b/bin/gameProfiles/default/00050000101daf00.ini
@@ -1,4 +1,1 @@
 # Chronicles of Teddy: Harmony of Exidus (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101db000.ini
+++ b/bin/gameProfiles/default/00050000101db000.ini
@@ -1,4 +1,1 @@
 # Oddworld New 'n' Tasty (US)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dbb00.ini
+++ b/bin/gameProfiles/default/00050000101dbb00.ini
@@ -1,4 +1,1 @@
 # Oddworld New 'n' Tasty (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dbc00.ini
+++ b/bin/gameProfiles/default/00050000101dbc00.ini
@@ -1,4 +1,1 @@
 # Star Ghost (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dbe00.ini
+++ b/bin/gameProfiles/default/00050000101dbe00.ini
@@ -2,6 +2,3 @@
 
 [General]
 loadSharedLibraries = false
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dbf00.ini
+++ b/bin/gameProfiles/default/00050000101dbf00.ini
@@ -1,4 +1,1 @@
 # Angry Video Game Nerd Adventures (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dc000.ini
+++ b/bin/gameProfiles/default/00050000101dc000.ini
@@ -1,4 +1,1 @@
 # Vektor Wars (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dc200.ini
+++ b/bin/gameProfiles/default/00050000101dc200.ini
@@ -1,4 +1,1 @@
 # Vektor Wars (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dd000.ini
+++ b/bin/gameProfiles/default/00050000101dd000.ini
@@ -1,4 +1,1 @@
 # Star Ghost (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dd600.ini
+++ b/bin/gameProfiles/default/00050000101dd600.ini
@@ -1,4 +1,1 @@
 # BIT.TRIP Presents... Runner2: Future Legend of Rhythm Alien (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dd700.ini
+++ b/bin/gameProfiles/default/00050000101dd700.ini
@@ -1,7 +1,4 @@
 # Runbow (JPN)
 
-
-
 [Graphics]
-
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101dd700.ini
+++ b/bin/gameProfiles/default/00050000101dd700.ini
@@ -1,4 +1,1 @@
 # Runbow (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ddf00.ini
+++ b/bin/gameProfiles/default/00050000101ddf00.ini
@@ -1,4 +1,1 @@
 # Hive Jump (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e0100.ini
+++ b/bin/gameProfiles/default/00050000101e0100.ini
@@ -1,6 +1,4 @@
 #  Minecraft: Story Mode (USA)
 
-
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e0100.ini
+++ b/bin/gameProfiles/default/00050000101e0100.ini
@@ -1,4 +1,1 @@
 #  Minecraft: Story Mode (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e1800.ini
+++ b/bin/gameProfiles/default/00050000101e1800.ini
@@ -1,4 +1,1 @@
 # Human Resource Machine (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e1a00.ini
+++ b/bin/gameProfiles/default/00050000101e1a00.ini
@@ -1,4 +1,1 @@
 # Human Resource Machine (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e1b00.ini
+++ b/bin/gameProfiles/default/00050000101e1b00.ini
@@ -2,6 +2,3 @@
 
 [CPU]
 cpuTimer = hostBased
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e3800.ini
+++ b/bin/gameProfiles/default/00050000101e3800.ini
@@ -1,4 +1,1 @@
 # Dual Core (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e3800.ini
+++ b/bin/gameProfiles/default/00050000101e3800.ini
@@ -1,7 +1,4 @@
 # Dual Core (USA)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e4200.ini
+++ b/bin/gameProfiles/default/00050000101e4200.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuTimer = cycleCounter
 cpuMode = Singlecore-Interpreter
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e5300.ini
+++ b/bin/gameProfiles/default/00050000101e5300.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuMode = Singlecore-Recompiler
 cpuTimer = cycleCounter
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101e5400.ini
+++ b/bin/gameProfiles/default/00050000101e5400.ini
@@ -6,6 +6,3 @@ useRDTSC = false
 [CPU]
 cpuMode = Singlecore-Recompiler
 cpuTimer = cycleCounter
-
-[Graphics]
-GPUBufferCacheAccuracy = 1

--- a/bin/gameProfiles/default/00050000101e5e00.ini
+++ b/bin/gameProfiles/default/00050000101e5e00.ini
@@ -1,4 +1,1 @@
 # Chasing Dead (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e7300.ini
+++ b/bin/gameProfiles/default/00050000101e7300.ini
@@ -1,4 +1,1 @@
 # The Deer God (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e7400.ini
+++ b/bin/gameProfiles/default/00050000101e7400.ini
@@ -1,4 +1,1 @@
 # Grumpy Reaper (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e9300.ini
+++ b/bin/gameProfiles/default/00050000101e9300.ini
@@ -1,4 +1,1 @@
 # Gear Gauntlet (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101e9400.ini
+++ b/bin/gameProfiles/default/00050000101e9400.ini
@@ -1,4 +1,1 @@
 # Gear Gauntlet (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101eb300.ini
+++ b/bin/gameProfiles/default/00050000101eb300.ini
@@ -1,4 +1,1 @@
 # The Beggar's Ride (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ec700.ini
+++ b/bin/gameProfiles/default/00050000101ec700.ini
@@ -1,4 +1,1 @@
 # The Beggar's Ride (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ecf00.ini
+++ b/bin/gameProfiles/default/00050000101ecf00.ini
@@ -1,4 +1,1 @@
 # Buddy & Me Dream Edition (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f1300.ini
+++ b/bin/gameProfiles/default/00050000101f1300.ini
@@ -1,4 +1,1 @@
 # Armikrog (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f2800.ini
+++ b/bin/gameProfiles/default/00050000101f2800.ini
@@ -1,7 +1,4 @@
 # 8Bit Hero (USA)
 
-[Graphics]
-GPUBufferCacheAccuracy = 0
-
 [CPU]
 cpuMode = Singlecore-Interpreter

--- a/bin/gameProfiles/default/00050000101f4a00.ini
+++ b/bin/gameProfiles/default/00050000101f4a00.ini
@@ -1,4 +1,1 @@
 # Buddy & Me Dream Edition (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f5700.ini
+++ b/bin/gameProfiles/default/00050000101f5700.ini
@@ -1,4 +1,1 @@
 # Jotun Valhalla Edition (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f6f00.ini
+++ b/bin/gameProfiles/default/00050000101f6f00.ini
@@ -1,4 +1,1 @@
 # Jotun Valhalla Edition (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f7600.ini
+++ b/bin/gameProfiles/default/00050000101f7600.ini
@@ -1,7 +1,4 @@
 # Dual Core (EUR)
 
-[General]
-loadSharedLibraries = false
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f7600.ini
+++ b/bin/gameProfiles/default/00050000101f7600.ini
@@ -1,4 +1,1 @@
 # Dual Core (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101f9700.ini
+++ b/bin/gameProfiles/default/00050000101f9700.ini
@@ -1,4 +1,1 @@
 # Darksiders Warmastered Edition (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101fa600.ini
+++ b/bin/gameProfiles/default/00050000101fa600.ini
@@ -1,4 +1,1 @@
 # Darksiders Warmastered Edition (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101fd100.ini
+++ b/bin/gameProfiles/default/00050000101fd100.ini
@@ -1,4 +1,1 @@
 # Grumpy Reaper (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ff200.ini
+++ b/bin/gameProfiles/default/00050000101ff200.ini
@@ -1,4 +1,1 @@
 # Exile's End (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/00050000101ffc00.ini
+++ b/bin/gameProfiles/default/00050000101ffc00.ini
@@ -1,5 +1,4 @@
 # Ghost Blade HD (USA)
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/00050000101ffe00.ini
+++ b/bin/gameProfiles/default/00050000101ffe00.ini
@@ -1,4 +1,1 @@
 # Tetrimos (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010200300.ini
+++ b/bin/gameProfiles/default/0005000010200300.ini
@@ -1,4 +1,1 @@
 # Armikrog (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010200b00.ini
+++ b/bin/gameProfiles/default/0005000010200b00.ini
@@ -1,4 +1,1 @@
 # Tetrimos (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010204a00.ini
+++ b/bin/gameProfiles/default/0005000010204a00.ini
@@ -1,4 +1,1 @@
 # Exile's End (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010207300.ini
+++ b/bin/gameProfiles/default/0005000010207300.ini
@@ -1,4 +1,1 @@
 # Koi DX (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000010207500.ini
+++ b/bin/gameProfiles/default/0005000010207500.ini
@@ -1,4 +1,1 @@
 # Koi DX (USA)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001020a200.ini
+++ b/bin/gameProfiles/default/000500001020a200.ini
@@ -1,5 +1,4 @@
 #  Minecraft: Story Mode (EUR)
 
-
 [Graphics]
 GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001020a200.ini
+++ b/bin/gameProfiles/default/000500001020a200.ini
@@ -1,4 +1,1 @@
 #  Minecraft: Story Mode (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/000500001020b600.ini
+++ b/bin/gameProfiles/default/000500001020b600.ini
@@ -1,5 +1,4 @@
 # Ghost Blade HD (EUR)
 
 [Graphics]
-GPUBufferCacheAccuracy = 0
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010211b00.ini
+++ b/bin/gameProfiles/default/0005000010211b00.ini
@@ -1,4 +1,1 @@
 # Sphere Slice (EUR)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0

--- a/bin/gameProfiles/default/0005000C1012BC00.ini
+++ b/bin/gameProfiles/default/0005000C1012BC00.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000C1012BC00.ini
+++ b/bin/gameProfiles/default/0005000C1012BC00.ini
@@ -1,8 +1,5 @@
 # Pikmin 3 (JAP)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000C1012BD00.ini
+++ b/bin/gameProfiles/default/0005000C1012BD00.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000C1012BD00.ini
+++ b/bin/gameProfiles/default/0005000C1012BD00.ini
@@ -1,8 +1,5 @@
 # Pikmin 3 (USA)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000C1012BE00.ini
+++ b/bin/gameProfiles/default/0005000C1012BE00.ini
@@ -2,4 +2,3 @@
 
 [Graphics]
 extendedTextureReadback = true
-GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000C1012BE00.ini
+++ b/bin/gameProfiles/default/0005000C1012BE00.ini
@@ -1,8 +1,5 @@
 # Pikmin 3 (EU)
 
-
-
 [Graphics]
-
 extendedTextureReadback = true
 GPUBufferCacheAccuracy = 2

--- a/bin/gameProfiles/default/0005000e1019c800.ini
+++ b/bin/gameProfiles/default/0005000e1019c800.ini
@@ -1,4 +1,1 @@
 # TLoZ: Twilight Princess (JPN)
-
-[Graphics]
-GPUBufferCacheAccuracy = 0


### PR DESCRIPTION
Restores in game audio to some games that erroneously had shared libraries turned off but required them.

Closes #384

Adds missing Cabela's Big Game Hunter: Pro Hunts profile with correct workaround set.
Removes extra lines
unused sections
added missing [Graphics] section to lego batman 2.