### PR TITLE
macOS: fix software keyboard input delete

### DIFF
--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -568,7 +568,7 @@ void swkbd_inputStringChanged()
 
 void swkbd_keyInput(uint32 keyCode)
 {
-	if (keyCode == 8) // backspace
+	if (keyCode == 8 || keyCode == 127) // backspace || backwards delete
 	{
 		if (swkbdInternalState->formStringLength > 0)
 			swkbdInternalState->formStringLength--;


### PR DESCRIPTION
On macOS delete (hex 7f) is used instead of backspace (hex 8) for removing a character before the cursor