### PR TITLE
GameList: fix the last column is hidden

### DIFF
--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -871,6 +871,9 @@ void wxGameList::OnColumnResize(wxListEvent& event)
 {
 	event.Skip();
 
+	if(m_style != Style::kList)
+		return;
+
 	const int column = event.GetColumn();
 	const int width = GetColumnWidth(column);
 


### PR DESCRIPTION
 Occurs if gamelist is Icons or SmallIcons style everytime cemu starts