### PR TITLE
Minor AppImage fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build
+        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream
 
     - name: "Build AppImage"
       run: dist/linux/appimage.sh

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -20,7 +20,7 @@ mkdir -p AppDir/usr/share/applications
 mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
 mkdir -p AppDir/usr/lib
 
-cp dist/linux/{info.cemu.Cemu.desktop,info.cemu.Cemu.png} AppDir/
+cp dist/linux/info.cemu.Cemu.{desktop,png} AppDir/
 
 cp -r bin AppDir/usr/share/Cemu
 

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -17,7 +17,7 @@ fi
 
 mkdir -p AppDir/usr/bin
 mkdir -p AppDir/usr/share/applications
-mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
+mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
 mkdir -p AppDir/usr/lib
 
 cp dist/linux/{info.cemu.Cemu.desktop,info.cemu.Cemu.png} AppDir/

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${GITHUB_WORKSPACE}" ]]; then
-    export GITHUB_WORKSPACE="."
+	export GITHUB_WORKSPACE="."
 fi
 
 curl -sSfLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
@@ -12,7 +12,7 @@ curl -sSfLO "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gt
 chmod a+x linuxdeploy-plugin-gtk.sh
 
 if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
-    sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
+	sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
 fi
 
 mkdir -p AppDir/usr/bin
@@ -43,7 +43,7 @@ export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
 GITVERSION="$(git rev-parse --short HEAD)"
 echo "${GITVERSION}"
 if [[ -z "${GITVERSION}" ]]; then
-    GITVERSION=experimental
+	GITVERSION=experimental
 fi
 
 echo "Cemu Version Cemu-${GITVERSION}"

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -16,13 +16,14 @@ if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
 fi
 
 mkdir -p AppDir/usr/bin
+mkdir -p AppDir/usr/share/Cemu
 mkdir -p AppDir/usr/share/applications
 mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
 mkdir -p AppDir/usr/lib
 
 cp dist/linux/info.cemu.Cemu.{desktop,png} AppDir/
 
-cp -r bin AppDir/usr/share/Cemu
+cp -r bin/* AppDir/usr/share/Cemu
 
 mv AppDir/usr/share/Cemu/Cemu AppDir/usr/bin/
 chmod +x AppDir/usr/bin/Cemu

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -19,9 +19,11 @@ mkdir -p AppDir/usr/bin
 mkdir -p AppDir/usr/share/Cemu
 mkdir -p AppDir/usr/share/applications
 mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
+mkdir -p AppDir/usr/share/metainfo/
 mkdir -p AppDir/usr/lib
 
 cp dist/linux/info.cemu.Cemu.{desktop,png} AppDir/
+cp dist/linux/info.cemu.Cemu.metainfo.xml AppDir/usr/share/metainfo/info.cemu.Cemu.appdata.xml
 
 cp -r bin/* AppDir/usr/share/Cemu
 

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-if [ -z "${GITHUB_WORKSPACE}" ]; then
+if [[ -z "${GITHUB_WORKSPACE}" ]]; then
     export GITHUB_WORKSPACE="."
 fi
-  
+
 curl -sSfLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
 chmod a+x linuxdeploy*.AppImage
-curl -sSfL https://github.com$(curl https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous | grep "mkappimage-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2) -o mkappimage.AppImage
+curl -sSfL https://github.com"$(curl https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous | grep "mkappimage-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)" -o mkappimage.AppImage
 chmod a+x mkappimage.AppImage
 curl -sSfLO "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 chmod a+x linuxdeploy-plugin-gtk.sh
 
 if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
-	sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
+    sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
 fi
 
 mkdir -p AppDir/usr/bin
@@ -29,23 +29,23 @@ mv AppDir/usr/share/Cemu/Cemu AppDir/usr/bin/
 chmod +x AppDir/usr/bin/Cemu
 
 export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
-./linuxdeploy-x86_64.AppImage --appimage-extract-and-run\
-  --appdir="$GITHUB_WORKSPACE"/AppDir/          	\
-  -d "$GITHUB_WORKSPACE"/AppDir/info.cemu.Cemu.desktop  \
-  -i "$GITHUB_WORKSPACE"/AppDir/info.cemu.Cemu.png      \
-  -e "$GITHUB_WORKSPACE"/AppDir/usr/bin/Cemu		\
+./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \
+  --appdir="${GITHUB_WORKSPACE}"/AppDir/ \
+  -d "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.desktop \
+  -i "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.png \
+  -e "${GITHUB_WORKSPACE}"/AppDir/usr/bin/Cemu \
   --plugin gtk
 
-GITVERSION=$(git rev-parse --short HEAD) 
-echo $GITVERSION
-if [[ -z ${GITVERSION} ]]; then
-	GITVERSION=experimental
+GITVERSION="$(git rev-parse --short HEAD)"
+echo "${GITVERSION}"
+if [[ -z "${GITVERSION}" ]]; then
+    GITVERSION=experimental
 fi
 
 echo "Cemu Version Cemu-${GITVERSION}"
 rm AppDir/usr/lib/libwayland-client.so.0
 echo "export LC_ALL=C" >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
-VERSION=${GITVERSION} ./mkappimage.AppImage --appimage-extract-and-run "$GITHUB_WORKSPACE"/AppDir
+VERSION="${GITVERSION}" ./mkappimage.AppImage --appimage-extract-and-run "${GITHUB_WORKSPACE}"/AppDir
 
-mkdir -p "$GITHUB_WORKSPACE"/artifacts/ 
-mv Cemu-${GITVERSION}-x86_64.AppImage "$GITHUB_WORKSPACE"/artifacts/ 
+mkdir -p "${GITHUB_WORKSPACE}"/artifacts/
+mv Cemu-"${GITVERSION}"-x86_64.AppImage "${GITHUB_WORKSPACE}"/artifacts/

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -19,7 +19,7 @@ mkdir -p AppDir/usr/bin
 mkdir -p AppDir/usr/share/Cemu
 mkdir -p AppDir/usr/share/applications
 mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
-mkdir -p AppDir/usr/share/metainfo/
+mkdir -p AppDir/usr/share/metainfo
 mkdir -p AppDir/usr/lib
 
 cp dist/linux/info.cemu.Cemu.{desktop,png} AppDir/
@@ -40,13 +40,11 @@ export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
   -e "${GITHUB_WORKSPACE}"/AppDir/usr/bin/Cemu \
   --plugin gtk
 
-GITVERSION="$(git rev-parse --short HEAD)"
-echo "${GITVERSION}"
-if [[ -z "${GITVERSION}" ]]; then
+if ! GITVERSION="$(git rev-parse --short HEAD 2>/dev/null)"; then
 	GITVERSION=experimental
 fi
-
 echo "Cemu Version Cemu-${GITVERSION}"
+
 rm AppDir/usr/lib/libwayland-client.so.0
 echo "export LC_ALL=C" >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 VERSION="${GITVERSION}" ./mkappimage.AppImage --appimage-extract-and-run "${GITHUB_WORKSPACE}"/AppDir

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -16,17 +16,18 @@ if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
 fi
 
 mkdir -p AppDir/usr/bin
-cp dist/linux/{info.cemu.Cemu.desktop,info.cemu.Cemu.png} AppDir/
-
-mkdir -p AppDir/usr/share/applications 
+mkdir -p AppDir/usr/share/applications
 mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
 mkdir -p AppDir/usr/lib
 
+cp dist/linux/{info.cemu.Cemu.desktop,info.cemu.Cemu.png} AppDir/
+
 cp -r bin AppDir/usr/share/Cemu
-cp /usr/lib/x86_64-linux-gnu/{libsepol.so.1,libffi.so.7,libpcre.so.3,libGLU.so.1,libthai.so.0} AppDir/usr/lib
 
 mv AppDir/usr/share/Cemu/Cemu AppDir/usr/bin/
 chmod +x AppDir/usr/bin/Cemu
+
+cp /usr/lib/x86_64-linux-gnu/{libsepol.so.1,libffi.so.7,libpcre.so.3,libGLU.so.1,libthai.so.0} AppDir/usr/lib
 
 export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
 ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \


### PR DESCRIPTION
- Fix incorrect recursive copy. Previously, if you didn't delete AppDir between builds, `bin/` would be copied *into* an existing `AppDir/usr/share/Cemu`

- Add metainfo file. [According to appstream docs](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-introduction), `metainfo.xml` is correct, but [the warning from linuxdeploy](https://github.com/cemu-project/Cemu/actions/runs/3640469545/jobs/6145427858#step:5:1494) says `appdata.xml` so that's where I put it.