### PR TITLE
Create install folder if it doesn't exist yet, fixes issue #498

### DIFF
--- a/src/gui/GameUpdateWindow.cpp
+++ b/src/gui/GameUpdateWindow.cpp
@@ -130,6 +130,10 @@ bool GameUpdateWindow::ParseUpdate(const fs::path& metaPath)
 		}
 	}
 
+	// The folder may not exist yet, create it
+	if (!fs::exists(target_location))
+		fs::create_directory(target_location);
+
 	// checking size is buggy on Wine (on Steam Deck this would return values too small to install bigger updates) - we therefore skip this step
 	if(!IsRunningInWine())
 	{


### PR DESCRIPTION
Tentative fix for issue #498

I am unable to test on OSX, but it fixes the issue on Windows