### PR TITLE
UI: add option to hide the icon column

### DIFF
--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -91,6 +91,8 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	game_list_style = gamelist.get("style", 0);
 	game_list_column_order = gamelist.get("order", "");
 
+	show_icon_column = parser.get("show_icon_column", true);
+
 	// return default width if value in config file out of range
 	auto loadColumnSize = [&gamelist] (const char *name, uint32 defaultWidth)
 	{
@@ -390,6 +392,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	psize.set<sint32>("x", pad_size.x);
 	psize.set<sint32>("y", pad_size.y);
 	config.set<bool>("pad_maximized", pad_maximized);
+	config.set<bool>("show_icon_column" , show_icon_column);
 
 	auto gamelist = config.set("GameList");
 	gamelist.set("style", game_list_style);

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -409,6 +409,8 @@ struct CemuConfig
 	ConfigValue<bool> did_show_graphic_pack_download{false};
 	ConfigValue<bool> did_show_macos_disclaimer{false};
 
+	ConfigValue<bool> show_icon_column{ false };
+
 	int game_list_style = 0;
 	std::string game_list_column_order;
 	struct

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -72,7 +72,6 @@ wxGameList::wxGameList(wxWindow* parent, wxWindowID id)
 	const auto& config = GetConfig();
 
 	InsertColumn(ColumnHiddenName, "", wxLIST_FORMAT_LEFT, 0);
-	InsertColumn(ColumnIcon, "", wxLIST_FORMAT_LEFT, kListIconWidth);
 	InsertColumn(ColumnName, _("Game"), wxLIST_FORMAT_LEFT, config.column_width.name);
 	InsertColumn(ColumnVersion, _("Version"), wxLIST_FORMAT_RIGHT, config.column_width.version);
 	InsertColumn(ColumnDLC, _("DLC"), wxLIST_FORMAT_RIGHT, config.column_width.dlc);
@@ -230,8 +229,6 @@ int wxGameList::GetColumnDefaultWidth(int column)
 {
 	switch (column)
 	{
-	case ColumnIcon:
-		return kListIconWidth;
 	case ColumnName:
 		return DefaultColumnSize::name;
 	case ColumnVersion:
@@ -777,8 +774,6 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 			{
 				switch (column)
 				{
-				case ColumnIcon:
-					break;
 				case ColumnName:
 					config.column_width.name = DefaultColumnSize::name;
 					break;
@@ -829,7 +824,6 @@ void wxGameList::ApplyGameListColumnWidths()
 {
 	const auto& config = GetConfig();
 	wxWindowUpdateLocker lock(this);
-	SetColumnWidth(ColumnIcon, kListIconWidth);
 	SetColumnWidth(ColumnName, config.column_width.name);
 	SetColumnWidth(ColumnVersion, config.column_width.version);
 	SetColumnWidth(ColumnDLC, config.column_width.dlc);
@@ -861,7 +855,7 @@ void wxGameList::OnColumnBeginResize(wxListEvent& event)
 		}
 #endif
 	}
-	if (width == 0 || column == ColumnIcon || column == last_col_index) // dont resize hidden name, icon, and last column
+	if (width == 0 || column == last_col_index) // dont resize hidden name and last column
 		event.Veto();
 	else
 		event.Skip();
@@ -955,7 +949,7 @@ void wxGameList::OnGameEntryUpdatedByTitleId(wxTitleIdEvent& event)
 
 	if (m_style == Style::kList)
 	{
-		SetItemColumnImage(index, ColumnIcon, icon_small);
+		SetItemColumnImage(index, ColumnName, icon_small);
 
 		SetItem(index, ColumnName, wxHelper::FromUtf8(GetNameByTitleId(baseTitleId)));
 

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -72,6 +72,7 @@ wxGameList::wxGameList(wxWindow* parent, wxWindowID id)
 	const auto& config = GetConfig();
 
 	InsertColumn(ColumnHiddenName, "", wxLIST_FORMAT_LEFT, 0);
+	InsertColumn(ColumnIcon, "", wxLIST_FORMAT_LEFT, kListIconWidth);
 	InsertColumn(ColumnName, _("Game"), wxLIST_FORMAT_LEFT, config.column_width.name);
 	InsertColumn(ColumnVersion, _("Version"), wxLIST_FORMAT_RIGHT, config.column_width.version);
 	InsertColumn(ColumnDLC, _("DLC"), wxLIST_FORMAT_RIGHT, config.column_width.dlc);
@@ -229,6 +230,8 @@ int wxGameList::GetColumnDefaultWidth(int column)
 {
 	switch (column)
 	{
+	case ColumnIcon:
+		return kListIconWidth;
 	case ColumnName:
 		return DefaultColumnSize::name;
 	case ColumnVersion:
@@ -774,6 +777,8 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 			{
 				switch (column)
 				{
+				case ColumnIcon:
+					break;
 				case ColumnName:
 					config.column_width.name = DefaultColumnSize::name;
 					break;
@@ -824,6 +829,7 @@ void wxGameList::ApplyGameListColumnWidths()
 {
 	const auto& config = GetConfig();
 	wxWindowUpdateLocker lock(this);
+	SetColumnWidth(ColumnIcon, kListIconWidth);
 	SetColumnWidth(ColumnName, config.column_width.name);
 	SetColumnWidth(ColumnVersion, config.column_width.version);
 	SetColumnWidth(ColumnDLC, config.column_width.dlc);
@@ -855,7 +861,7 @@ void wxGameList::OnColumnBeginResize(wxListEvent& event)
 		}
 #endif
 	}
-	if (width == 0 || column == last_col_index) // dont resize hidden name and last column
+	if (width == 0 || column == ColumnIcon || column == last_col_index) // dont resize hidden name, icon, and last column
 		event.Veto();
 	else
 		event.Skip();
@@ -949,7 +955,7 @@ void wxGameList::OnGameEntryUpdatedByTitleId(wxTitleIdEvent& event)
 
 	if (m_style == Style::kList)
 	{
-		SetItemColumnImage(index, ColumnName, icon_small);
+		SetItemColumnImage(index, ColumnIcon, icon_small);
 
 		SetItem(index, ColumnName, wxHelper::FromUtf8(GetNameByTitleId(baseTitleId)));
 

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -72,7 +72,10 @@ wxGameList::wxGameList(wxWindow* parent, wxWindowID id)
 	const auto& config = GetConfig();
 
 	InsertColumn(ColumnHiddenName, "", wxLIST_FORMAT_LEFT, 0);
-	InsertColumn(ColumnIcon, "", wxLIST_FORMAT_LEFT, kListIconWidth);
+	if(config.show_icon_column)
+		InsertColumn(ColumnIcon, _("Icon"), wxLIST_FORMAT_LEFT, kListIconWidth);
+	else
+		InsertColumn(ColumnIcon, _("Icon"), wxLIST_FORMAT_LEFT, 0);
 	InsertColumn(ColumnName, _("Game"), wxLIST_FORMAT_LEFT, config.column_width.name);
 	InsertColumn(ColumnVersion, _("Version"), wxLIST_FORMAT_RIGHT, config.column_width.version);
 	InsertColumn(ColumnDLC, _("DLC"), wxLIST_FORMAT_RIGHT, config.column_width.dlc);
@@ -723,6 +726,7 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 		ResetWidth = wxID_HIGHEST + 1,
 		ResetOrder,
 
+		ShowIcon,
 		ShowName,
 		ShowVersion,
 		ShowDlc,
@@ -738,6 +742,7 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 	menu.Append(ResetOrder, _("Reset &order"))	;
 
 	menu.AppendSeparator();
+	menu.AppendCheckItem(ShowIcon, _("Show &icon"))->Check(GetColumnWidth(ColumnIcon) > 0);
 	menu.AppendCheckItem(ShowName, _("Show &name"))->Check(GetColumnWidth(ColumnName) > 0);
 	menu.AppendCheckItem(ShowVersion, _("Show &version"))->Check(GetColumnWidth(ColumnVersion) > 0);
 	menu.AppendCheckItem(ShowDlc, _("Show &dlc"))->Check(GetColumnWidth(ColumnDLC) > 0);
@@ -755,6 +760,9 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 
 			switch (event.GetId())
 			{
+			case ShowIcon:
+				config.show_icon_column = menu->IsChecked(ShowIcon);
+				break;
 			case ShowName:
 				config.column_width.name = menu->IsChecked(ShowName) ? DefaultColumnSize::name : 0;
 				break;
@@ -829,7 +837,10 @@ void wxGameList::ApplyGameListColumnWidths()
 {
 	const auto& config = GetConfig();
 	wxWindowUpdateLocker lock(this);
-	SetColumnWidth(ColumnIcon, kListIconWidth);
+	if(config.show_icon_column)
+		SetColumnWidth(ColumnIcon, kListIconWidth);
+	else
+		SetColumnWidth(ColumnIcon, 0);
 	SetColumnWidth(ColumnName, config.column_width.name);
 	SetColumnWidth(ColumnVersion, config.column_width.version);
 	SetColumnWidth(ColumnDLC, config.column_width.dlc);

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -68,6 +68,7 @@ private:
 	enum ItemColumns
 	{
 		ColumnHiddenName = 0,
+		ColumnIcon,
 		ColumnName,
 		ColumnVersion,
 		ColumnDLC,

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -68,7 +68,6 @@ private:
 	enum ItemColumns
 	{
 		ColumnHiddenName = 0,
-		ColumnIcon,
 		ColumnName,
 		ColumnVersion,
 		ColumnDLC,


### PR DESCRIPTION
Remove the icon column and display the icon in the name column.
Before:
![Screenshot_20230106_111429](https://user-images.githubusercontent.com/37044560/210971200-926d60b6-4a2e-40c4-ae61-9db106f41e74.png)
After:
![Screenshot_20230106_111346](https://user-images.githubusercontent.com/37044560/210971234-f7b0696b-45c2-4f9f-8998-0178a8e01de9.png)

