### PR TITLE
Vulkan: Use the correct resolution for out-of-date check

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2636,9 +2636,9 @@ bool VulkanRenderer::UpdateSwapchainProperties(bool mainWindow)
 
 	int width, height;
 	if (mainWindow)
-		gui_getWindowSize(width, height);
+		gui_getWindowPhysSize(width, height);
 	else
-		gui_getPadWindowSize(width, height);
+		gui_getPadWindowPhysSize(width, height);
 	auto extent = chainInfo.getExtent();
 	if (width != extent.width || height != extent.height)
 		stateChanged = true;


### PR DESCRIPTION
Fixes macOS crash on newer versions.