### PR TITLE
macOS: Add platform specific control/tab keycodes

### DIFF
--- a/src/gui/guiWrapper.h
+++ b/src/gui/guiWrapper.h
@@ -7,6 +7,10 @@
 #include <gdk/gdkkeysyms.h>
 #endif
 
+#if BOOST_OS_MACOS
+#include <Carbon/Carbon.h>
+#endif
+
 struct WindowHandleInfo
 {
 #if BOOST_OS_WINDOWS
@@ -36,6 +40,10 @@ enum struct PlatformKeyCodes : uint32
 	LCONTROL = GDK_KEY_Control_L,
 	RCONTROL = GDK_KEY_Control_R,
 	TAB = GDK_KEY_Tab,
+#elif BOOST_OS_MACOS
+	LCONTROL = kVK_Control,
+	RCONTROL = kVK_RightControl,
+	TAB = kVK_Tab,
 #else
 	LCONTROL = 0,
 	RCONTROL = 0,


### PR DESCRIPTION
Control doesn't seem to like to be picked up still. Might be because I'm not using an apple keyboard.
Have to hold tab, press control, release tab, then press tab again to activate the toggle hotkey.
Could also be because macOS is capturing control for something.
At the very least this should fix the gamepad toggle when someone presses A on their keyboard (keycode 0 😅)