### PR TITLE
Fix black screen when graphics packs are used and regression in #536

### DIFF
--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -1179,7 +1179,7 @@ std::vector<uint64> GraphicPack2::ParseTitleIds(IniParser& rules, const char* op
 void GraphicPack2::ApplyShaderPresets(std::string& shader_source) const
 {
 	const auto active_presets = GetActivePresets();
-	const std::regex regex(R"($[a-zA-Z_0-9]+)");
+	const std::regex regex(R"(\$[a-zA-Z_0-9]+)");
 
 	std::smatch match;
 	size_t offset = 0;


### PR DESCRIPTION
apologies, I thought the first backslash was a left over escape character and my testing wasn't thorough enough. Turns out it was a regular character to search for.

Before no graphics pack.
![Screenshot 2022-11-28 at 8 06 04 PM](https://user-images.githubusercontent.com/35825944/204421047-58611c41-c48e-4717-bc59-19a397300817.png)

Before with graphics pack(serfrost clarity preset)
![Screenshot 2022-11-28 at 8 09 39 PM](https://user-images.githubusercontent.com/35825944/204421328-9580a72c-8795-4177-a3fb-197c4491c194.png)

After with graphics pack
note the extra blue tint from the graphics pack and not black screen.
![Screenshot 2022-11-28 at 7 55 12 PM](https://user-images.githubusercontent.com/35825944/204419329-808f27a5-e0e1-409d-96da-000fbfb236f7.png)
