### PR TITLE
Shared libraries crash MH3U on load so disable them by default.

### DIFF
--- a/bin/gameProfiles/default/0005000010104d00.ini
+++ b/bin/gameProfiles/default/0005000010104d00.ini
@@ -1,4 +1,7 @@
 # Monster Hunter 3(tri-)GHD Ver. (JPN)
 
+[General]
+loadSharedLibraries = false
+
 [Graphics]
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010117200.ini
+++ b/bin/gameProfiles/default/0005000010117200.ini
@@ -1,4 +1,7 @@
 # Monster Hunter 3 Ultimate (EUR)
 
+[General]
+loadSharedLibraries = false
+
 [Graphics]
 streamoutBufferCacheSize = 48

--- a/bin/gameProfiles/default/0005000010118300.ini
+++ b/bin/gameProfiles/default/0005000010118300.ini
@@ -1,4 +1,7 @@
 # Monster Hunter 3 Ultimate (USA)
 
+[General]
+loadSharedLibraries = false
+
 [Graphics]
 streamoutBufferCacheSize = 48


### PR DESCRIPTION
Surprised nobody reported this yet.