### PR TITLE
macOS: implement support for high DPI scaling

### DIFF
--- a/bin/shaderCache/info.txt
+++ b/bin/shaderCache/info.txt
@@ -1,1 +1,0 @@
-If you plan to transfer the shader cache to a different PC or Cemu installation you only need to copy the 'transferable' directory.

--- a/bin/shaderCache/info.txt
+++ b/bin/shaderCache/info.txt
@@ -1,0 +1,1 @@
+If you plan to transfer the shader cache to a different PC or Cemu installation you only need to copy the 'transferable' directory.

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
@@ -15,6 +15,13 @@
 
 -(CALayer*) makeBackingLayer { return [self.class.layerClass layer]; }
 
+- (void)viewDidChangeBackingProperties {
+	NSScreen* screen = [[self window] screen];
+	if (screen) {
+		self.layer.contentsScale = [[self window] backingScaleFactor];
+	}
+}
+
 @end
 
 VkSurfaceKHR CreateCocoaSurface(VkInstance instance, void* handle)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1506,7 +1506,12 @@ void MainWindow::OnSizeEvent(wxSizeEvent& event)
 	if (!IsMaximized() && !gui_isFullScreen())
 		m_restored_size = GetSize();
 
-	const wxSize client_size = GetClientSize();
+	#if BOOST_OS_MACOS
+		const wxSize client_size = ToPhys(GetClientSize());
+	#else
+		const wxSize client_size = GetClientSize();
+	#endif
+
 	g_window_info.width = client_size.GetWidth();
 	g_window_info.height = client_size.GetHeight();
 


### PR DESCRIPTION
These changes only impact macOS, so Windows/Linux should be unaffected.
These commits enable initial high DPI scaling support, whereas previously only the logical resolution was used, which effectively reduced the resolution to 0.5*0.5 of physical resolution.

Dynamic switching of scaling is supported and happens transparently (the logical window size is not changed when moving between displays of different DPI).

At the moment, in some cases the scaling change (after moving between displays) only occurs after the window is resized.
I think that is only a minor issue and still an improvement from current behaviour.