### PR TITLE
Vulkan: Correct swapchain error handling

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2654,7 +2654,7 @@ void VulkanRenderer::SwapBuffer(bool mainWindow)
 	VkResult result = vkQueuePresentKHR(m_presentQueue, &presentInfo);
 	if (result < 0 && result != VK_ERROR_OUT_OF_DATE_KHR)
 	{
-		throw std::runtime_error(fmt::format("Failed to acquire next image: {}", result));
+		throw std::runtime_error(fmt::format("Failed to present image: {}", result));
 	}
 	if(result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
 		chainInfo.m_shouldRecreate = true;


### PR DESCRIPTION
In #514 there were some mysterious crashes.
[greybaron](https://github.com/greybaron) was helpful in bisecting which revealed that #522 introduces a bug.
Because #522 checks to see if an image is already acquired _before_ checking if the swapchain is out of date the swapchain does not get recreated on a VK_ERROR_OUT_OF_DATE_KHR error. This meant that the swapchainImageIndex never got reset and cemu would try to present images it never acquired. This wasn't an issue on main and I think that is because only DPI switches trigger VK_ERROR_OUT_OF_DATE_KHR and only on some macOS systems (like the M1 macbook pro).