### PR TITLE
Vulkan: Fix flicker on resize

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2540,11 +2540,11 @@ bool VulkanRenderer::AcquireNextSwapchainImage(bool mainWindow)
 
 	auto& chainInfo = GetChainInfo(mainWindow);
 
-	if (!UpdateSwapchainProperties(mainWindow))
-		return false;
-
 	if (chainInfo.swapchainImageIndex != -1)
 		return true; // image already reserved
+
+	if (!UpdateSwapchainProperties(mainWindow))
+		return false;
 
 	vkResetFences(m_logicalDevice, 1, &chainInfo.m_imageAvailableFence);
 	VkResult result = vkAcquireNextImageKHR(m_logicalDevice, chainInfo.swapchain, std::numeric_limits<uint64_t>::max(), VK_NULL_HANDLE, chainInfo.m_imageAvailableFence, &chainInfo.swapchainImageIndex);


### PR DESCRIPTION
When a swapchain becomes suboptimal after an acquire for rendering, SwapBuffer would recreate the swapchain and acquire a new image from it which would get filled in with black because the content is undefined, resulting in black flickering when resizing.
By changing the order in AcquireNextSwapchainImage it'll always try to present the suboptimal image it already acquired and drew content to and drop the image if it is out of date and cannot be used. Then when no image is reserved anymore the next acquire will recreate the swapchain.