### PR TITLE
Linux OpenGL: Fix gamepad not updating

### DIFF
--- a/src/gui/canvas/OpenGLCanvas.cpp
+++ b/src/gui/canvas/OpenGLCanvas.cpp
@@ -90,7 +90,15 @@ bool GLCanvas_MakeCurrent(bool padView)
 void GLCanvas_SwapBuffers(bool swapTV, bool swapDRC)
 {
 	if (swapTV && sGLTVView)
+	{
+		GLCanvas_MakeCurrent(false);
 		sGLTVView->SwapBuffers();
+	}
 	if (swapDRC && sGLPadView)
+	{
+		GLCanvas_MakeCurrent(true);
 		sGLPadView->SwapBuffers();
+	}
+
+	GLCanvas_MakeCurrent(false);
 }


### PR DESCRIPTION
Apparently in order for a canvas to be able to swap buffers, on linux the context needs to be current for that canvas.