### PR TITLE
ImGui: match all begin/end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.out
 *.app
 .vs
+.vscode
 .idea/
 
 build/

--- a/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
@@ -123,8 +123,8 @@ void LatteOverlay_renderOverlay(ImVec2& position, ImVec2& pivot, sint32 directio
 				g_renderer->AppendOverlayDebugInfo();
 
 			position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-			ImGui::End();
 		}
+		ImGui::End();
 	}
 
 	ImGui::PopStyleColor();
@@ -170,8 +170,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 					ImGui::TextUnformatted(s_mii_name.c_str());
 
 					position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-					ImGui::End();
 				}
+				ImGui::End();
 				
 				// controller
 				std::vector<std::pair<int, std::string>> profiles;
@@ -209,8 +209,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 						}
 
 						position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-						ImGui::End();
 					}
+					ImGui::End();
 				}
 				else
 					s_init_overlay = true;
@@ -254,10 +254,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 				}
 
 				position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-				ImGui::End();
 			}
-
-
+			ImGui::End();
 		}
 	}
 
@@ -306,8 +304,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 				}
 
 				position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-				ImGui::End();
 			}
+			ImGui::End();
 		}
 	}
 
@@ -363,8 +361,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 					}
 
 					position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-					ImGui::End();
 				}
+				ImGui::End();
 			}
 		}
 		
@@ -435,8 +433,8 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 					}
 #endif
 					position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-					ImGui::End();
 				}
+				ImGui::End();
 			}
 		}
 	}
@@ -475,10 +473,9 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 			}
 
 			position.y += (ImGui::GetWindowSize().y + 10.0f) * direction;
-			ImGui::End();
 		}
+		ImGui::End();
 	}
-
 	ImGui::PopStyleColor();
 	ImGui::PopFont();
 }

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -350,10 +350,10 @@ void LatteShaderCache_load()
 
 					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureTVId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
 				}
-				ImGui::End();
-				ImGui::PopStyleVar(2);
-				g_renderer->ImguiEnd();
 			}
+			ImGui::End();
+			ImGui::PopStyleVar(2);
+			g_renderer->ImguiEnd();
 		}
 
 		g_renderer->BeginFrame(false);
@@ -365,7 +365,7 @@ void LatteShaderCache_load()
 			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0,0 });
 
 			if (ImGui::Begin("Background texture2", nullptr, kPopupFlags))
-				{
+			{
 				if (g_shaderCacheLoaderState.textureDRCId)
 				{
 					float imageDisplayWidth = io.DisplaySize.x;
@@ -383,11 +383,11 @@ void LatteShaderCache_load()
 
 					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureDRCId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
 				}
-				ImGui::End();
-				ImGui::PopStyleVar(2);
-				g_renderer->ImguiEnd();
-				}
-				}
+			}
+			ImGui::End();
+			ImGui::PopStyleVar(2);
+			g_renderer->ImguiEnd();
+		}
 				
 		g_renderer->SwapBuffers(true, true);
 	}
@@ -452,8 +452,8 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 					}
 
 					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureTVId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
-					ImGui::End();
 				}
+				ImGui::End();
 				ImGui::PopStyleVar(2);
 			}
 
@@ -502,8 +502,8 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 					text = fmt::format("{}/{} ({}%)", g_shaderCacheLoaderState.loadedShaderFiles, g_shaderCacheLoaderState.shaderFileCount, (int)(percentLoaded * 100));
 				ImGui::SetCursorPosX(width - ImGui::CalcTextSize(text.c_str()).x / 2);
 				ImGui::Text("%s", text.c_str());
-				ImGui::End();
 			}
+			ImGui::End();
 			ImGui::PopFont();
 			ImGui::PopStyleColor(2);
 
@@ -529,13 +529,11 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 					ImGui::Text("Geometry shaders");
 					ImGui::SameLine(offset);
 					ImGui::Text("%d", shaderCacheScreenStats.geometryShaderCount);
-
-					ImGui::End();
 				}
+				ImGui::End();
 				ImGui::PopStyleColor();
 				ImGui::PopFont();
 			}
-
 			g_renderer->ImguiEnd();
 			lastFrameUpdate = tick_cached();
 		}
@@ -565,11 +563,11 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 					}
 					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureDRCId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
 				}
-					ImGui::End();
-					ImGui::PopStyleVar(2);
-					g_renderer->ImguiEnd();
-				}
-				}
+			}
+			ImGui::End();
+			ImGui::PopStyleVar(2);
+			g_renderer->ImguiEnd();
+		}
 
 		// finish frame
 		g_renderer->SwapBuffers(true, true);

--- a/src/Cafe/OS/libs/erreula/erreula.cpp
+++ b/src/Cafe/OS/libs/erreula/erreula.cpp
@@ -346,7 +346,6 @@ namespace erreula
 				std::string button2 = "No";
 				if (appearArg.button2Text)
 					button2 = boost::nowide::narrow(GetText(appearArg.button2Text.GetPtr()));
-					
 
 				float width1 = std::max(100.0f, ImGui::CalcTextSize(button1.c_str()).x + 10.0f);
 				float width2 = std::max(100.0f, ImGui::CalcTextSize(button2.c_str()).x + 10.0f);
@@ -359,10 +358,8 @@ namespace erreula
 				break;
 			}
 			}
-
-			ImGui::End();
 		}
-
+		ImGui::End();
 		ImGui::PopFont();
 
 		if(g_errEula.buttonPressed || g_errEula.rightButtonPressed)

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -373,8 +373,8 @@ void swkbd_render(bool mainWindow)
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0,0 });
 	ImGui::SetNextWindowBgAlpha(0.8f);
-	if (ImGui::Begin("Background overlay", nullptr, kPopupFlags | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing))
-		ImGui::End();
+	ImGui::Begin("Background overlay", nullptr, kPopupFlags | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus);
+	ImGui::End();
 	ImGui::PopStyleVar(2);
 
 	ImVec2 position = { io.DisplaySize.x / 2.0f, io.DisplaySize.y / 3.0f };
@@ -412,10 +412,8 @@ void swkbd_render(bool mainWindow)
 		ImGui::PopTextWrapPos();
 
 		position.y += ImGui::GetWindowSize().y + 100.0f;
-
-		ImGui::End();
 	}
-
+	ImGui::End();
 	ImGui::PopFont();
 
 	ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
@@ -490,10 +488,8 @@ void swkbd_render(bool mainWindow)
 			}
 		}
 		ImGui::NewLine();
-		
-
-		ImGui::End();
 	}
+	ImGui::End();
 
 	if (io.NavInputs[ImGuiNavInput_Cancel] > 0)
 	{


### PR DESCRIPTION
1. As commented in imgui.h, should call a matching End() for each Begin()  regardless of its return value. Tested in BotW, this seems to improve performance very slightly.
2. Fix softkeyboard, click on background overlay will bring it to front and cover the softkeyboard.