### PR TITLE
Disable Discord checkbox based on build option

### DIFF
--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -153,6 +153,9 @@ wxPanel* GeneralSettings2::AddGeneralPage(wxNotebook* notebook)
 			m_discord_presence = new wxCheckBox(box, wxID_ANY, _("Discord Presence"));
 			m_discord_presence->SetToolTip(_("Enables the Discord Rich Presence feature\nYou will also need to enable it in the Discord settings itself!"));
 			second_row->Add(m_discord_presence, 0, botflag, 5);
+#ifndef ENABLE_DISCORD_RPC
+			m_discord_presence->Disable();
+#endif
 			second_row->AddSpacer(10);
 			m_fullscreen_menubar = new wxCheckBox(box, wxID_ANY, _("Fullscreen menu bar"));
 			m_fullscreen_menubar->SetToolTip(_("Displays the menu bar when Cemu is running in fullscreen mode and the mouse cursor is moved to the top"));


### PR DESCRIPTION
Disable the Discord checkbox when compiled with `-DENABLE_DISCORD_RPC=OFF`.

I'm not a programmer (but I play one on TV), so please let me know where the code should go if not here.

![screenshot](https://user-images.githubusercontent.com/23169302/201319602-24da72a3-b2f9-4c41-925a-687a92fff6c6.png)
