### PR TITLE
Always set GDK_BACKEND=x11

### DIFF
--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -15,6 +15,8 @@ if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
 	sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
 fi
 
+sed -i '/^Exec=/ c Exec=Cemu' dist/linux/info.cemu.Cemu.desktop
+
 mkdir -p AppDir/usr/bin
 cp dist/linux/{info.cemu.Cemu.desktop,info.cemu.Cemu.png} AppDir/
 

--- a/dist/linux/info.cemu.Cemu.desktop
+++ b/dist/linux/info.cemu.Cemu.desktop
@@ -3,7 +3,7 @@ Name=Cemu
 Type=Application
 Terminal=false
 Icon=info.cemu.Cemu
-Exec=Cemu
+Exec=env GDK_BACKEND=x11 Cemu
 GenericName=Wii U Emulator
 GenericName[fi]=Wii U -emulaattori
 GenericName[el]=Πρόγραμμα προσομοίωσης Wii U


### PR DESCRIPTION
[Workaround for Wayland](https://github.com/cemu-project/Cemu/issues/92#issue-1353130696). No effect on X11.

Should be fine to add it for everyone, [pcsx2 has had it for 6 years](https://github.com/PCSX2/pcsx2/commit/8958b2042fc1877617dcdcc335b8a0f082e2ca89).
