### PR TITLE
DSUMessages: fix bad crc calculate

### DIFF
--- a/src/input/api/DSU/DSUMessages.cpp
+++ b/src/input/api/DSU/DSUMessages.cpp
@@ -16,7 +16,14 @@ void MessageHeader::Finalize(size_t size)
 
 uint32_t MessageHeader::CRC32(size_t size) const
 {
-	return crc32_calc(this, size);
+	uint32_t tmp, tmp2;
+
+	tmp = m_crc32;
+	m_crc32 = 0;
+	tmp2 = crc32_calc(this, size);
+	m_crc32 = tmp;
+
+	return tmp2;
 }
 
 bool MessageHeader::IsClientMessage() const { return m_magic == kMagicClient; }


### PR DESCRIPTION
We need to set m_crc32 to zero before calculate crc value. m_crc32 is zero when the peer calculate crc value.

Signed-off-by: Schspa Shi <schspa@gmail.com>