### PR TITLE
macOS: fix error sound for every KB keypress on render canvas

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1388,7 +1388,7 @@ void MainWindow::OnChar(wxKeyEvent& event)
 	if (swkbd_hasKeyboardInputHook())
 		swkbd_keyInput(event.GetUnicodeKey());
 	
-	event.Skip();
+	// event.Skip();
 }
 
 void MainWindow::OnToolsInput(wxCommandEvent& event)


### PR DESCRIPTION
Whenever any key except for the arrow keys is pressed, macOS generates an error sound.

To my understanding, this is caused because event.Skip() causes wxWidgets to keep looking for further handlers.
However as no further handling occurs, macOS reports this as an unhandled event.


I am leaving this as a draft for now, as I cannot test if this has any drawbacks on other platforms than macOS.
Also I am unsure which purpose event.Skip() serves in the other occurences. Only one occurrence has been modified, which fixed the issue without apparent drawbacks.
However, if not Skipping has no drawbacks on other platforms and other occurences in this file, the other occurences should be modified as well.