### PR TITLE
Macos Optimization

### DIFF
--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -351,10 +351,9 @@ bool match_any_of(T1 value, T2 compareTo, Types&&... others)
 #endif
 }
 
-
 [[nodiscard]] static std::chrono::steady_clock::time_point tick_cached() noexcept
 {
-#ifdef _WIN32
+#if BOOST_OS_WINDOWS
     // get current time
 	static const long long _Freq = _Query_perf_frequency();	// doesn't change after system boot
 	const long long _Ctr = _Query_perf_counter();
@@ -362,11 +361,14 @@ bool match_any_of(T1 value, T2 compareTo, Types&&... others)
 	const long long _Whole = (_Ctr / _Freq) * std::nano::den;
 	const long long _Part = (_Ctr % _Freq) * std::nano::den / _Freq;
 	return (std::chrono::steady_clock::time_point(std::chrono::nanoseconds(_Whole + _Part)));
-#else
+#elif BOOST_OS_LINUX
 	struct timespec tp;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 	return std::chrono::steady_clock::time_point(
 		std::chrono::seconds(tp.tv_sec) + std::chrono::nanoseconds(tp.tv_nsec));
+#elif BOOST_OS_MACOS
+	return std::chrono::steady_clock::time_point(
+		std::chrono::nanoseconds(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)));
 #endif
 }
 

--- a/src/Common/unix/platform.cpp
+++ b/src/Common/unix/platform.cpp
@@ -1,9 +1,14 @@
-#include <stdint.h>
-#include <time.h>
+#include <cstdint>
+#include <ctime>
 
 uint32_t GetTickCount()
 {
-        struct timespec ts;
+#if BOOST_OS_LINUX
+	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-        return (1000 * ts.tv_sec + ts.tv_nsec / 1000000);
+	return (1000 * ts.tv_sec + ts.tv_nsec / 1000000);
+#elif BOOST_OS_MACOS
+	return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) / 1000000;
+#endif
+
 }

--- a/src/util/highresolutiontimer/HighResolutionTimer.cpp
+++ b/src/util/highresolutiontimer/HighResolutionTimer.cpp
@@ -7,11 +7,13 @@ HighResolutionTimer HighResolutionTimer::now()
 	LARGE_INTEGER pc;
 	QueryPerformanceCounter(&pc);
 	return HighResolutionTimer(pc.QuadPart);
-#else
+#elif BOOST_OS_LINUX
     timespec pc;
     clock_gettime(CLOCK_MONOTONIC_RAW, &pc);
     uint64 nsec = (uint64)pc.tv_sec * (uint64)1000000000 + (uint64)pc.tv_nsec;
     return HighResolutionTimer(nsec);
+#elif BOOST_OS_MACOS
+	return HighResolutionTimer(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW));
 #endif
 }
 
@@ -19,7 +21,6 @@ HRTick HighResolutionTimer::getFrequency()
 {
 	return m_freq;
 }
-
 
 uint64 HighResolutionTimer::m_freq = []() -> uint64 {
 #if BOOST_OS_WINDOWS


### PR DESCRIPTION
clock_gettime_nsec_np is an optimization of clock_gettime, roughly 90% time needed from some [testing](https://gist.github.com/Tillsunset/61d8681c7b681b8f0922fca068db6ca1). It is specific to macOS though.

CLOCK_MONOTONIC_RAW_APPROX is another potential optimization for macOS, roughly 50% time needed compared to CLOCK_MONOTONIC_RAW. But typically only guarantees 1 millisecond accuracy. Its potential usage and overall speedup is extremely debatable. I could see it potentially being used in GetTickCount() and tick_cached(). 

clock_getres also always returns 1 nanosecond, I'm not sure if that is the intended purpose when used in HighResolutionTimer::getFrequency(). Feedback needed