### PR TITLE
Linux: Excplicitly enable some flags related to security.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,13 @@ elseif(UNIX)
 	if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
 		add_compile_options(-Wno-ambiguous-reversed-operator)
 	endif()
+	# most linux environments should enable pie by default, but make sure just in case.
+	# the same cannot be said for no executable stack which some linkers
+	# and configurations thereof might enable enable due to the assembly in the project
+	if(NOT APPLE)
+		add_compile_options(-fpie)
+		add_link_options(-pie -Wl,-z,noexecstack)
+	endif()
 
     add_compile_options(-Wno-multichar -Wno-invalid-offsetof -Wno-switch -Wno-ignored-attributes -Wno-deprecated-enum-enum-conversion)
 endif()


### PR DESCRIPTION
Most modern systems and compilers will enable PIE by default for ASLR. Someone in discord reported that their debian configuration does not, so this PR enables it explicitly.
Additionally the GNU linker will output a binary with an executable stack when there's an object file without a ``.note.GNU-stack`` section linked in. Since GNU binutils 2.39 they include a compile-time configuration option to stop this behavior. Some distro's like arch have it enabled but the Github CI action uses ubuntu 20.04 which uses an older binutils version. The result is that at least some artifacts (have not checked all of them) have an executable stack. This PR also passes the option to explicitly disable an executable stack under all circumstances.