### PR TITLE
Vulkan: Fix freeze when closing pad view.

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -658,10 +658,9 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 	}
 	else
 	{
-		m_forceStopPadUse = false;
-
 		m_padSwapchainInfo = std::make_unique<SwapChainInfo>(m_logicalDevice, surface);
 		CreateSwapChain(*m_padSwapchainInfo, size, isMainWindow);
+		m_forceStopPadUse = false;
 	}
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -34,7 +34,6 @@
 #define VK_API_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3FFU)
 
 extern std::atomic_int g_compiling_pipelines;
-extern WindowInfo g_window_info;
 
 const  std::vector<const char*> kOptionalDeviceExtensions =
 {

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -661,7 +661,6 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 	{
 		m_isPadWindowOpen = true;
 		m_usingPadFrameSurface.acquire();
-		std::cout << "renderer acquired" << std::endl;
 		m_padSwapchainInfo = std::make_unique<SwapChainInfo>(m_logicalDevice, surface);
 		CreateSwapChain(*m_padSwapchainInfo, size, isMainWindow);
 	}
@@ -670,7 +669,6 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 void VulkanRenderer::ClosePadWindow()
 {
 	m_isPadWindowOpen = false;
-	std::cout << "Pad closing and getting semaphore" << std::endl;
 	m_usingPadFrameSurface.acquire();
 	m_usingPadFrameSurface.release();
 }
@@ -1523,9 +1521,7 @@ bool VulkanRenderer::IsSwapchainInfoValid(bool mainWindow)
 
 	if(valid && !m_isPadWindowOpen)
 	{
-		std::cout << "Validity check occurred with closed window destroying swapchain" << std::endl;
 		m_padSwapchainInfo.reset();
-		std::cout << "Renderer releasing semaphore" << std::endl;
 		m_usingPadFrameSurface.release();
 		return false;
 	}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -658,7 +658,6 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 	}
 	else
 	{
-		m_padCloseReadySemaphore = nullptr;
 		m_forceStopPadUse = false;
 
 		m_padSwapchainInfo = std::make_unique<SwapChainInfo>(m_logicalDevice, surface);
@@ -1515,8 +1514,8 @@ bool VulkanRenderer::IsSwapchainInfoValid(bool mainWindow) const
 	if (mainWindow)
 		return m_mainSwapchainInfo && m_mainSwapchainInfo->swapChain && m_mainSwapchainInfo->m_imageAvailableFence;
 
-	if(m_padCloseReadySemaphore)
-		m_padCloseReadySemaphore->notify();
+	if(auto semaphore = m_padCloseReadySemaphore.lock())
+		semaphore->notify();
 	return m_padSwapchainInfo && m_padSwapchainInfo->swapChain && m_padSwapchainInfo->m_imageAvailableFence && !m_forceStopPadUse;
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -659,7 +659,7 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 	}
 	else
 	{
-		m_isPadWindowOpen = true;
+		m_padCanvasDestroying = false;
 		m_usingPadFrameSurface.acquire();
 		m_padSwapchainInfo = std::make_unique<SwapChainInfo>(m_logicalDevice, surface);
 		CreateSwapChain(*m_padSwapchainInfo, size, isMainWindow);
@@ -668,7 +668,7 @@ void VulkanRenderer::Initialize(const Vector2i& size, bool isMainWindow)
 
 void VulkanRenderer::ClosePadWindow()
 {
-	m_isPadWindowOpen = false;
+	m_padCanvasDestroying = true;
 	m_usingPadFrameSurface.acquire();
 	m_usingPadFrameSurface.release();
 }
@@ -1519,7 +1519,7 @@ bool VulkanRenderer::IsSwapchainInfoValid(bool mainWindow)
 
 	bool valid = m_padSwapchainInfo && m_padSwapchainInfo->swapChain && m_padSwapchainInfo->m_imageAvailableFence;
 
-	if(valid && !m_isPadWindowOpen)
+	if(valid && m_padCanvasDestroying)
 	{
 		m_padSwapchainInfo.reset();
 		m_usingPadFrameSurface.release();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -187,6 +187,7 @@ public:
 	void DetermineVendor();
 	void Initialize(const Vector2i& size, bool isMainWindow);
 
+	void ClosePadWindow();
 	bool IsPadWindowActive() override;
 
 	void HandleScreenshotRequest(LatteTextureView* texView, bool padView) override;
@@ -485,7 +486,9 @@ private:
 		VkRenderPass m_imguiRenderPass = nullptr;
 	};
 	std::unique_ptr<SwapChainInfo> m_mainSwapchainInfo{}, m_padSwapchainInfo{};
-	bool IsSwapchainInfoValid(bool mainWindow) const;
+	bool m_isPadWindowOpen = false;
+	std::binary_semaphore m_usingPadFrameSurface{1};
+	bool IsSwapchainInfoValid(bool mainWindow);
 	VkSwapchainKHR CreateSwapChain(SwapChainInfo& swap_chain_info, const Vector2i& size, bool mainwindow);
 
 	struct

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -486,7 +486,7 @@ private:
 		VkRenderPass m_imguiRenderPass = nullptr;
 	};
 	std::unique_ptr<SwapChainInfo> m_mainSwapchainInfo{}, m_padSwapchainInfo{};
-	std::shared_ptr<Semaphore> m_padCloseReadySemaphore;
+	std::weak_ptr<Semaphore> m_padCloseReadySemaphore;
 	bool m_forceStopPadUse = false;
 	bool IsSwapchainInfoValid(bool mainWindow) const;
 	VkSwapchainKHR CreateSwapChain(SwapChainInfo& swap_chain_info, const Vector2i& size, bool mainwindow);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -187,7 +187,7 @@ public:
 	void DetermineVendor();
 	void Initialize(const Vector2i& size, bool isMainWindow);
 
-	void ClosePadWindow();
+	void ClosePadWindow(const std::shared_ptr<Semaphore>& readySemaphore);
 	bool IsPadWindowActive() override;
 
 	void HandleScreenshotRequest(LatteTextureView* texView, bool padView) override;
@@ -486,9 +486,9 @@ private:
 		VkRenderPass m_imguiRenderPass = nullptr;
 	};
 	std::unique_ptr<SwapChainInfo> m_mainSwapchainInfo{}, m_padSwapchainInfo{};
-	bool m_padCanvasDestroying = false;
-	std::binary_semaphore m_usingPadFrameSurface{1};
-	bool IsSwapchainInfoValid(bool mainWindow);
+	std::shared_ptr<Semaphore> m_padCloseReadySemaphore;
+	bool m_forceStopPadUse = false;
+	bool IsSwapchainInfoValid(bool mainWindow) const;
 	VkSwapchainKHR CreateSwapChain(SwapChainInfo& swap_chain_info, const Vector2i& size, bool mainwindow);
 
 	struct

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -486,7 +486,7 @@ private:
 		VkRenderPass m_imguiRenderPass = nullptr;
 	};
 	std::unique_ptr<SwapChainInfo> m_mainSwapchainInfo{}, m_padSwapchainInfo{};
-	bool m_isPadWindowOpen = false;
+	bool m_padCanvasDestroying = false;
 	std::binary_semaphore m_usingPadFrameSurface{1};
 	bool IsSwapchainInfoValid(bool mainWindow);
 	VkSwapchainKHR CreateSwapChain(SwapChainInfo& swap_chain_info, const Vector2i& size, bool mainwindow);

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -15,6 +15,9 @@ VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_wi
 	else
 		gui_initHandleContextFromWxWidgetsWindow(gui_getWindowInfo().canvas_pad, this);
 
+	if(!is_main_window)
+		m_readyForCloseSemaphore = std::make_shared<Semaphore>();
+
 	cemu_assert(g_vulkan_available);
 
 	try

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -6,7 +6,6 @@
 
 VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_window)
 	: IRenderCanvas(is_main_window), wxWindow(parent, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS)
-	, is_main_window(is_main_window)
 {
 	Bind(wxEVT_PAINT, &VulkanCanvas::OnPaint, this);
 	Bind(wxEVT_SIZE, &VulkanCanvas::OnResize, this);
@@ -43,7 +42,7 @@ VulkanCanvas::~VulkanCanvas()
 	Unbind(wxEVT_PAINT, &VulkanCanvas::OnPaint, this);
 	Unbind(wxEVT_SIZE, &VulkanCanvas::OnResize, this);
 
-	if(!is_main_window)
+	if(!m_is_main_window)
 	{
 		auto vulkan_renderer = VulkanRenderer::GetInstance();
 		vulkan_renderer->ClosePadWindow();

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -6,6 +6,7 @@
 
 VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_window)
 	: IRenderCanvas(is_main_window), wxWindow(parent, wxID_ANY, wxDefaultPosition, size, wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS)
+	, is_main_window(is_main_window)
 {
 	Bind(wxEVT_PAINT, &VulkanCanvas::OnPaint, this);
 	Bind(wxEVT_SIZE, &VulkanCanvas::OnResize, this);
@@ -41,6 +42,14 @@ VulkanCanvas::~VulkanCanvas()
 {
 	Unbind(wxEVT_PAINT, &VulkanCanvas::OnPaint, this);
 	Unbind(wxEVT_SIZE, &VulkanCanvas::OnResize, this);
+
+	if(!is_main_window)
+	{
+		auto vulkan_renderer = VulkanRenderer::GetInstance();
+		std::cout << "Canvas signalling close to renderer" << std::endl;
+		vulkan_renderer->ClosePadWindow();
+		std::cout << "Destroyed canvas";
+	}
 }
 
 void VulkanCanvas::OnPaint(wxPaintEvent& event)

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -45,7 +45,10 @@ VulkanCanvas::~VulkanCanvas()
 	if(!m_is_main_window)
 	{
 		auto vulkan_renderer = VulkanRenderer::GetInstance();
-		vulkan_renderer->ClosePadWindow();
+		if(vulkan_renderer){
+			vulkan_renderer->ClosePadWindow(m_readyForCloseSemaphore);
+			m_readyForCloseSemaphore->wait();
+		}
 	}
 }
 

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -46,9 +46,7 @@ VulkanCanvas::~VulkanCanvas()
 	if(!is_main_window)
 	{
 		auto vulkan_renderer = VulkanRenderer::GetInstance();
-		std::cout << "Canvas signalling close to renderer" << std::endl;
 		vulkan_renderer->ClosePadWindow();
-		std::cout << "Destroyed canvas";
 	}
 }
 

--- a/src/gui/canvas/VulkanCanvas.h
+++ b/src/gui/canvas/VulkanCanvas.h
@@ -17,6 +17,8 @@ public:
 
 private:
 
+	bool is_main_window;
+
 	void OnPaint(wxPaintEvent& event);
 	void OnResize(wxSizeEvent& event);
 };

--- a/src/gui/canvas/VulkanCanvas.h
+++ b/src/gui/canvas/VulkanCanvas.h
@@ -6,7 +6,7 @@
 
 #include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
 #include <set>
-
+#include <util/helpers/Semaphore.h>
 
 
 class VulkanCanvas : public IRenderCanvas, public wxWindow
@@ -16,6 +16,8 @@ public:
 	~VulkanCanvas();
 
 private:
+
+	std::shared_ptr<Semaphore> m_readyForCloseSemaphore = std::make_shared<Semaphore>();
 
 	void OnPaint(wxPaintEvent& event);
 	void OnResize(wxSizeEvent& event);

--- a/src/gui/canvas/VulkanCanvas.h
+++ b/src/gui/canvas/VulkanCanvas.h
@@ -17,8 +17,6 @@ public:
 
 private:
 
-	bool is_main_window;
-
 	void OnPaint(wxPaintEvent& event);
 	void OnResize(wxSizeEvent& event);
 };


### PR DESCRIPTION
Explanation:
The pad VulkanCanvas has a Semaphore wrapped in a shared_ptr.
Added a boolean variable to VulkanRenderer that indicates if the pad window should be stop being updated. It also has a weak_ptr for a semaphore.
Swapchain operations only take place if IsSwapchainInfoValid returns true. We add the boolean to the check for the pad window.
When the pad canvas's destructor is called it calls a function in VulkanRenderer that sets the boolean that stops swapchain use, and as an argument it passes it's shared_ptr to the semaphore. The function saves this semaphore as a weak reference. 
When the function returns the canvas destructor awaits the semaphore.
When the rendering thread reaches the next IsSwapchainInfoValid for the pad window it checks to see if the weak reference is valid and if it is it notifies the semaphore. This causes the Canvas destructor to finish, invalidating the swapchain. Then it returns false because of the boolean flag which means the invalid swapchain is never used again.
The next time the pad view is opened it resets the flag and recreates the swapchain like the first Initialize call.