### PR TITLE
OpenGL: Bind back buffer before clearing (fixes #222)

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -548,6 +548,9 @@ void OpenGLRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	renderstate_resetDepthControl();
 	attributeStream_reset();
 
+	// bind back buffer
+	rendertarget_bindFramebufferObject(nullptr);
+
 	if (clearBackground)
 	{
 		int windowWidth, windowHeight;
@@ -558,9 +561,6 @@ void OpenGLRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 		g_renderer->renderTarget_setViewport(0, 0, windowWidth, windowHeight, 0.0f, 1.0f);
 		g_renderer->ClearColorbuffer(padView);
 	}
-
-	// bind back buffer
-	rendertarget_bindFramebufferObject(nullptr);
 
 	// calculate effective size
 	sint32 effectiveWidth;


### PR DESCRIPTION
This fixes #222.
The back buffer is not attached when clearing, causing the previously bound framebuffer object to be cleared instead. The solution is to bind the back buffer before clearing. In the vulkan renderer it is done in the same way.