### PR TITLE
Various fixes + readback performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bin/title_list_cache.xml
 bin/debugger/*
 bin/sdcard/*
 bin/screenshots/*
+bin/dump/*
 
 !bin/shaderCache/info.txt
 bin/shaderCache/*

--- a/src/Cafe/HW/Espresso/Const.h
+++ b/src/Cafe/HW/Espresso/Const.h
@@ -8,4 +8,5 @@ namespace Espresso
 	constexpr inline uint64 BUS_CLOCK = 248625000;
 	constexpr inline uint64 TIMER_CLOCK = BUS_CLOCK / 4;
 
+	constexpr inline uint32 MEM_PAGE_SIZE = 0x20000;
 };

--- a/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
@@ -224,7 +224,6 @@ void LatteCP_itIndirectBufferDepr(uint32 nWords)
 	uint32 physicalAddressHigh = readU32(); // unused
 	uint32 sizeInDWords = readU32();
 	uint32 displayListSize = sizeInDWords * 4;
-	cemu_assert_debug(displayListSize >= 4);
 	DrawPassContext drawPassCtx;
 	LatteCP_processCommandBuffer(memory_getPointerFromPhysicalOffset(physicalAddress), displayListSize, drawPassCtx);
 	if (drawPassCtx.isWithinDrawPass())

--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
@@ -746,7 +746,7 @@ void LatteTextureLoader_writeReadbackTextureToMemory(LatteTextureDefinition* tex
 		return;
 	}
 
-	cemuLog_log(LogType::TextureReadback, "[WriteReadbackTex] PhysAddr {:08x} Res {}x{} Fmt {} Slice {} Mip {}", textureData->physAddress, textureData->width, textureData->height, textureData->format, sliceIndex, mipIndex);
+	cemuLog_log(LogType::TextureReadback, "[TextureReadback-Write] PhysAddr {:08x} Res {}x{} Fmt {} Slice {} Mip {}", textureData->physAddress, textureData->width, textureData->height, textureData->format, sliceIndex, mipIndex);
 
 	if (textureData->tileMode == Latte::E_HWTILEMODE::TM_LINEAR_ALIGNED)
 	{

--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
@@ -746,6 +746,8 @@ void LatteTextureLoader_writeReadbackTextureToMemory(LatteTextureDefinition* tex
 		return;
 	}
 
+	cemuLog_log(LogType::TextureReadback, "[WriteReadbackTex] PhysAddr {:08x} Res {}x{} Fmt {} Slice {} Mip {}", textureData->physAddress, textureData->width, textureData->height, textureData->format, sliceIndex, mipIndex);
+
 	if (textureData->tileMode == Latte::E_HWTILEMODE::TM_LINEAR_ALIGNED)
 	{
 		uint32 pitch = textureLoader.width;

--- a/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
@@ -21,6 +21,7 @@ std::queue<LatteTextureReadbackInfo*> sTextureActiveReadbackQueue; // readbacks 
 
 void LatteTextureReadback_StartTransfer(LatteTextureView* textureView)
 {
+	cemuLog_log(LogType::TextureReadback, "[TextureReadback-Start] PhysAddr {:08x} Res {}x{} Fmt {} Slice {} Mip {}", textureView->baseTexture->physAddress, textureView->baseTexture->width, textureView->baseTexture->height, textureView->baseTexture->format, textureView->firstSlice, textureView->firstMip);
 	// create info entry and store in ordered linked list
 	LatteTextureReadbackInfo* readbackInfo = g_renderer->texture_createReadback(textureView);
 	sTextureActiveReadbackQueue.push(readbackInfo);
@@ -30,8 +31,8 @@ void LatteTextureReadback_StartTransfer(LatteTextureView* textureView)
 }
 
 /*
- * Checks for queued transfers and starts them if at least one drawcall has passed since the last write
- * Called after a draw operation has finished
+ * Checks for queued transfers and starts them if at least five drawcalls have passed since the last write
+ * Called after a draw sequence is completed
  * Returns true if at least one transfer was started
  */
 bool LatteTextureReadback_Update(bool forceStart)
@@ -41,12 +42,14 @@ bool LatteTextureReadback_Update(bool forceStart)
 	{
 		LatteTextureReadbackQueueEntry& entry = sTextureScheduledReadbacks[i];
 		uint32 numPassedDrawcalls = LatteGPUState.drawCallCounter - entry.lastUpdateDrawcallIndex;
-		// initiate transfer
-		LatteTextureReadback_StartTransfer(entry.textureView);
-		// remove element
-		vectorRemoveByIndex(sTextureScheduledReadbacks, i);
-		i--;
-		hasStartedTransfer = true;
+		if (forceStart || numPassedDrawcalls >= 5)
+		{
+			LatteTextureReadback_StartTransfer(entry.textureView);
+			// remove element
+			vectorRemoveByIndex(sTextureScheduledReadbacks, i);
+			i--;
+			hasStartedTransfer = true;
+		}
 	}
 	return hasStartedTransfer;
 }

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
@@ -304,8 +304,7 @@ namespace LatteDecompiler
 		}
 		else if (decompilerContext->shaderType == LatteConst::ShaderType::Pixel)
 		{
-			//fCStr_shaderSource->append("#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy+uf_fragCoordScale.zw,gl_FragCoord.zw)" STR_LINEBREAK);
-			src->add("#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)" _CRLF);
+			src->add("#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.z, 1.0/gl_FragCoord.w)" _CRLF);
 		}
 		src->add("#else" _CRLF);
 		// OpenGL defines

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -59,7 +59,6 @@ uint32 VulkanPipelineStableCache::BeginLoading(uint64 cacheTitleId)
 
 	// open cache file or create it
 	cemu_assert_debug(s_cache == nullptr);
-	const uint32 cacheFileVersion = 1;
 	s_cache = FileCache::Open(pathCacheFile.generic_wstring(), true, LatteShaderCache_getPipelineCacheExtraVersion(cacheTitleId));
 	if (!s_cache)
 	{

--- a/src/Cafe/HW/MMU/MMU.h
+++ b/src/Cafe/HW/MMU/MMU.h
@@ -138,8 +138,6 @@ MMURange* memory_getMMURangeByAddress(MPTR address);
 
 bool memory_isAddressRangeAccessible(MPTR virtualAddress, uint32 size);
 
-#define MEMORY_PAGE_SIZE					(0x20000)
-
 #define MEMORY_CODELOW0_ADDR				(0x00010000)
 #define MEMORY_CODELOW0_SIZE				(0x000F0000) // ~1MB
 
@@ -158,27 +156,11 @@ bool memory_isAddressRangeAccessible(MPTR virtualAddress, uint32 size);
 #define MEMORY_FGBUCKET_AREA_ADDR			(0xE0000000) // actual offset is 0xE0000000 according to PPC kernel
 #define MEMORY_FGBUCKET_AREA_SIZE			(0x04000000) // 64MB split up into multiple subareas, size is verified with value from PPC kernel
 
-// move these to rpl loader
-#define MEMORY_SDA_SIZE						(0x10000)
-#define MEMORY_SDA2_SIZE					(0x10000)
-
-//#define MEMORY_SYSTEM_AREA_ADDR				(0x90000000)
-//#define MEMORY_SYSTEM_AREA_SIZE				(0x02000000) // 32MB of memory area that can't be allocated by the game directly - this is emulator specific.
-
-//#define MEMORY_SYSTEM_AREA_ADDR				(0x7C000000)
-//#define MEMORY_SYSTEM_AREA_SIZE				(0x02000000) // 32MB of memory area that can't be allocated by the game directly - this is emulator specific.
-// moved the sys area below 0x80000000. Turns out that some games treat stack/os-object pointers as signed and run into issues if the highest bit is set (e.g. Monster Hunter Frontier G)
-
 #define MEMORY_TILINGAPERTURE_AREA_ADDR		(0xE8000000)
 #define MEMORY_TILINGAPERTURE_AREA_SIZE		(0x02000000) // 32MB
 
 #define MEMORY_OVERLAY_AREA_OFFSET			(0xA0000000)
-#define MEMORY_OVERLAY_AREA_SIZE			(448*1024*1024) // 448MB (todo: verify if correct)
-
-#define MEMORY_MAPABLE_PHYS_AREA_OFFSET		(0x80000000) // todo: verify offset
-#define MEMORY_MAPABLE_PHYS_AREA_SIZE		(32*1024*1024) // todo: verify size
-#define MEMORY_MAPABLE_VIRT_AREA_OFFSET		(0x70000000) // todo: verify offset
-#define MEMORY_MAPABLE_VIRT_AREA_SIZE		(32*1024*1024) // todo: verify size
+#define MEMORY_OVERLAY_AREA_SIZE			(448*1024*1024) // 448MB (recycled background app memory)
 
 #define MEMORY_MEM1_AREA_ADDR				(0xF4000000)
 #define MEMORY_MEM1_AREA_SIZE				(0x02000000) // 32MB
@@ -191,7 +173,6 @@ bool memory_isAddressRangeAccessible(MPTR virtualAddress, uint32 size);
 
 static uint16 CPU_swapEndianU16(uint16 v)
 {
-	//return _byteswap_ushort(v);
 	return (v>>8)|(v<<8);
 }
 

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -283,7 +283,7 @@ namespace iosu
 				return -0x400;
 			}
 			*fileHandle = fsFileHandle;
-			cemuLog_log(LogType::File, "Open file {} (access: {} result: ok handle: 0x{})", path, accessModifierStr, (uint32)*fileHandle);
+			cemuLog_log(LogType::CoreinitFile, "Open file {} (access: {} result: ok handle: 0x{})", path, accessModifierStr, (uint32)*fileHandle);
 			return (FSStatus)FS_RESULT::SUCCESS;
 		}
 
@@ -307,7 +307,7 @@ namespace iosu
 				return -0x400;
 			}
 			*dirHandle = fsDirHandle;
-			cemuLog_log(LogType::File, "Open directory {} (result: ok handle: 0x{})", path, (uint32)*dirHandle);
+			cemuLog_log(LogType::CoreinitFile, "Open directory {} (result: ok handle: 0x{})", path, (uint32)*dirHandle);
 			return (FSStatus)FS_RESULT::SUCCESS;
 		}
 

--- a/src/Cafe/OS/libs/coreinit/coreinit.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit.cpp
@@ -366,10 +366,11 @@ void coreinit_load()
 	coreinit::InitializeMessageQueue();
 	coreinit::InitializeIPC();
 	coreinit::InitializeIPCBuf();
+	coreinit::InitializeMemoryMapping();
 	coreinit::InitializeCodeGen();
 	coreinit::InitializeCoroutine();
 	coreinit::InitializeOSScreen();
-
+	
 	// legacy mem stuff
 	coreinit::expheap_load();
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -1564,96 +1564,96 @@ namespace coreinit
 
 	void InitializeFS()
 	{
-		cafeExportRegister("coreinit", FSInit, LogType::File);
-		cafeExportRegister("coreinit", FSShutdown, LogType::File);
+		cafeExportRegister("coreinit", FSInit, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSShutdown, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSGetMountSource, LogType::File);
-		cafeExportRegister("coreinit", FSGetMountSourceNext, LogType::File);
+		cafeExportRegister("coreinit", FSGetMountSource, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetMountSourceNext, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSMount, LogType::File);
-		cafeExportRegister("coreinit", FSBindMount, LogType::File);
+		cafeExportRegister("coreinit", FSMount, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSBindMount, LogType::CoreinitFile);
 
 		// client management
-		cafeExportRegister("coreinit", FSAddClientEx, LogType::File);
-		cafeExportRegister("coreinit", FSAddClient, LogType::File);
-		cafeExportRegister("coreinit", FSDelClient, LogType::File);
-		cafeExportRegister("coreinit", FSGetClientNum, LogType::File);
+		cafeExportRegister("coreinit", FSAddClientEx, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSAddClient, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSDelClient, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetClientNum, LogType::CoreinitFile);
 
 		// cmd
-		cafeExportRegister("coreinit", FSInitCmdBlock, LogType::File);
-		cafeExportRegister("coreinit", FSGetAsyncResult, LogType::File);
+		cafeExportRegister("coreinit", FSInitCmdBlock, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetAsyncResult, LogType::CoreinitFile);
 
 		// file operations
-		cafeExportRegister("coreinit", FSOpenFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSOpenFile, LogType::File);
-		cafeExportRegister("coreinit", FSOpenFileExAsync, LogType::File);
-		cafeExportRegister("coreinit", FSOpenFileEx, LogType::File);
-		cafeExportRegister("coreinit", FSCloseFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSCloseFile, LogType::File);
+		cafeExportRegister("coreinit", FSOpenFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSOpenFile, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSOpenFileExAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSOpenFileEx, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSCloseFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSCloseFile, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSReadFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSReadFile, LogType::File);
-		cafeExportRegister("coreinit", FSReadFileWithPosAsync, LogType::File);
-		cafeExportRegister("coreinit", FSReadFileWithPos, LogType::File);
+		cafeExportRegister("coreinit", FSReadFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSReadFile, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSReadFileWithPosAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSReadFileWithPos, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSWriteFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSWriteFile, LogType::File);
-		cafeExportRegister("coreinit", FSWriteFileWithPosAsync, LogType::File);
-		cafeExportRegister("coreinit", FSWriteFileWithPos, LogType::File);
+		cafeExportRegister("coreinit", FSWriteFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSWriteFile, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSWriteFileWithPosAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSWriteFileWithPos, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSSetPosFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSSetPosFile, LogType::File);
-		cafeExportRegister("coreinit", FSGetPosFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSGetPosFile, LogType::File);
+		cafeExportRegister("coreinit", FSSetPosFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSSetPosFile, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetPosFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetPosFile, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSAppendFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSAppendFile, LogType::File);
+		cafeExportRegister("coreinit", FSAppendFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSAppendFile, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSTruncateFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSTruncateFile, LogType::File);
+		cafeExportRegister("coreinit", FSTruncateFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSTruncateFile, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSRenameAsync, LogType::File);
-		cafeExportRegister("coreinit", FSRename, LogType::File);
-		cafeExportRegister("coreinit", FSRemoveAsync, LogType::File);
-		cafeExportRegister("coreinit", FSRemove, LogType::File);
-		cafeExportRegister("coreinit", FSMakeDirAsync, LogType::File);
-		cafeExportRegister("coreinit", FSMakeDir, LogType::File);
-		cafeExportRegister("coreinit", FSChangeDirAsync, LogType::File);
-		cafeExportRegister("coreinit", FSChangeDir, LogType::File);
-		cafeExportRegister("coreinit", FSGetCwdAsync, LogType::File);
-		cafeExportRegister("coreinit", FSGetCwd, LogType::File);		
+		cafeExportRegister("coreinit", FSRenameAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSRename, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSRemoveAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSRemove, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSMakeDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSMakeDir, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSChangeDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSChangeDir, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetCwdAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetCwd, LogType::CoreinitFile);		
 
-		cafeExportRegister("coreinit", FSIsEofAsync, LogType::File);
-		cafeExportRegister("coreinit", FSIsEof, LogType::File);
+		cafeExportRegister("coreinit", FSIsEofAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSIsEof, LogType::CoreinitFile);
 
 		// directory operations
-		cafeExportRegister("coreinit", FSOpenDirAsync, LogType::File);
-		cafeExportRegister("coreinit", FSOpenDir, LogType::File);
-		cafeExportRegister("coreinit", FSReadDirAsync, LogType::File);
-		cafeExportRegister("coreinit", FSReadDir, LogType::File);
-		cafeExportRegister("coreinit", FSCloseDirAsync, LogType::File);
-		cafeExportRegister("coreinit", FSCloseDir, LogType::File);
+		cafeExportRegister("coreinit", FSOpenDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSOpenDir, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSReadDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSReadDir, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSCloseDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSCloseDir, LogType::CoreinitFile);
 		
 		// stat
-		cafeExportRegister("coreinit", FSGetFreeSpaceSizeAsync, LogType::File);
-		cafeExportRegister("coreinit", FSGetFreeSpaceSize, LogType::File);
+		cafeExportRegister("coreinit", FSGetFreeSpaceSizeAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetFreeSpaceSize, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSGetStatAsync, LogType::File);
-		cafeExportRegister("coreinit", FSGetStat, LogType::File);
+		cafeExportRegister("coreinit", FSGetStatAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetStat, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSGetStatFileAsync, LogType::File);
-		cafeExportRegister("coreinit", FSGetStatFile, LogType::File);
+		cafeExportRegister("coreinit", FSGetStatFileAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetStatFile, LogType::CoreinitFile);
 
 		// misc
-		cafeExportRegister("coreinit", FSFlushQuotaAsync, LogType::File);
-		cafeExportRegister("coreinit", FSFlushQuota, LogType::File);
+		cafeExportRegister("coreinit", FSFlushQuotaAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSFlushQuota, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSSetUserData, LogType::File);
-		cafeExportRegister("coreinit", FSGetUserData, LogType::File);
+		cafeExportRegister("coreinit", FSSetUserData, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSGetUserData, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSGetCurrentCmdBlock, LogType::File);
+		cafeExportRegister("coreinit", FSGetCurrentCmdBlock, LogType::CoreinitFile);
 
-		cafeExportRegister("coreinit", FSGetVolumeState, LogType::File);
+		cafeExportRegister("coreinit", FSGetVolumeState, LogType::CoreinitFile);
 		cafeExportRegister("coreinit", FSGetErrorCodeForViewer, LogType::Placeholder);
 		cafeExportRegister("coreinit", FSGetLastErrorCodeForViewer, LogType::Placeholder);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -66,6 +66,11 @@ namespace coreinit
 
 	std::unordered_map<OSThread_t*, OSHostThread*> s_threadToFiber;
 
+	bool __CemuIsMulticoreMode()
+	{
+		return g_isMulticoreMode;
+	}
+
 	// create host thread (fiber) that will be used to run the PPC instance
 	// note that host threads are fibers and not actual threads
 	void __OSCreateHostThread(OSThread_t* thread)

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
@@ -488,6 +488,8 @@ namespace coreinit
 	void InitializeThread();
 	void InitializeConcurrency();
 
+	bool __CemuIsMulticoreMode();
+
 	OSThread_t* OSGetDefaultThread(sint32 coreIndex);
 	void* OSGetDefaultThreadStack(sint32 coreIndex, uint32& size);
 

--- a/src/Cafe/OS/libs/padscore/padscore.cpp
+++ b/src/Cafe/OS/libs/padscore/padscore.cpp
@@ -748,8 +748,8 @@ namespace padscore
 
 	void load()
 	{
-		cafeExportRegister("padscore", WPADIsMplsAttached, LogType::Input);
-		cafeExportRegister("padscore", WPADGetAccGravityUnit, LogType::Input);
+		cafeExportRegister("padscore", WPADIsMplsAttached, LogType::InputAPI);
+		cafeExportRegister("padscore", WPADGetAccGravityUnit, LogType::InputAPI);
 
 		// wpad
 		//osLib_addFunction("padscore", "WPADInit", padscore::export_WPADInit);

--- a/src/Cafe/OS/libs/vpad/vpad.cpp
+++ b/src/Cafe/OS/libs/vpad/vpad.cpp
@@ -1159,9 +1159,9 @@ namespace vpad
 
 void load()
 {
-	cafeExportRegister("vpad", VPADSetBtnRepeat, LogType::Input);
-	cafeExportRegister("vpad", VPADSetSamplingCallback, LogType::Input);
-	cafeExportRegister("vpad", VPADRead, LogType::Input);
+	cafeExportRegister("vpad", VPADSetBtnRepeat, LogType::InputAPI);
+	cafeExportRegister("vpad", VPADSetSamplingCallback, LogType::InputAPI);
+	cafeExportRegister("vpad", VPADRead, LogType::InputAPI);
 	
 	osLib_addFunction("vpad", "VPADGetAccParam", vpadExport_VPADGetAccParam);
 	osLib_addFunction("vpad", "VPADSetAccParam", vpadExport_VPADSetAccParam);

--- a/src/Cemu/Logging/CemuLogging.cpp
+++ b/src/Cemu/Logging/CemuLogging.cpp
@@ -33,16 +33,16 @@ struct _LogContext
 
 const std::map<LogType, std::string> g_logging_window_mapping
 {
-	{LogType::File, "Coreinit File-Access"},
+	{LogType::CoreinitFile, "Coreinit File-Access"},
 	{LogType::GX2, "GX2"},
 	{LogType::ThreadSync, "Coreinit Thread-Synchronization"},
 	{LogType::SoundAPI, "Audio"},
-	{LogType::Input, "Input"},
+	{LogType::InputAPI, "Input"},
 	{LogType::Socket, "Socket"},
 	{LogType::Save, "Save"},
 	{LogType::CoreinitMem, "Coreinit Memory"},
 	{LogType::H264, "H264"},
-	{LogType::OpenGL, "OpenGL"},
+	{LogType::OpenGLLogging, "OpenGL"},
 	{LogType::TextureCache, "Texture Cache"},
 	{LogType::nn_nfp, "NFP"},
 };

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -2,6 +2,7 @@
 
 enum class LogType : sint32
 {
+	// note: IDs must not exceed 63
 	Placeholder = -2,
 	None = -1,
 	Force = 0, // this logging type is always on
@@ -28,12 +29,14 @@ enum class LogType : sint32
 	PPC_IPC = 20,
 	NN_AOC = 21,
 	NN_PDM = 22,
+	
+	TextureReadback = 30,
 
 	ProcUi = 40,
 
-	TextureReadback = 60,
+	APIErrors = 0, // alias for Force. Logs bad parameters or other API errors in OS libs
 
-	APIErrors = 0, // alias for 0. Logs bad parameters or other API errors in OS libs
+	
 };
 
 template <>

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -5,17 +5,17 @@ enum class LogType : sint32
 	Placeholder = -2,
 	None = -1,
 	Force = 0, // this logging type is always on
-	File = 1, // coreinit file?
+	CoreinitFile = 1,
 	GX2 = 2,
 	UnsupportedAPI = 3,
 	ThreadSync = 4,
 	SoundAPI = 5, // any audio related API
-	Input = 6, // any input related API
+	InputAPI = 6, // any input related API
 	Socket = 7,
 	Save = 8,
 	CoreinitMem = 9, // coreinit memory functions
 	H264 = 10,
-	OpenGL = 11, // OpenGL debug logging
+	OpenGLLogging = 11, // OpenGL debug logging
 	TextureCache = 12, // texture cache warnings and info
 	VulkanValidation = 13, // Vulkan validation layer
 	nn_nfp = 14, // nn_nfp (Amiibo) API
@@ -30,6 +30,8 @@ enum class LogType : sint32
 	NN_PDM = 22,
 
 	ProcUi = 40,
+
+	TextureReadback = 60,
 
 	APIErrors = 0, // alias for 0. Logs bad parameters or other API errors in OS libs
 };

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -23,6 +23,7 @@ enum class LogType : sint32
 	CoreinitMP = 16,
 	CoreinitThread = 17,
 	CoreinitLogging = 18, // OSReport, OSConsoleWrite etc.
+	CoreinitMemoryMapping = 19, // OSGetAvailPhysAddrRange, OSAllocVirtAddr, OSMapMemory etc.
 
 	PPC_IPC = 20,
 	NN_AOC = 21,

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -516,3 +516,15 @@ inline uint32 GetTitleIdLow(uint64 titleId)
 #include "Cafe/HW/MMU/MMU.h"
 #include "Cafe/HW/Espresso/PPCState.h"
 #include "Cafe/HW/Espresso/PPCCallback.h"
+
+// useful C++23 stuff that isn't yet widely supported
+
+// std::to_underlying
+namespace stdx
+{
+    template <typename EnumT, typename = std::enable_if_t < std::is_enum<EnumT>{} >>
+        constexpr std::underlying_type_t<EnumT> to_underlying(EnumT e) noexcept {
+        return static_cast<std::underlying_type_t<EnumT>>(e);
+    };
+}
+

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2113,26 +2113,27 @@ void MainWindow::RecreateMenu()
 	// debug->logging submenu
 	wxMenu* debugLoggingMenu = new wxMenu;
 
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_UNSUPPORTED_API, _("&Unsupported API calls"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_UNSUPPORTED_API));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_COREINIT_LOGGING, _("&Coreinit Logging (OSReport/OSConsole)"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_COREINIT_LOGGING));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_FILE, _("&Coreinit File-Access"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_FILE));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_THREADSYNC, _("&Coreinit Thread-Synchronization API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_THREADSYNC));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_COREINIT_MEM, _("&Coreinit Memory API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_COREINIT_MEM));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_COREINIT_MP, _("&Coreinit MP API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_COREINIT_MP));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_COREINIT_THREAD, _("&Coreinit Thread API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_COREINIT_THREAD));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_NFP, _("&NN NFP"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_NFP));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_GX2, _("&GX2 API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_GX2));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_SNDAPI, _("&Audio API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_SNDAPI));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_INPUT, _("&Input API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_INPUT));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_SOCKET, _("&Socket API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_SOCKET));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_SAVE, _("&Save API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_SAVE));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_H264, _("&H264 API"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_H264));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::UnsupportedAPI), _("&Unsupported API calls"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::UnsupportedAPI));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitLogging), _("&Coreinit Logging (OSReport/OSConsole)"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitLogging));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitFile), _("&Coreinit File-Access API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitFile));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::ThreadSync), _("&Coreinit Thread-Synchronization API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::ThreadSync));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitMem), _("&Coreinit Memory API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitMem));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitMP), _("&Coreinit MP API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitMP));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitThread), _("&Coreinit Thread API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitThread));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::nn_nfp), _("&NN NFP"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::nn_nfp));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::GX2), _("&GX2 API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::GX2));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::SoundAPI), _("&Audio API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::SoundAPI));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::InputAPI), _("&Input API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::InputAPI));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::Socket), _("&Socket API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::Socket));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::Save), _("&Save API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::Save));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::H264), _("&H264 API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::H264));
 	debugLoggingMenu->AppendSeparator();
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_PATCHES, _("&Graphic pack patches"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_PATCHES));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_TEXTURE_CACHE, _("&Texture cache warnings"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_TEXTURE_CACHE));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::Patches), _("&Graphic pack patches"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::Patches));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::TextureCache), _("&Texture cache warnings"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::TextureCache));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::TextureReadback), _("&Texture readback"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::TextureReadback));
 	debugLoggingMenu->AppendSeparator();
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_OPENGL, _("&OpenGL debug output"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_OPENGL));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_VULKAN_VALIDATION, _("&Vulkan validation layer (slow)"), wxEmptyString)->Check(cafeLog_isLoggingFlagEnabled(LOG_TYPE_VULKAN_VALIDATION));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::OpenGLLogging), _("&OpenGL debug output"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::OpenGLLogging));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::VulkanValidation), _("&Vulkan validation layer (slow)"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::VulkanValidation));
 #ifdef CEMU_DEBUG_ASSERT
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_ADVANCED_PPC_INFO, _("&Log PPC context for API"), wxEmptyString)->Check(cemuLog_advancedPPCLoggingEnabled());
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -134,7 +134,7 @@ enum
 
 	// debug->logging
 	MAINFRAME_MENU_ID_DEBUG_LOGGING0 = 21500,
-	MAINFRAME_MENU_ID_DEBUG_ADVANCED_PPC_INFO,
+	MAINFRAME_MENU_ID_DEBUG_ADVANCED_PPC_INFO = 21599,
 	// debug->dump
 	MAINFRAME_MENU_ID_DEBUG_DUMP_TEXTURES = 21600,
 	MAINFRAME_MENU_ID_DEBUG_DUMP_SHADERS,
@@ -195,7 +195,7 @@ EVT_MENU(MAINFRAME_MENU_ID_TIMER_SPEED_0125X, MainWindow::OnDebugSetting)
 EVT_MENU(MAINFRAME_MENU_ID_NFC_TOUCH_NFC_FILE, MainWindow::OnNFCMenu)
 EVT_MENU_RANGE(MAINFRAME_MENU_ID_NFC_RECENT_0 + 0, MAINFRAME_MENU_ID_NFC_RECENT_LAST, MainWindow::OnNFCMenu)
 // debug -> logging menu
-EVT_MENU_RANGE(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 0, MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 19, MainWindow::OnDebugLoggingToggleFlagGeneric)
+EVT_MENU_RANGE(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 0, MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 98, MainWindow::OnDebugLoggingToggleFlagGeneric)
 EVT_MENU(MAINFRAME_MENU_ID_DEBUG_ADVANCED_PPC_INFO, MainWindow::OnPPCInfoToggle)
 // debug -> dump menu
 EVT_MENU(MAINFRAME_MENU_ID_DEBUG_DUMP_TEXTURES, MainWindow::OnDebugDumpUsedTextures)
@@ -1040,7 +1040,7 @@ void MainWindow::OnDebugLoggingToggleFlagGeneric(wxCommandEvent& event)
 	sint32 loggingIdBase = MAINFRAME_MENU_ID_DEBUG_LOGGING0;
 
 	sint32 id = event.GetId();
-	if (id >= loggingIdBase && id < (MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 20))
+	if (id >= loggingIdBase && id < (MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 64))
 	{
 		cafeLog_setLoggingFlagEnable(id - loggingIdBase, event.IsChecked());
 	}

--- a/src/input/api/ControllerState.h
+++ b/src/input/api/ControllerState.h
@@ -102,6 +102,7 @@ struct ControllerButtonState
 	ControllerButtonState& operator=(ControllerButtonState&& other)
 	{
 		cemu_assert_debug(!other.m_spinlock.is_locked());
+		std::scoped_lock _l(this->m_spinlock, other.m_spinlock);
 		this->m_pressedButtons = std::move(other.m_pressedButtons);
 		return *this;
 	}


### PR DESCRIPTION
Fixes:
- Potential random crash when reading controller button state
- Many Unity based games are working again (restored missing coreinit.OSMapMemory)
- General improvements to DS VC emulation. Yoshi's Island DS is now playable, other games still freeze during menus.
- Fixed z-sorting in DS VC, so backgrounds don't get drawn above everything else now.

I also restored and tweaked an optimization that avoids expensive texture readbacks if they are redundant. I'm not sure when this broke but either way it's working again now. In DS titles this boosts performance by a factor of 5x and in BotW the FPS shouldn't drop as much anymore when triggering dynamic fire (e.g. when burning grass). Other games don't really use readback frequently enough for it to make a difference.

Demonstration of Yoshi's Island DS:

https://user-images.githubusercontent.com/13877693/215043248-817f8306-b9a9-4ee7-9447-3c09800bb2a7.mp4
