### PR TITLE
[macOS] workaround for Metal and vulkan stride behavior difference.

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
@@ -457,6 +457,12 @@ void PipelineCompiler::InitVertexInputState(const LatteContextRegister& latteReg
 		uint32 bufferStride = (latteRegister.GetRawView()[bufferBaseRegisterIndex + 2] >> 11) & 0xFFFF;
 
 		VkVertexInputBindingDescription entry{};
+#if BOOST_OS_MACOS
+		if (bufferStride % 4 != 0) {
+			forceLog_printf("MoltenVK error: vertex stride was %d, expected multiple of 4", bufferStride);
+			bufferStride = 0;
+		}
+#endif
 		entry.stride = bufferStride;
 		if (!fetchType.has_value() || fetchType == LatteConst::VertexFetchType2::VERTEX_DATA)
 			entry.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;


### PR DESCRIPTION
When an unsupported vertex stride is given, replace with zero. Trying to set to any other value makes textures flicker and cover the whole screen. Also added output to log

Effects include many missing textures are now rendered visually correct. Any related missing textures are may also be rendered but may be have incorrect position and orientation.

![Screenshot 2022-11-02 at 8 18 05 PM](https://user-images.githubusercontent.com/35825944/199632180-3c8e869b-1d22-4fa7-9ccf-0320b9c01a6c.png)
![Screenshot 2022-11-02 at 8 19 32 PM](https://user-images.githubusercontent.com/35825944/199632195-400862d2-739c-48ad-ab06-d3b52de3fb6c.png)
