### PR TITLE
Fixes some compiler warnings

### DIFF
--- a/src/Cafe/HW/Latte/Core/Latte.h
+++ b/src/Cafe/HW/Latte/Core/Latte.h
@@ -64,8 +64,8 @@ struct LatteGPUState_t
 		{
 			bool isEnabled;
 			MPTR physPtr;
-			volatile uint32 flipRequestCount;
-			volatile uint32 flipExecuteCount;
+			std::atomic<uint32> flipRequestCount;
+			std::atomic<uint32> flipExecuteCount;
 		}screen[2];
 	}osScreen;
 };

--- a/src/Cafe/HW/Latte/Core/LatteThread.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteThread.cpp
@@ -78,7 +78,7 @@ bool LatteHandleOSScreen_TV()
 	LatteRenderTarget_copyToBackbuffer(osScreenTVTex[bufferIndexTV]->baseTexture->baseView, false);
 	
 	if (LatteGPUState.osScreen.screen[0].flipExecuteCount != LatteGPUState.osScreen.screen[0].flipRequestCount)
-		LatteGPUState.osScreen.screen[0].flipExecuteCount = LatteGPUState.osScreen.screen[0].flipRequestCount;
+		LatteGPUState.osScreen.screen[0].flipExecuteCount.store(LatteGPUState.osScreen.screen[0].flipRequestCount);
 	return true;
 }
 
@@ -101,7 +101,7 @@ bool LatteHandleOSScreen_DRC()
 	LatteRenderTarget_copyToBackbuffer(osScreenDRCTex[bufferIndexDRC]->baseTexture->baseView, true);
 
 	if (LatteGPUState.osScreen.screen[1].flipExecuteCount != LatteGPUState.osScreen.screen[1].flipRequestCount)
-		LatteGPUState.osScreen.screen[1].flipExecuteCount = LatteGPUState.osScreen.screen[1].flipRequestCount;
+		LatteGPUState.osScreen.screen[1].flipExecuteCount.store(LatteGPUState.osScreen.screen[1].flipRequestCount);
 	return true;
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -55,7 +55,7 @@ uint64 VulkanRenderer::draw_calculateGraphicsPipelineHash(const LatteFetchShader
 	// An alternative would be to use VK_EXT_vertex_input_dynamic_state but it comes with minor overhead
 	// Regardless, the extension is not well supported as of writing this (July 2021, only 10% of GPUs support it on Windows. Nvidia only)
 
-	cemu_assert_debug(fetchShader->key == fetchShader->key); // fetch shaders must be layout compatible, but may have different offsets
+	cemu_assert_debug(vertexShader->compatibleFetchShader->key == fetchShader->key); // fetch shaders must be layout compatible, but may have different offsets
 
 	uint64 stateHash;
 	stateHash = draw_calculateMinimalGraphicsPipelineHash(fetchShader, lcr);

--- a/src/audio/CubebAPI.cpp
+++ b/src/audio/CubebAPI.cpp
@@ -75,7 +75,7 @@ CubebAPI::CubebAPI(cubeb_devid devid, uint32 samplerate, uint32 channels, uint32
 		output_params.layout = CUBEB_LAYOUT_3F4_LFE;
 		break;
 	case 6:
-		output_params.layout = CUBEB_LAYOUT_QUAD_LFE | CHANNEL_FRONT_CENTER;
+		output_params.layout = CUBEB_LAYOUT_3F2_LFE_BACK;
 		break;
 	case 4:
 		output_params.layout = CUBEB_LAYOUT_QUAD;

--- a/src/gui/CemuUpdateWindow.cpp
+++ b/src/gui/CemuUpdateWindow.cpp
@@ -509,7 +509,7 @@ void CemuUpdateWindow::WorkerThread()
 						forceLog_printf("applying update error: %s", sys.what());
 					}
 
-					if ((counter++ / 10) * 10 == counter)
+					if ((counter++ % 10) == 0)
 					{
 						auto* event = new wxCommandEvent(wxEVT_PROGRESS);
 						event->SetInt(counter);

--- a/src/util/Zir/Core/IR.cpp
+++ b/src/util/Zir/Core/IR.cpp
@@ -207,11 +207,11 @@ namespace ZpIR
 		// print imports
 		printf("Imports:\n");
 		for(auto itr : block->m_imports)
-			printf("   reg: %s sym:0x%llux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
+			printf("   reg: %s sym:0x%llx\n", getRegisterName(block, itr.reg).c_str(), itr.name);
 		// print exports
 		printf("Exports:\n");
 		for (auto itr : block->m_exports)
-			printf("   reg: %s sym:0x%llux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
+			printf("   reg: %s sym:0x%llx\n", getRegisterName(block, itr.reg).c_str(), itr.name);
 		// print instructions
 		printf("Assembly:\n");
 		IR::__InsBase* instruction = block->m_instructionFirst;

--- a/src/util/Zir/Core/IR.cpp
+++ b/src/util/Zir/Core/IR.cpp
@@ -207,11 +207,11 @@ namespace ZpIR
 		// print imports
 		printf("Imports:\n");
 		for(auto itr : block->m_imports)
-			printf("   reg: %s sym:0x%lux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
+			printf("   reg: %s sym:0x%llux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
 		// print exports
 		printf("Exports:\n");
 		for (auto itr : block->m_exports)
-			printf("   reg: %s sym:0x%lux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
+			printf("   reg: %s sym:0x%llux\n", getRegisterName(block, itr.reg).c_str(), itr.name);
 		// print instructions
 		printf("Assembly:\n");
 		IR::__InsBase* instruction = block->m_instructionFirst;


### PR DESCRIPTION
replaces volatile with std::atomic
always true assert
bitwise operation on enum with equivalent builtin enum
printf format with proper unsigned long long
counter operation that always returns false