### PR TITLE
Fix sign error of distance calculate

### DIFF
--- a/src/Cemu/PPCAssembler/ppcAssembler.cpp
+++ b/src/Cemu/PPCAssembler/ppcAssembler.cpp
@@ -2126,7 +2126,7 @@ bool _ppcAssembler_isConstantBranchTargetExpr(std::string& expressionString, sin
 		{
 			return false;
 		}
-		relativeAddr = (uint32)branchDistance;
+		relativeAddr = (sint32)branchDistance;
 		return true;
 	}
 	return false;


### PR DESCRIPTION
will cause distance == 0, when distance is a minus one.