### PR TITLE
Fix fullscreen on macos

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -281,6 +281,10 @@ MainWindow::MainWindow()
 	SetClientSize(1280, 720);
 	SetIcon(wxICON(M_WND_ICON128));
 
+#if BOOST_OS_MACOS
+	this->EnableFullScreenView(true);
+#endif
+
 #if BOOST_OS_WINDOWS
 	HICON hWindowIcon = (HICON)LoadImageA(NULL, "M_WND_ICON16", IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
 	SendMessage(this->GetHWND(), WM_SETICON, ICON_SMALL, (LPARAM)hWindowIcon);
@@ -1579,7 +1583,6 @@ void MainWindow::SetFullScreen(bool state)
 	g_window_info.is_fullscreen = state;
 	m_fullscreenMenuItem->Check(state);
 
-	this->EnableFullScreenView(true);
 	this->ShowFullScreen(state);
 
 	if (state)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1579,6 +1579,7 @@ void MainWindow::SetFullScreen(bool state)
 	g_window_info.is_fullscreen = state;
 	m_fullscreenMenuItem->Check(state);
 
+	this->EnableFullScreenView(true);
 	this->ShowFullScreen(state);
 
 	if (state)


### PR DESCRIPTION
The current full screen option is broken on macOS. It disables the menu and task bar on all desktops and monitors when in focus. It is also incorrectly positioned, top portion is off screen. Rendering the menu bar unreachable.

This opts to use the native full screen option through wxWidgets, fixing the above issues. Also enables the auto hiding of the menu and task bar and getting rid of the rounded corners in full screen. This effect can already be achieved by using the full screen button on the window instead of the "alt+enter" shortcut.

I'm assuming cemu uses a borderless window mode for full screen, this usually has issues on macOS. A similar effect can be seen on firefox when using a video player's full screen as opposed to the native full screen(clicking the green button on macOS)

![Screenshot 2022-10-29 at 2 54 10 AM](https://user-images.githubusercontent.com/35825944/198820613-5c0a7f9d-388b-4192-8d36-22a40f339980.png)
![Screenshot 2022-10-29 at 2 52 01 AM](https://user-images.githubusercontent.com/35825944/198820614-74f33bca-ee14-40a5-b1b6-4ce7ab434bfc.png)
