### PR TITLE
Non-windows: Link fontawesome into executable.

### DIFF
--- a/src/imgui/imgui_extension.cpp
+++ b/src/imgui/imgui_extension.cpp
@@ -43,6 +43,10 @@ void ImRotateEnd(float rad, ImVec2 center)
 uint8* extractCafeDefaultFont(sint32* size);
 sint32 g_font_size = 0;
 uint8* g_font_data = nullptr;
+#if !BOOST_OS_WINDOWS
+extern int const g_fontawesome_size;
+extern char const g_fontawesome_data[];
+#endif
 std::unordered_map<int, ImFont*> g_imgui_fonts;
 std::stack<int> g_font_requests;
 
@@ -66,6 +70,14 @@ void ImGui_PrecacheFonts()
 		//cfg.SizePixels = size;
 		ImFont* font = io.Fonts->AddFontFromMemoryTTF(g_font_data, g_font_size, (float)size, &cfg);
 
+		ImFontConfig cfgmerge{};
+		cfgmerge.FontDataOwnedByAtlas = false;
+		cfgmerge.MergeMode = true;
+		cfgmerge.GlyphMinAdvanceX = 20.0f;
+		//cfgmerge.GlyphOffset = { 2,2 };
+
+		static const ImWchar icon_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0 };
+
 #if BOOST_OS_WINDOWS
 		const auto hinstance = GetModuleHandle(nullptr);
 		const HRSRC res = FindResource(hinstance, MAKEINTRESOURCE(IDR_FONTAWESOME), RT_RCDATA);
@@ -77,16 +89,11 @@ void ImGui_PrecacheFonts()
 				void* data = LockResource(mem);
 				const size_t len = SizeofResource(hinstance, res);
 
-				ImFontConfig cfgmerge{};
-				cfgmerge.FontDataOwnedByAtlas = false;
-				cfgmerge.MergeMode = true;
-				cfgmerge.GlyphMinAdvanceX = 20.0f;
-				//cfgmerge.GlyphOffset = { 2,2 };
-
-				static const ImWchar icon_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0 };
 				io.Fonts->AddFontFromMemoryTTF(data, (int)len, (float)size, &cfgmerge, icon_ranges);
 			}
 		}
+#else
+		io.Fonts->AddFontFromMemoryTTF((void*)g_fontawesome_data, (int)g_fontawesome_size, (float)size, &cfgmerge, icon_ranges);
 #endif
 
 		g_imgui_fonts[(int)size] = font;

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -10,8 +10,12 @@ embedded/resources.cpp
 embedded/resources.h
 )
 
-if(NOT WINDOWS)
-target_sources(CemuResource PRIVATE embedded/fontawesome.S)
+if(UNIX)
+    if(NOT APPLE)
+        target_sources(CemuResource PRIVATE embedded/fontawesome.S)
+    else()
+        target_sources(CemuResource PRIVATE embedded/fontawesome_macos.S)
+    endif()
 endif()
 
 target_sources(CemuResource PRIVATE CafeDefaultFont.cpp)

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -2,11 +2,17 @@ add_library(CemuResource)
 
 set_property(TARGET CemuResource PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+enable_language(ASM)
+
 # icon resources
 target_sources(CemuResource PRIVATE
 embedded/resources.cpp
 embedded/resources.h
 )
+
+if(NOT WINDOWS)
+target_sources(CemuResource PRIVATE embedded/fontawesome.S)
+endif()
 
 target_sources(CemuResource PRIVATE CafeDefaultFont.cpp)
 

--- a/src/resource/embedded/fontawesome.S
+++ b/src/resource/embedded/fontawesome.S
@@ -1,0 +1,8 @@
+.section .rodata
+.global g_fontawesome_data, g_fontawesome_size
+
+g_fontawesome_data:
+.incbin "fontawesome-webfont.ttf"
+g_fontawesome_size:
+.int g_fontawesome_size - g_fontawesome_data
+

--- a/src/resource/embedded/fontawesome.S
+++ b/src/resource/embedded/fontawesome.S
@@ -1,4 +1,4 @@
-.section .rodata
+.section .text
 .global g_fontawesome_data, g_fontawesome_size
 
 g_fontawesome_data:

--- a/src/resource/embedded/fontawesome_macos.S
+++ b/src/resource/embedded/fontawesome_macos.S
@@ -1,8 +1,8 @@
 .section __DATA, __const
-.global g_fontawesome_data, g_fontawesome_size
+.global _g_fontawesome_data, _g_fontawesome_size
 
-g_fontawesome_data:
+_g_fontawesome_data:
 .incbin "fontawesome-webfont.ttf"
-g_fontawesome_size:
-.int g_fontawesome_size - g_fontawesome_data
+_g_fontawesome_size:
+.int _g_fontawesome_size - _g_fontawesome_data
 

--- a/src/resource/embedded/fontawesome_macos.S
+++ b/src/resource/embedded/fontawesome_macos.S
@@ -1,0 +1,8 @@
+.section __DATA, __const
+.global g_fontawesome_data, g_fontawesome_size
+
+g_fontawesome_data:
+.incbin "fontawesome-webfont.ttf"
+g_fontawesome_size:
+.int g_fontawesome_size - g_fontawesome_data
+


### PR DESCRIPTION
On linux we don't have access to resource files so we have to resort to converting files to C source code.
For fontawesome this would result in a 1MB C source file from a 160KB .ttf file. Clearly not acceptable.
This is the next best thing. Short assembly file that exposes symbols to the .ttf file data.
I'm creating this pull request to trigger CI to check if mac supports it too. ~If not I'll make it linux only.~
Confirmed working on macOS and Linux.