### PR TITLE
DSUController: fix crash when running on offline mode.

### DIFF
--- a/src/input/api/DSU/DSUControllerProvider.cpp
+++ b/src/input/api/DSU/DSUControllerProvider.cpp
@@ -78,7 +78,8 @@ bool DSUControllerProvider::connect()
 		using namespace boost::asio;
 
 		ip::udp::resolver resolver(m_io_service);
-		const ip::udp::resolver::query query(ip::udp::v4(), get_settings().ip, fmt::format("{}", get_settings().port));
+		const ip::udp::resolver::query query(ip::udp::v4(), get_settings().ip, fmt::format("{}", get_settings().port),
+		                                     ip::udp::resolver::query::canonical_name);
 		m_receiver_endpoint = *resolver.resolve(query);
 
 		if (m_socket.is_open())


### PR DESCRIPTION
the default flags argument passed here is boost::asio::ip::tcp::resolver::query::address_configured, which means that the call should only resolve IPv4/IPv6 addresses if a non-loopback IPv4/IPv6 address is configured for the system.

Signed-off-by: Schspa Shi <schspa@gmail.com>