### PR TITLE
Vulkan: Further simplify swapchain code

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -118,6 +118,8 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	result = vkCreateFence(logicalDevice, &fenceInfo, nullptr, &m_imageAvailableFence);
 	if (result != VK_SUCCESS)
 		UnrecoverableError("Failed to create fence for swapchain");
+
+	hasDefinedSwapchainImage = false;
 }
 
 void SwapchainInfoVk::Cleanup()

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -14,7 +14,7 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	m_actualExtent = ChooseSwapExtent(details.capabilities);
 
 	// calculate number of swapchain presentation images
-	uint32_t image_count = details.capabilities.minImageCount + 1;
+	uint32_t image_count = details.capabilities.minImageCount;
 	if (details.capabilities.maxImageCount > 0 && image_count > details.capabilities.maxImageCount)
 		image_count = details.capabilities.maxImageCount;
 
@@ -115,16 +115,6 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 			UnrecoverableError("Failed to create semaphore for swapchain present");
 	}
 
-	m_acquireSemaphores.resize(m_swapchainImages.size());
-	for (auto& semaphore : m_acquireSemaphores)
-	{
-		VkSemaphoreCreateInfo info = {};
-		info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-		if (vkCreateSemaphore(logicalDevice, &info, nullptr, &semaphore) != VK_SUCCESS)
-			UnrecoverableError("Failed to create semaphore for swapchain acquire");
-	}
-	m_acquireIndex = 0;
-
 	VkFenceCreateInfo fenceInfo = {};
 	fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
 	fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
@@ -140,10 +130,6 @@ void SwapchainInfoVk::Cleanup()
 	for (auto& sem: m_swapchainPresentSemaphores)
 		vkDestroySemaphore(m_logicalDevice, sem, nullptr);
 	m_swapchainPresentSemaphores.clear();
-
-	for (auto& itr: m_acquireSemaphores)
-		vkDestroySemaphore(m_logicalDevice, itr, nullptr);
-	m_acquireSemaphores.clear();
 
 	if (m_swapchainRenderPass)
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -13,10 +13,7 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	m_surfaceFormat = ChooseSurfaceFormat(details.formats);
 	m_actualExtent = ChooseSwapExtent(details.capabilities);
 
-	// calculate number of swapchain presentation images
 	uint32_t image_count = details.capabilities.minImageCount;
-	if (details.capabilities.maxImageCount > 0 && image_count > details.capabilities.maxImageCount)
-		image_count = details.capabilities.maxImageCount;
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;
@@ -331,12 +328,12 @@ VkSwapchainCreateInfoKHR SwapchainInfoVk::CreateSwapchainCreateInfo(VkSurfaceKHR
 	createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
 	const QueueFamilyIndices indices = FindQueueFamilies(surface, m_physicalDevice);
-	uint32_t queueFamilyIndices[] = { (uint32)indices.graphicsFamily, (uint32)indices.presentFamily };
+	m_swapchainQueueFamilyIndices = { (uint32)indices.graphicsFamily, (uint32)indices.presentFamily };
 	if (indices.graphicsFamily != indices.presentFamily)
 	{
 		createInfo.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
-		createInfo.queueFamilyIndexCount = 2;
-		createInfo.pQueueFamilyIndices = queueFamilyIndices;
+		createInfo.queueFamilyIndexCount = m_swapchainQueueFamilyIndices.size();
+		createInfo.pQueueFamilyIndices = m_swapchainQueueFamilyIndices.data();
 	}
 	else
 		createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -160,6 +160,11 @@ bool SwapchainInfoVk::IsValid() const
 	return swapchain && m_imageAvailableFence;
 }
 
+void SwapchainInfoVk::WaitAvailableFence() const
+{
+	vkWaitForFences(m_logicalDevice, 1, &m_imageAvailableFence, VK_TRUE, UINT64_MAX);
+}
+
 void SwapchainInfoVk::UnrecoverableError(const char* errMsg)
 {
 	forceLog_printf("Unrecoverable error in Vulkan swapchain");

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -34,6 +34,8 @@ struct SwapchainInfoVk
 
 	bool IsValid() const;
 
+	void WaitAvailableFence() const;
+
 	static void UnrecoverableError(const char* errMsg);
 
 	// todo: move this function somewhere more sensible. Not directly swapchain related

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -76,7 +76,6 @@ struct SwapchainInfoVk
 	Vector2i m_desiredExtent{};
 	VkFence m_imageAvailableFence{};
 	uint32 swapchainImageIndex = (uint32)-1;
-	uint32 m_acquireIndex = 0; // increases with every successful vkAcquireNextImageKHR
 
 
 	// swapchain image ringbuffer (indexed by swapchainImageIndex)
@@ -84,7 +83,6 @@ struct SwapchainInfoVk
 	std::vector<VkImageView> m_swapchainImageViews;
 	std::vector<VkFramebuffer> m_swapchainFramebuffers;
 	std::vector<VkSemaphore> m_swapchainPresentSemaphores;
-	std::vector<VkSemaphore> m_acquireSemaphores; // indexed by acquireIndex
 
 	VkRenderPass m_swapchainRenderPass = nullptr;
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -83,6 +83,7 @@ struct SwapchainInfoVk
 	std::vector<VkImageView> m_swapchainImageViews;
 	std::vector<VkFramebuffer> m_swapchainFramebuffers;
 	std::vector<VkSemaphore> m_swapchainPresentSemaphores;
+	std::array<uint32, 2> m_swapchainQueueFamilyIndices;
 
 	VkRenderPass m_swapchainRenderPass = nullptr;
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1665,6 +1665,7 @@ bool VulkanRenderer::ImguiBegin(bool mainWindow)
 	draw_endRenderPass();
 	m_state.currentPipeline = VK_NULL_HANDLE;
 
+	chainInfo.WaitAvailableFence();
 	ImGui_ImplVulkan_CreateFontsTexture(m_state.currentCommandBuffer);
 	ImGui_ImplVulkan_NewFrame(m_state.currentCommandBuffer, chainInfo.m_swapchainFramebuffers[chainInfo.swapchainImageIndex], chainInfo.getExtent());
 	ImGui_UpdateWindowInformation(mainWindow);
@@ -1721,6 +1722,7 @@ bool VulkanRenderer::BeginFrame(bool mainWindow)
 
 	auto& chainInfo = GetChainInfo(mainWindow);
 
+	chainInfo.WaitAvailableFence();
 	VkClearColorValue clearColor{ 0, 0, 0, 0 };
 	ClearColorImageRaw(chainInfo.m_swapchainImages[chainInfo.swapchainImageIndex], 0, 0, clearColor, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
@@ -2557,7 +2559,6 @@ bool VulkanRenderer::AcquireNextSwapchainImage(bool mainWindow)
 		if (result != VK_ERROR_OUT_OF_DATE_KHR && result != VK_SUBOPTIMAL_KHR)
 			throw std::runtime_error(fmt::format("Failed to acquire next image: {}", result));
 	}
-	vkWaitForFences(m_logicalDevice, 1, &chainInfo.m_imageAvailableFence, VK_TRUE, std::numeric_limits<uint64_t>::max());
 
 	return true;
 }
@@ -2632,6 +2633,7 @@ void VulkanRenderer::SwapBuffer(bool mainWindow)
 
 	if (!chainInfo.hasDefinedSwapchainImage)
 	{
+		chainInfo.WaitAvailableFence();
 		// set the swapchain image to a defined state
 		VkClearColorValue clearColor{ 0, 0, 0, 0 };
 		ClearColorImageRaw(chainInfo.m_swapchainImages[chainInfo.swapchainImageIndex], 0, 0, clearColor, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
@@ -2699,6 +2701,7 @@ void VulkanRenderer::ClearColorbuffer(bool padView)
 	if (chainInfo.swapchainImageIndex == -1)
 		return;
 
+	chainInfo.WaitAvailableFence();
 	VkClearColorValue clearColor{ 0, 0, 0, 0 };
 	ClearColorImageRaw(chainInfo.m_swapchainImages[chainInfo.swapchainImageIndex], 0, 0, clearColor, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL);
 }
@@ -2789,6 +2792,7 @@ void VulkanRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	LatteTextureViewVk* texViewVk = (LatteTextureViewVk*)texView;
 	draw_endRenderPass();
 
+	chainInfo.WaitAvailableFence();
 	if (clearBackground)
 		ClearColorbuffer(padView);
 


### PR DESCRIPTION
- Fix use after free bug in CreateSwapchainCreateInfo
- Always use minImageCount. Unclear why it was min+1. This also reduces input lag on double buffered vsync by one frame.
- Remove unnecessary semaphore, it is unnecessary because the image is awaited by means of a fence.
- Don't submit command buffer in AcquireNextSwapchainImage
- Don't wait for fence when recreating; already waited for device to be idle.
- Remove barrier before present. VkQueuePresentKHR is set to wait for the presentSemaphore which becomes signalled when the command buffer that writes to the swapchain image finishes execution. No barrier is required because: ```Any writes to memory backing the images referenced by the pImageIndices and pSwapchains members of pPresentInfo, that are available before vkQueuePresentKHR is executed, are automatically made visible to the read access performed by the presentation engine. This automatic visibility operation for an image happens-after the semaphore signal operation, and happens-before the presentation engine accesses the image.```
- Remove SwapBuffer error handling loop and replace with code similar to AcquireNextSwapchainImage error handling

> it is unnecessary because the image is awaited by means of a fence.

Clarification: while working on this PR I had a version where I deleted the fence instead and relied on the semaphore to synchronize access to the swapchain image. This worked as well but the specification has an informative note in vkAcquireNextImageKHR saying: ```Applications should not rely on vkAcquireNextImageKHR blocking in order to meter their rendering speed. The implementation may return from this function immediately regardless of how many presentation requests are queued, and regardless of when queued presentation requests will complete relative to the call. Instead, applications can use fence to meter their frame generation work to match the presentation rate.```
> Applications should not rely on vkAcquireNextImageKHR blocking in order to meter their rendering speed.

Getting rid of the fence does exactly this. But if we use the fence anyway the semaphore becomes redundant because we do not submit the command buffer that writes to the acquired swapchain image before the fence is signalled.

Remaining questions:
These statements seem to contradict eachother:
Normative text:
> If timeout is UINT64_MAX, the timeout period is treated as infinite, and vkAcquireNextImageKHR will block until an image is acquired or an error occurs.

Informative text:
> The implementation may return from this function immediately regardless of how many presentation requests are queued, and regardless of when queued presentation requests will complete relative to the call. 

It would be nicer if we _could_ rely on vkAcquireNextImageKHR to block because then all the access synchronization happens on-device although in practice this probably makes little difference.