### PR TITLE
Use cross platform format specifiers (fixes #387)

### DIFF
--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -11,6 +11,7 @@
 #include "util/IniParser/IniParser.h"
 #include "util/helpers/StringHelpers.h"
 #include "Cafe/CafeSystem.h"
+#include <cinttypes>
 
 std::vector<GraphicPackPtr> GraphicPack2::s_graphic_packs;
 std::vector<GraphicPackPtr> GraphicPack2::s_active_graphic_packs;
@@ -660,7 +661,7 @@ void GraphicPack2::LoadShaders()
 			uint64 shader_base_hash = 0;
 			uint64 shader_aux_hash = 0;
 			wchar_t shader_type[256]{};
-			if (filename.size() < 256 && swscanf(filename.c_str(), L"%I64x_%I64x_%ls", &shader_base_hash, &shader_aux_hash, shader_type) == 3)
+			if (filename.size() < 256 && swscanf(filename.c_str(), L"%" SCNx64 "_%" SCNx64 "_%ls", &shader_base_hash, &shader_aux_hash, shader_type) == 3)
 			{
 				if (shader_type[0] == 'p' && shader_type[1] == 's')
 					m_custom_shaders.emplace_back(LoadShader(p, shader_base_hash, shader_aux_hash, GP_SHADER_TYPE::PIXEL));

--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -13,6 +13,7 @@
 #include "util/Zir/EmitterGLSL/ZpIREmitGLSL.h"
 #include "util/Zir/Core/ZpIRDebug.h"
 #include "util/containers/flat_hash_map.hpp"
+#include <cinttypes>
 
 struct _ShaderHashCache
 {
@@ -294,7 +295,7 @@ void LatteShader_CreateRendererShader(LatteDecompilerShader* shader, bool compil
 {
 	if (shader->hasError )
 	{
-		forceLog_printf("Unable to compile shader %I64x", shader->baseHash);
+		forceLog_printf("Unable to compile shader %" PRIx64, shader->baseHash);
 		return;
 	}
 

--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -21,6 +21,8 @@
 #include "GX2_Surface_Copy.h"
 #include "GX2_Texture.h"
 
+#include <cinttypes>
+
 #define GX2_TV_RENDER_NONE			0
 #define GX2_TV_RENDER_480			1
 #define GX2_TV_RENDER_480_WIDE		2
@@ -343,7 +345,7 @@ void _GX2SubmitToTCL()
 	// update last submitted CB timestamp
 	uint64 commandBufferTimestamp = Latte_GetTime();
 	LatteGPUState.lastSubmittedCommandBufferTimestamp.store(commandBufferTimestamp);
-	gx2Log_printf("Submitting GX2 command buffer with timestamp %016I64x", commandBufferTimestamp);
+	gx2Log_printf("Submitting GX2 command buffer with timestamp %016" PRIx64, commandBufferTimestamp);
 	// submit HLE packet to write retirement timestamp
 	gx2WriteGather_submitU32AsBE(pm4HeaderType3(IT_HLE_SET_CB_RETIREMENT_TIMESTAMP, 2));
 	gx2WriteGather_submitU32AsBE((uint32)(commandBufferTimestamp>>32ULL));

--- a/src/tools/ShaderCacheMerger.cpp
+++ b/src/tools/ShaderCacheMerger.cpp
@@ -1,12 +1,13 @@
 #include "Cemu/FileCache/FileCache.h"
 #include "Cafe/HW/Latte/Core/LatteShaderCache.h"
 #include <regex>
+#include <cinttypes>
 
 void MergeShaderCacheFile(std::string fileName)
 {
 	// parse titleId from fileName
 	uint64 titleId = 0;
-	if (sscanf(fileName.c_str(), "%I64x", &titleId) != 1)
+	if (sscanf(fileName.c_str(), "%" SCNx64, &titleId) != 1)
 		return;
 
 	const std::string mainPath = "shaderCache/transferable/" + fileName;
@@ -26,7 +27,7 @@ void MergeShaderCacheFile(std::string fileName)
 		return;
 	}
 	// begin merging
-	printf("Merging shaders %I64x...", titleId);
+	printf("Merging shaders %" PRIx64 "...", titleId);
 	uint32 numMergedEntries = 0; // number of files added to the main cache file
 	for (sint32 i = 0; i < sourceCache->GetFileCount(); i++)
 	{
@@ -52,7 +53,7 @@ void MergePipelineCacheFile(std::string fileName)
 {
 	// parse titleId from fileName
 	uint64 titleId = 0;
-	if (sscanf(fileName.c_str(), "%I64x", &titleId) != 1)
+	if (sscanf(fileName.c_str(), "%" SCNx64, &titleId) != 1)
 		return;
 
 	const std::string mainPath = "shaderCache/transferable/" + fileName;
@@ -73,7 +74,7 @@ void MergePipelineCacheFile(std::string fileName)
 		return;
 	}
 	// begin merging
-	printf("Merging pipelines %I64x...", titleId);
+	printf("Merging pipelines %" PRIx64 "...", titleId);
 	uint32 numMergedEntries = 0; // number of files added to the main cache file
 	for (sint32 i = 0; i < sourceCache->GetFileCount(); i++)
 	{


### PR DESCRIPTION
Graphics pack custom shader matching fails on linux (and most likely macos) because `%I64x` is a windows specific format specifier. The solution is to use `SCNx64` instead, except in inherently platform dependent code (e.g. `src/Common/ExceptionHandler/ExceptionHandler_win32.cpp`).