### PR TITLE
FSA: Add missing path translations

### DIFF
--- a/src/Cafe/Filesystem/fsc.cpp
+++ b/src/Cafe/Filesystem/fsc.cpp
@@ -441,7 +441,7 @@ bool fsc_nextDir(FSCVirtualFile* fscFile, FSCDirEntry* dirEntry)
 /*
  * Create directory
  */
-bool fsc_createDir(char* path, sint32* fscStatus)
+bool fsc_createDir(const char* path, sint32* fscStatus)
 {
 	fscDeviceC* fscDevice = NULL;
 	*fscStatus = FSC_STATUS_UNDEFINED;
@@ -461,7 +461,7 @@ bool fsc_createDir(char* path, sint32* fscStatus)
 /*
  * Rename file or directory
  */
-bool fsc_rename(char* srcPath, char* dstPath, sint32* fscStatus)
+bool fsc_rename(const char* srcPath, const char* dstPath, sint32* fscStatus)
 {
 	std::string srcDevicePath;
 	std::string dstDevicePath;
@@ -481,7 +481,7 @@ bool fsc_rename(char* srcPath, char* dstPath, sint32* fscStatus)
 /*
  * Delete file or subdirectory
  */
-bool fsc_remove(char* path, sint32* fscStatus)
+bool fsc_remove(const char* path, sint32* fscStatus)
 {
 	std::string devicePath;
 	fscDeviceC* fscDevice = NULL;

--- a/src/Cafe/Filesystem/fsc.h
+++ b/src/Cafe/Filesystem/fsc.h
@@ -167,9 +167,9 @@ void fsc_unmountAll();
 
 FSCVirtualFile* fsc_open(const char* path, FSC_ACCESS_FLAG accessFlags, sint32* fscStatus, sint32 maxPriority=FSC_PRIORITY_MAX);
 FSCVirtualFile* fsc_openDirIterator(const char* path, sint32* fscStatus);
-bool fsc_createDir(char* path, sint32* fscStatus);
-bool fsc_rename(char* srcPath, char* dstPath, sint32* fscStatus);
-bool fsc_remove(char* path, sint32* fscStatus);
+bool fsc_createDir(const char* path, sint32* fscStatus);
+bool fsc_rename(const char* srcPath, const char* dstPath, sint32* fscStatus);
+bool fsc_remove(const char* path, sint32* fscStatus);
 bool fsc_nextDir(FSCVirtualFile* fscFile, FSCDirEntry* dirEntry);
 void fsc_close(FSCVirtualFile* fscFile);
 uint32 fsc_getFileSize(FSCVirtualFile* fscFile);

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -328,26 +328,26 @@ namespace iosu
 
 		FSStatus FSAProcessCmd_remove(FSAClient* client, FSAIpcCommand* cmd)
 		{
-			char* path = (char*)cmd->cmdRemove.path;
+			std::string path = __FSATranslatePath(client, (char*)cmd->cmdRemove.path);
 			sint32 fscStatus = FSC_STATUS_FILE_NOT_FOUND;
-			fsc_remove(path, &fscStatus);
+			fsc_remove(path.c_str(), &fscStatus);
 			return FSA_convertFSCtoFSStatus(fscStatus);
 		}
 
 		FSStatus FSAProcessCmd_makeDir(FSAClient* client, FSAIpcCommand* cmd)
 		{
-			char* path = (char*)cmd->cmdMakeDir.path;
+			std::string path = __FSATranslatePath(client, (char*)cmd->cmdMakeDir.path);
 			sint32 fscStatus = FSC_STATUS_FILE_NOT_FOUND;
-			fsc_createDir(path, &fscStatus);
+			fsc_createDir(path.c_str(), &fscStatus);
 			return FSA_convertFSCtoFSStatus(fscStatus);
 		}
 
 		FSStatus FSAProcessCmd_rename(FSAClient* client, FSAIpcCommand* cmd)
 		{
-			char* srcPath = (char*)cmd->cmdRename.srcPath;
-			char* dstPath = (char*)cmd->cmdRename.dstPath;
+			std::string srcPath = __FSATranslatePath(client, (char*)cmd->cmdRename.srcPath);
+			std::string dstPath = __FSATranslatePath(client, (char*)cmd->cmdRename.dstPath);
 			sint32 fscStatus = FSC_STATUS_FILE_NOT_FOUND;
-			fsc_rename(srcPath, dstPath, &fscStatus);
+			fsc_rename(srcPath.c_str(), dstPath.c_str(), &fscStatus);
 			return FSA_convertFSCtoFSStatus(fscStatus);
 		}
 


### PR DESCRIPTION
Translates paths for remove, makeDir and rename.
This fixes issues where the working directory was not respected for those commands.