### PR TITLE
Fix input settings not refreshing + SDL controller crash

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_crypto.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.cpp
@@ -273,7 +273,7 @@ void iosuCrypto_generateDeviceCertificate()
 	BIGNUM* bn_x = BN_CTX_get(context);
 	BIGNUM* bn_y = BN_CTX_get(context);	
 
-	EC_POINT_get_affine_coordinates_GF2m(group, pubkey, bn_x, bn_y, NULL);
+	EC_POINT_get_affine_coordinates(group, pubkey, bn_x, bn_y, NULL);
 
 	uint8 publicKeyOutput[0x3C];
 	memset(publicKeyOutput, 0, sizeof(publicKeyOutput));

--- a/src/Cemu/ncrypto/ncrypto.cpp
+++ b/src/Cemu/ncrypto/ncrypto.cpp
@@ -550,7 +550,7 @@ namespace NCrypto
 		EC_POINT_mul(group, pubkey, bn_privKey, NULL, NULL, NULL);
 		BIGNUM* bn_x = BN_new();
 		BIGNUM* bn_y = BN_new();
-		EC_POINT_get_affine_coordinates_GF2m(group, pubkey, bn_x, bn_y, NULL);
+		EC_POINT_get_affine_coordinates(group, pubkey, bn_x, bn_y, NULL);
 
 		// store public key
 		ECCPubKey genPubKey;

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -418,7 +418,15 @@ void InputSettings2::update_state()
 
 	// enabled correct panel for active controller
 	if (active_api && emulated_controller && emulated_controller->type() == active_api.value())
+	{
+		// same controller type panel already shown, refresh content of panels
+		for (auto* panel : page_data.m_panels)
+		{
+			if (panel)
+				panel->load_controller(page_data.m_controller);
+		}
 		return;
+	}
 
 	// hide all panels
 	for (auto* panel : page_data.m_panels)

--- a/src/input/api/SDL/SDLController.cpp
+++ b/src/input/api/SDL/SDLController.cpp
@@ -58,13 +58,9 @@ bool SDLController::connect()
 	if (m_diid == -1)
 		return false;
 
-	m_controller = SDL_GameControllerFromInstanceID(m_diid);
+	m_controller = SDL_GameControllerOpen(index);
 	if (!m_controller)
-	{
-		m_controller = SDL_GameControllerOpen(index);
-		if (!m_controller)
-			return false;
-	}
+		return false;
 
 	if (const char* name = SDL_GameControllerName(m_controller))
 		m_display_name = name;


### PR DESCRIPTION
Having the same SDL controller active more than once and then removing one instance caused Cemu to crash