### PR TITLE
Vulkan: return to more conventional swapchain sync method, encapsulate more code

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -15,10 +15,10 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 
 	// Use at least two swapchain images. Fewer than that causes problems on some drivers.
 	uint32_t image_count = std::max(2u, details.capabilities.minImageCount);
-    if(details.capabilities.maxImageCount > 0)
-        image_count = std::min(image_count, details.capabilities.maxImageCount);
-    if(image_count < 2)
-        cemuLog_force("Vulkan: Swapchain image count less than 2.");
+	if(details.capabilities.maxImageCount > 0)
+		image_count = std::min(image_count, details.capabilities.maxImageCount);
+	if(image_count < 2)
+		cemuLog_force("Vulkan: Swapchain image count less than 2.");
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -13,11 +13,12 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	m_surfaceFormat = ChooseSurfaceFormat(details.formats);
 	m_actualExtent = ChooseSwapExtent(details.capabilities);
 
+	// Use at least two swapchain images. Fewer than that causes problems on some drivers.
 	uint32_t image_count = std::max(2u, details.capabilities.minImageCount);
     if(details.capabilities.maxImageCount > 0)
         image_count = std::min(image_count, details.capabilities.maxImageCount);
     if(image_count < 2)
-        cemuLog_force("Vulkan: Swapchain image count less than 2. imgui requires at least two");
+        cemuLog_force("Vulkan: Swapchain image count less than 2.");
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -13,7 +13,7 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	m_surfaceFormat = ChooseSurfaceFormat(details.formats);
 	m_actualExtent = ChooseSwapExtent(details.capabilities);
 
-	// Use at least two swapchain images. Fewer than that causes problems on some drivers.
+	// use at least two swapchain images. fewer than that causes problems on some drivers
 	uint32_t image_count = std::max(2u, details.capabilities.minImageCount);
 	if(details.capabilities.maxImageCount > 0)
 		image_count = std::min(image_count, details.capabilities.maxImageCount);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -18,7 +18,7 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	if(details.capabilities.maxImageCount > 0)
 		image_count = std::min(image_count, details.capabilities.maxImageCount);
 	if(image_count < 2)
-		cemuLog_force("Vulkan: Swapchain image count less than 2.");
+		cemuLog_force("Vulkan: Swapchain image count less than 2 may cause problems");
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -182,11 +182,6 @@ bool SwapchainInfoVk::IsValid() const
 	return swapchain && !m_acquireSemaphores.empty();
 }
 
-void SwapchainInfoVk::WaitAvailableFence() const
-{
-	vkWaitForFences(m_logicalDevice, 1, &m_imageAvailableFence, VK_TRUE, UINT64_MAX);
-}
-
 void SwapchainInfoVk::UnrecoverableError(const char* errMsg)
 {
 	forceLog_printf("Unrecoverable error in Vulkan swapchain");

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -13,7 +13,11 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	m_surfaceFormat = ChooseSurfaceFormat(details.formats);
 	m_actualExtent = ChooseSwapExtent(details.capabilities);
 
-	uint32_t image_count = details.capabilities.minImageCount;
+	uint32_t image_count = std::max(2u, details.capabilities.minImageCount);
+    if(details.capabilities.maxImageCount > 0)
+        image_count = std::min(image_count, details.capabilities.maxImageCount);
+    if(image_count < 2)
+        cemuLog_force("Vulkan: Swapchain image count less than 2. imgui requires at least two");
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -34,8 +34,6 @@ struct SwapchainInfoVk
 
 	bool IsValid() const;
 
-	void WaitAvailableFence() const;
-
 	static void UnrecoverableError(const char* errMsg);
 
 	// todo: move this function somewhere more sensible. Not directly swapchain related

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -34,6 +34,15 @@ struct SwapchainInfoVk
 
 	bool IsValid() const;
 
+	void WaitAvailableFence();
+	void ResetAvailableFence() const;
+
+	bool AcquireImage(uint64 timeout);
+	// retrieve semaphore of last acquire for submitting a wait operation
+	// only one wait operation must be submitted per acquire (which submits a single signal operation)
+	// therefore subsequent calls will return a NULL handle
+	VkSemaphore ConsumeAcquireSemaphore();
+
 	static void UnrecoverableError(const char* errMsg);
 
 	// todo: move this function somewhere more sensible. Not directly swapchain related
@@ -74,21 +83,24 @@ struct SwapchainInfoVk
 	VkSurfaceFormatKHR m_surfaceFormat{};
 	VkSwapchainKHR swapchain{};
 	Vector2i m_desiredExtent{};
-	VkFence m_imageAvailableFence{};
 	uint32 swapchainImageIndex = (uint32)-1;
-	uint32 m_acquireIndex = 0;
 
 
 	// swapchain image ringbuffer (indexed by swapchainImageIndex)
 	std::vector<VkImage> m_swapchainImages;
 	std::vector<VkImageView> m_swapchainImageViews;
 	std::vector<VkFramebuffer> m_swapchainFramebuffers;
-	std::vector<VkSemaphore> m_acquireSemaphores; // indexed by m_acquireIndex
 	std::vector<VkSemaphore> m_presentSemaphores; // indexed by swapchainImageIndex
-	std::array<uint32, 2> m_swapchainQueueFamilyIndices;
 
 	VkRenderPass m_swapchainRenderPass = nullptr;
 
 private:
+	uint32 m_acquireIndex = 0;
+	std::vector<VkSemaphore> m_acquireSemaphores; // indexed by m_acquireIndex
+	VkFence m_imageAvailableFence{};
+	VkSemaphore m_currentSemaphore = VK_NULL_HANDLE;
+	VkFence m_awaitableFence = VK_NULL_HANDLE;
+
+	std::array<uint32, 2> m_swapchainQueueFamilyIndices;
 	VkExtent2D m_actualExtent{};
 };

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -78,13 +78,15 @@ struct SwapchainInfoVk
 	Vector2i m_desiredExtent{};
 	VkFence m_imageAvailableFence{};
 	uint32 swapchainImageIndex = (uint32)-1;
+	uint32 m_acquireIndex = 0;
 
 
 	// swapchain image ringbuffer (indexed by swapchainImageIndex)
 	std::vector<VkImage> m_swapchainImages;
 	std::vector<VkImageView> m_swapchainImageViews;
 	std::vector<VkFramebuffer> m_swapchainFramebuffers;
-	std::vector<VkSemaphore> m_swapchainPresentSemaphores;
+	std::vector<VkSemaphore> m_acquireSemaphores; // indexed by m_acquireIndex
+	std::vector<VkSemaphore> m_presentSemaphores; // indexed by swapchainImageIndex
 	std::array<uint32, 2> m_swapchainQueueFamilyIndices;
 
 	VkRenderPass m_swapchainRenderPass = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2569,9 +2569,13 @@ bool VulkanRenderer::AcquireNextSwapchainImage(bool mainWindow)
 
 void VulkanRenderer::RecreateSwapchain(bool mainWindow, bool skipCreate)
 {
+	using namespace std::chrono_literals;
 	SubmitCommandBuffer();
 	WaitDeviceIdle();
 	auto& chainInfo = GetChainInfo(mainWindow);
+	vkWaitForFences(m_logicalDevice, 1, &chainInfo.m_imageAvailableFence, VK_TRUE,
+		std::chrono::duration_cast<std::chrono::nanoseconds>(10ms).count()
+	);
 
 	Vector2i size;
 	if (mainWindow)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1471,10 +1471,8 @@ void VulkanRenderer::ImguiInit()
 	info.Queue = m_presentQueue;
 	info.PipelineCache = m_pipeline_cache;
 	info.DescriptorPool = m_descriptorPool;
-	// these parameters are deceptively named
-	// they have nothing to do with swapchain images but must be at least 2
-	info.MinImageCount = 2;
-	info.ImageCount = 2;
+	info.MinImageCount = m_mainSwapchainInfo->m_swapchainImages.size();
+	info.ImageCount = info.MinImageCount;
 
 	ImGui_ImplVulkan_Init(&info, m_imguiRenderPass);
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1471,8 +1471,10 @@ void VulkanRenderer::ImguiInit()
 	info.Queue = m_presentQueue;
 	info.PipelineCache = m_pipeline_cache;
 	info.DescriptorPool = m_descriptorPool;
-	info.MinImageCount = m_mainSwapchainInfo->m_swapchainImages.size();
-	info.ImageCount = info.MinImageCount;
+	// these parameters are deceptively named
+	// they have nothing to do with swapchain images but must be at least 2
+	info.MinImageCount = 2;
+	info.ImageCount = 2;
 
 	ImGui_ImplVulkan_Init(&info, m_imguiRenderPass);
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -233,7 +233,7 @@ public:
 	void InitFirstCommandBuffer();
 	void ProcessFinishedCommandBuffers();
 	void WaitForNextFinishedCommandBuffer();
-	void SubmitCommandBuffer(VkSemaphore* signalSemaphore = nullptr, VkSemaphore* waitSemaphore = nullptr);
+	void SubmitCommandBuffer(VkSemaphore signalSemaphore = VK_NULL_HANDLE, VkSemaphore waitSemaphore = VK_NULL_HANDLE);
 	void RequestSubmitSoon();
 	void RequestSubmitOnIdle();
 


### PR DESCRIPTION
#502 adopted a swapchain sync method that is correct in theory but is not commonly used. 
This changes the sync method back to what was used before.

The [validation layer](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12) appears to not have made up their mind about whether using only a fence is valid and one of the authors of the vulkan specification says it is unintended and basically advises against it [here](https://github.com/KhronosGroup/Vulkan-Docs/issues/117#issuecomment-200357476)

This PR also ups the minimum swapchain image count to at least two images (not min+1 which might be > 2 causing unnecessary input lag and wasting resources). Using only one swapchain image caused a freeze on AMD windows drivers when switching to fullscreen.
One of the issues that popped up after removing the acquire semaphore is that on macOS the fonts in the imgui overlay disappeared.
I do not have a concrete answer as to why moltenVK has issues while other platforms do not. It may be that moltenVK assumes swapchain image access is guarded with a semaphore.

Additionally some more swapchain code is moved from VulkanRenderer into the SwapchainInfoVk class. There is likely more code that could be moved there before the encapsulation is optimal but that would make the scope of the PR a bit too large.