### PR TITLE
Add GDB stub for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .idea/
 
 build/
+cmake-build-*-*/
 out/
 .cache/
 bin/Cemu_*

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ It's written in C/C++ and is being actively developed with new features and fixe
 Cemu is currently only available for 64-bit Windows, Linux & macOS devices.
 
 ### Links:
- - [Original 2.0 announcement post](https://www.reddit.com/r/cemu/comments/wwa22c/cemu_20_announcement_linux_builds_opensource_and/)
+ - [Open Source Announcement](https://www.reddit.com/r/cemu/comments/wwa22c/cemu_20_announcement_linux_builds_opensource_and/)
  - [Official Website](https://cemu.info)
  - [Compatibility List/Wiki](https://wiki.cemu.info/wiki/Main_Page)
  - [Official Subreddit](https://reddit.com/r/Cemu)
  - [Official Discord](https://discord.gg/5psYsup)
  - [Official Matrix Server](https://matrix.to/#/#cemu:cemu.info)
- - [Unofficial Setup Guide](https://cemu.cfw.guide)
+ - [Setup Guide](https://cemu.cfw.guide)
 
 #### Other relevant repositories:
  - [Cemu-Language](https://github.com/cemu-project/Cemu-Language)

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(CemuCafe
   HW/Espresso/Debugger/Debugger.h
   HW/Espresso/Debugger/DebugSymbolStorage.cpp
   HW/Espresso/Debugger/DebugSymbolStorage.h
+  HW/Espresso/Debugger/GDBStub.h
+  HW/Espresso/Debugger/GDBStub.cpp
   HW/Espresso/EspressoISA.h
   HW/Espresso/Interpreter/PPCInterpreterALU.hpp
   HW/Espresso/Interpreter/PPCInterpreterFPU.cpp
@@ -464,7 +466,7 @@ add_library(CemuCafe
   TitleList/TitleInfo.h
   TitleList/TitleList.cpp
   TitleList/TitleList.h
-)
+        )
 
 if(APPLE)
 	target_sources(CemuCafe PRIVATE "HW/Latte/Renderer/Vulkan/CocoaSurface.mm")

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(CemuCafe
   HW/Espresso/Debugger/DebugSymbolStorage.h
   HW/Espresso/Debugger/GDBStub.h
   HW/Espresso/Debugger/GDBStub.cpp
+  HW/Espresso/Debugger/GDBBreakpoints.h
   HW/Espresso/EspressoISA.h
   HW/Espresso/Interpreter/PPCInterpreterALU.hpp
   HW/Espresso/Interpreter/PPCInterpreterFPU.cpp
@@ -466,7 +467,7 @@ add_library(CemuCafe
   TitleList/TitleInfo.h
   TitleList/TitleList.cpp
   TitleList/TitleList.h
-        )
+)
 
 if(APPLE)
 	target_sources(CemuCafe PRIVATE "HW/Latte/Renderer/Vulkan/CocoaSurface.mm")

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -400,7 +400,10 @@ void cemu_initForGame()
 	Latte_Start();
 	// check for debugger entrypoint bp
     if (g_gdbstub)
+    {
         g_gdbstub->HandleEntryStop(_entryPoint);
+        g_gdbstub->Initialize();
+    }
 	debugger_handleEntryBreakpoint(_entryPoint);
 	// load graphic packs
 	forceLog_printf("------- Activate graphic packs -------");
@@ -416,10 +419,6 @@ void cemu_initForGame()
 	OSThread_t* initialThread = coreinit::OSGetDefaultThread(1);
 	coreinit::OSSetThreadPriority(initialThread, 16);
 	coreinit::OSRunThread(initialThread, PPCInterpreter_makeCallableExportDepr(coreinit_start), 0, nullptr);
-    // init gdb debugger
-    if (g_gdbstub) {
-        g_gdbstub->Initialize();
-    }
 	// init AX and start AX I/O thread
 	snd_core::AXOut_init();
 	// init ppc recompiler

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -30,6 +30,7 @@
 #include "GamePatch.h"
 
 #include <time.h>
+#include "HW/Espresso/Debugger/GDBStub.h"
 
 #include "Cafe/IOSU/legacy/iosu_ioctl.h"
 #include "Cafe/IOSU/legacy/iosu_act.h"
@@ -398,6 +399,8 @@ void cemu_initForGame()
 	InfoLog_PrintActiveSettings();
 	Latte_Start();
 	// check for debugger entrypoint bp
+    if (g_gdbstub)
+        g_gdbstub->HandleEntryStop(_entryPoint);
 	debugger_handleEntryBreakpoint(_entryPoint);
 	// load graphic packs
 	forceLog_printf("------- Activate graphic packs -------");
@@ -413,6 +416,11 @@ void cemu_initForGame()
 	OSThread_t* initialThread = coreinit::OSGetDefaultThread(1);
 	coreinit::OSSetThreadPriority(initialThread, 16);
 	coreinit::OSRunThread(initialThread, PPCInterpreter_makeCallableExportDepr(coreinit_start), 0, nullptr);
+    // init gdb debugger
+    if (g_gdbstub) {
+        g_gdbstub->Initialize();
+        //while (!g_gdbstub->ContinueStartup()) std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
 	// init AX and start AX I/O thread
 	snd_core::AXOut_init();
 	// init ppc recompiler

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -419,7 +419,6 @@ void cemu_initForGame()
     // init gdb debugger
     if (g_gdbstub) {
         g_gdbstub->Initialize();
-        //while (!g_gdbstub->ContinueStartup()) std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
 	// init AX and start AX I/O thread
 	snd_core::AXOut_init();

--- a/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
@@ -103,7 +103,7 @@ void debugger_updateExecutionBreakpoint(uint32 address, bool forceRestore)
 			if (bpItr->enabled && forceRestore == false)
 			{
 				// write TW instruction to memory
-				debugger_updateMemoryU32(address, (31 << 26) | (4 << 1));
+				debugger_updateMemoryU32(address, DEBUGGER_BP_T_DEBUGGER_TW);
 				return;
 			}
 			else

--- a/src/Cafe/HW/Espresso/Debugger/Debugger.h
+++ b/src/Cafe/HW/Espresso/Debugger/Debugger.h
@@ -3,11 +3,6 @@
 #include <set>
 #include "Cafe/HW/Espresso/PPCState.h"
 
-//#define DEBUGGER_BP_TYPE_NORMAL			(1<<0) // normal breakpoint
-//#define DEBUGGER_BP_TYPE_ONE_SHOT		(1<<1) // normal breakpoint
-//#define DEBUGGER_BP_TYPE_MEMORY_READ	(1<<2) // memory breakpoint
-//#define DEBUGGER_BP_TYPE_MEMORY_WRITE	(1<<3) // memory breakpoint
-
 #define DEBUGGER_BP_T_NORMAL		0 // normal breakpoint
 #define DEBUGGER_BP_T_ONE_SHOT		1 // normal breakpoint, deletes itself after trigger (used for stepping)
 #define DEBUGGER_BP_T_MEMORY_READ	2 // memory breakpoint
@@ -15,6 +10,9 @@
 
 #define DEBUGGER_BP_T_GDBSTUB		1 // breakpoint created by GDBStub
 #define DEBUGGER_BP_T_DEBUGGER		2 // breakpoint created by Cemu's debugger
+
+#define DEBUGGER_BP_T_GDBSTUB_TW    0x7C010008
+#define DEBUGGER_BP_T_DEBUGGER_TW   0x7C020008
 
 
 struct DebuggerBreakpoint

--- a/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
@@ -1,0 +1,121 @@
+
+
+enum class BreakpointType
+{
+	BP_SINGLE,
+	BP_PERSISTENT,
+	BP_RESTORE_POINT,
+	BP_STEP_POINT
+};
+
+class GDBServer::ExecutionBreakpoint {
+  public:
+	ExecutionBreakpoint(MPTR address, BreakpointType type, bool visible)
+		: m_address(address), m_removedAfterInterrupt(false)
+	{
+		if (type == BreakpointType::BP_SINGLE)
+		{
+			this->m_pauseThreads = true;
+			this->m_restoreAfterInterrupt = false;
+			this->m_deleteAfterAnyInterrupt = false;
+			this->m_pauseOnNextInterrupt = false;
+			this->m_visible = visible;
+		}
+		else if (type == BreakpointType::BP_PERSISTENT)
+		{
+			this->m_pauseThreads = true;
+			this->m_restoreAfterInterrupt = true;
+			this->m_deleteAfterAnyInterrupt = false;
+			this->m_pauseOnNextInterrupt = false;
+			this->m_visible = visible;
+		}
+		else if (type == BreakpointType::BP_RESTORE_POINT)
+		{
+			this->m_pauseThreads = false;
+			this->m_restoreAfterInterrupt = false;
+			this->m_deleteAfterAnyInterrupt = false;
+			this->m_pauseOnNextInterrupt = false;
+			this->m_visible = false;
+		}
+		else if (type == BreakpointType::BP_STEP_POINT)
+		{
+			this->m_pauseThreads = false;
+			this->m_restoreAfterInterrupt = false;
+			this->m_deleteAfterAnyInterrupt = true;
+			this->m_pauseOnNextInterrupt = true;
+			this->m_visible = false;
+		}
+
+		this->m_origOpCode = memory_readU32(address);
+		memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
+		PPCRecompiler_invalidateRange(address, address + 4);
+	};
+	~ExecutionBreakpoint()
+	{
+		memory_writeU32(this->m_address, this->m_origOpCode);
+		PPCRecompiler_invalidateRange(this->m_address, this->m_address + 4);
+	};
+
+	[[nodiscard]] uint32 GetVisibleOpCode() const
+	{
+		if (this->m_visible)
+			return memory_readU32(this->m_address);
+		else
+			return this->m_origOpCode;
+	};
+	[[nodiscard]] bool ShouldBreakThreads() const
+	{
+		return this->m_pauseThreads;
+	};
+	[[nodiscard]] bool ShouldBreakThreadsOnNextInterrupt()
+	{
+		bool shouldPause = this->m_pauseOnNextInterrupt;
+		this->m_pauseOnNextInterrupt = false;
+		return shouldPause;
+	};
+	[[nodiscard]] bool IsPersistent() const
+	{
+		return this->m_restoreAfterInterrupt;
+	};
+	[[nodiscard]] bool IsSkipBreakpoint() const
+	{
+		return this->m_deleteAfterAnyInterrupt;
+	};
+	[[nodiscard]] bool IsRemoved() const
+	{
+		return this->m_removedAfterInterrupt;
+	};
+
+	void RemoveTemporarily()
+	{
+		memory_writeU32(this->m_address, this->m_origOpCode);
+		PPCRecompiler_invalidateRange(this->m_address, this->m_address + 4);
+		this->m_restoreAfterInterrupt = true;
+	};
+	void Restore()
+	{
+		memory_writeU32(this->m_address, DEBUGGER_BP_T_GDBSTUB_TW);
+		PPCRecompiler_invalidateRange(this->m_address, this->m_address + 4);
+		this->m_restoreAfterInterrupt = false;
+	};
+	void PauseOnNextInterrupt()
+	{
+		this->m_pauseOnNextInterrupt = true;
+	};
+
+	void WriteNewOpCode(uint32 newOpCode)
+	{
+		this->m_origOpCode = newOpCode;
+	};
+
+  private:
+	const MPTR m_address;
+	uint32 m_origOpCode;
+	bool m_visible;
+	bool m_pauseThreads;
+	// type
+	bool m_pauseOnNextInterrupt;
+	bool m_restoreAfterInterrupt;
+	bool m_deleteAfterAnyInterrupt;
+	bool m_removedAfterInterrupt{};
+};

--- a/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
@@ -189,7 +189,7 @@ public:
 			SetThreadContext(hThread, &ctx);
 			ResumeThread(hThread);
 		}
-#elif defined(ARCH_X86_64) && BOOST_OS_UNIX
+#elif defined(ARCH_X86_64) && BOOST_OS_LINUX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			pid_t pid = (pid_t)(uintptr_t)hThreadNH;
@@ -243,7 +243,7 @@ public:
 			SetThreadContext(hThread, &ctx);
 			ResumeThread(hThread);
 		}
-#elif defined(ARCH_X86_64) && BOOST_OS_UNIX
+#elif defined(ARCH_X86_64) && BOOST_OS_LINUX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			pid_t pid = (pid_t)(uintptr_t)hThreadNH;

--- a/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
@@ -192,7 +192,7 @@ public:
 #elif defined(ARCH_X86_64) && BOOST_OS_UNIX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
-			pid_t pid = (pid_t)hThreadNH;
+			pid_t pid = (pid_t)(uintptr_t)hThreadNH;
 			ptrace(PTRACE_ATTACH, pid, nullptr, nullptr);
 			waitpid(pid, nullptr, 0);
 
@@ -246,7 +246,7 @@ public:
 #elif defined(ARCH_X86_64) && BOOST_OS_UNIX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
-			pid_t pid = (pid_t)hThreadNH;
+			pid_t pid = (pid_t)(uintptr_t)hThreadNH;
 			ptrace(PTRACE_ATTACH, pid, nullptr, nullptr);
 			waitpid(pid, nullptr, 0);
 

--- a/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
@@ -165,7 +165,7 @@ public:
 	AccessBreakpoint(MPTR address, AccessPointType type)
 		: m_address(address), m_type(type)
 	{
-#if BOOST_OS_WINDOWS
+#if defined(ARCH_X86_64) && BOOST_OS_WINDOWS
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			HANDLE hThread = (HANDLE)hThreadNH;
@@ -189,7 +189,7 @@ public:
 			SetThreadContext(hThread, &ctx);
 			ResumeThread(hThread);
 		}
-#else
+#elif defined(ARCH_X86_64) && BOOST_OS_UNIX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			pid_t pid = (pid_t)hThreadNH;
@@ -214,11 +214,13 @@ public:
 			_SetDR(pid, 7, dr7);			
 			ptrace(PTRACE_DETACH, pid, nullptr, nullptr);
 		}
+#else
+		cemuLog_log(LogType::Force, "Debugger read/write breakpoints are not supported on non-x86 CPUs yet.");
 #endif
 	};
 	~AccessBreakpoint()
 	{
-#if BOOST_OS_WINDOWS
+#if defined(ARCH_X86_64) && BOOST_OS_WINDOWS
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			HANDLE hThread = (HANDLE)hThreadNH;
@@ -241,7 +243,7 @@ public:
 			SetThreadContext(hThread, &ctx);
 			ResumeThread(hThread);
 		}
-#else
+#elif defined(ARCH_X86_64) && BOOST_OS_UNIX
 		for (auto& hThreadNH : coreinit::OSGetSchedulerThreads())
 		{
 			pid_t pid = (pid_t)hThreadNH;

--- a/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBBreakpoints.h
@@ -19,8 +19,6 @@ enum class BreakpointType
 	BP_STEP_POINT
 };
 
-#include <stacktrace>
-
 class GDBServer::ExecutionBreakpoint {
 public:
 	ExecutionBreakpoint(MPTR address, BreakpointType type, bool visible, std::string reason)

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
@@ -13,189 +13,230 @@
 #define GET_THREAD_ID(threadPtr) memory_getVirtualOffsetFromPointer(threadPtr)
 #define GET_THREAD_BY_ID(threadId) (OSThread_t*)memory_getPointerFromPhysicalOffset(threadId)
 
+static std::vector<MPTR> findNextInstruction(MPTR currAddress, uint32 lr, uint32 ctr)
+{
+	using namespace Espresso;
 
-static std::vector<MPTR> findNextInstruction(MPTR currAddress, uint32 lr, uint32 ctr) {
-    using namespace Espresso;
-
-    uint32 nextInstr = memory_readU32(currAddress);
-    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::B) {
-        uint32 LI;
-        bool AA, LK;
-        decodeOp_B(nextInstr, LI, AA, LK);
-        if (!AA)
-            LI += currAddress;
-        return {LI};
-    }
-    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::BC) {
-        uint32 BD, BI;
-        BOField BO{};
-        bool AA, LK;
-        decodeOp_BC(nextInstr, BD, BO, BI, AA, LK);
-        if (!LK)
-            BD += currAddress;
-        return {currAddress+4, BD};
-    }
-    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCLR) {
-        return {currAddress+4, lr};
-    }
-    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCCTR) {
-        return {currAddress+4, ctr};
-    }
-    return {currAddress+4};
+	uint32 nextInstr = memory_readU32(currAddress);
+	if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::B)
+	{
+		uint32 LI;
+		bool AA, LK;
+		decodeOp_B(nextInstr, LI, AA, LK);
+		if (!AA)
+			LI += currAddress;
+		return {LI};
+	}
+	if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::BC)
+	{
+		uint32 BD, BI;
+		BOField BO{};
+		bool AA, LK;
+		decodeOp_BC(nextInstr, BD, BO, BI, AA, LK);
+		if (!LK)
+			BD += currAddress;
+		return {currAddress + 4, BD};
+	}
+	if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCLR)
+	{
+		return {currAddress + 4, lr};
+	}
+	if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCCTR)
+	{
+		return {currAddress + 4, ctr};
+	}
+	return {currAddress + 4};
 }
 
 template<typename F>
-static void selectThread(sint64 selectorId, F&& action_for_thread) {
-    __OSLockScheduler();
-    cemu_assert_debug(activeThreadCount != 0);
+static void selectThread(sint64 selectorId, F&& action_for_thread)
+{
+	__OSLockScheduler();
+	cemu_assert_debug(activeThreadCount != 0);
 
-    if (selectorId == -1) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            action_for_thread(GET_THREAD_BY_ID(activeThread[i]));
-        }
-    }
-    else if (selectorId == 0) {
-        // Use first thread if attempted to be stopped
-        // todo: would this work better if it used main?
-        action_for_thread(coreinit::OSGetDefaultThread(1));
-    }
-    else if (selectorId > 0) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
-            if (GET_THREAD_ID(thread) == selectorId) {
-                action_for_thread(thread);
-                break;
-            }
-        }
-    }
-    __OSUnlockScheduler();
+	if (selectorId == -1)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			action_for_thread(GET_THREAD_BY_ID(activeThread[i]));
+		}
+	}
+	else if (selectorId == 0)
+	{
+		// Use first thread if attempted to be stopped
+		// todo: would this work better if it used main?
+		action_for_thread(coreinit::OSGetDefaultThread(1));
+	}
+	else if (selectorId > 0)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+			if (GET_THREAD_ID(thread) == selectorId)
+			{
+				action_for_thread(thread);
+				break;
+			}
+		}
+	}
+	__OSUnlockScheduler();
 }
 
 template<typename F>
-static void selectAndBreakThread(sint64 selectorId, F&& action_for_thread) {
-    __OSLockScheduler();
-    cemu_assert_debug(activeThreadCount != 0);
+static void selectAndBreakThread(sint64 selectorId, F&& action_for_thread)
+{
+	__OSLockScheduler();
+	cemu_assert_debug(activeThreadCount != 0);
 
-    std::vector<OSThread_t*> pausedThreads;
-    if (selectorId == -1) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
-            pausedThreads.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
-        }
-    }
-    else if (selectorId == 0) {
-        // Use first thread if attempted to be stopped
-        OSThread_t* thread = GET_THREAD_BY_ID(activeThread[0]);
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) < GET_THREAD_ID(thread)) {
-                thread = GET_THREAD_BY_ID(activeThread[i]);
-            }
-        }
-        coreinit::__OSSuspendThreadNolock(thread);
-        pausedThreads.emplace_back(thread);
-    }
-    else if (selectorId > 0) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
-            if (GET_THREAD_ID(thread) == selectorId) {
-                coreinit::__OSSuspendThreadNolock(thread);
-                pausedThreads.emplace_back(thread);
-                break;
-            }
-        }
-    }
-    __OSUnlockScheduler();
+	std::vector<OSThread_t*> pausedThreads;
+	if (selectorId == -1)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
+			pausedThreads.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
+		}
+	}
+	else if (selectorId == 0)
+	{
+		// Use first thread if attempted to be stopped
+		OSThread_t* thread = GET_THREAD_BY_ID(activeThread[0]);
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) < GET_THREAD_ID(thread))
+			{
+				thread = GET_THREAD_BY_ID(activeThread[i]);
+			}
+		}
+		coreinit::__OSSuspendThreadNolock(thread);
+		pausedThreads.emplace_back(thread);
+	}
+	else if (selectorId > 0)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+			if (GET_THREAD_ID(thread) == selectorId)
+			{
+				coreinit::__OSSuspendThreadNolock(thread);
+				pausedThreads.emplace_back(thread);
+				break;
+			}
+		}
+	}
+	__OSUnlockScheduler();
 
-    for (OSThread_t* thread : pausedThreads) {
-        while (coreinit::OSIsThreadRunning(thread)) std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        action_for_thread(thread);
-    }
+	for (OSThread_t* thread : pausedThreads)
+	{
+		while (coreinit::OSIsThreadRunning(thread))
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		action_for_thread(thread);
+	}
 }
 
-static void selectAndResumeThread(sint64 selectorId) {
-    __OSLockScheduler();
-    cemu_assert_debug(activeThreadCount != 0);
+static void selectAndResumeThread(sint64 selectorId)
+{
+	__OSLockScheduler();
+	cemu_assert_debug(activeThreadCount != 0);
 
-    if (selectorId == -1) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            coreinit::__OSResumeThreadInternal(GET_THREAD_BY_ID(activeThread[i]), 4);
-        }
-    }
-    else if (selectorId == 0) {
-        // Use first thread if attempted to be stopped
-        coreinit::__OSResumeThreadInternal(coreinit::OSGetDefaultThread(1), 1);
-    }
-    else if (selectorId > 0) {
-        for (sint32 i = 0; i < activeThreadCount; i++) {
-            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
-            if (GET_THREAD_ID(thread) == selectorId) {
-                coreinit::__OSResumeThreadInternal(thread, 1);
-                break;
-            }
-        }
-    }
-    __OSUnlockScheduler();
+	if (selectorId == -1)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			coreinit::__OSResumeThreadInternal(GET_THREAD_BY_ID(activeThread[i]), 4);
+		}
+	}
+	else if (selectorId == 0)
+	{
+		// Use first thread if attempted to be stopped
+		coreinit::__OSResumeThreadInternal(coreinit::OSGetDefaultThread(1), 1);
+	}
+	else if (selectorId > 0)
+	{
+		for (sint32 i = 0; i < activeThreadCount; i++)
+		{
+			auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+			if (GET_THREAD_ID(thread) == selectorId)
+			{
+				coreinit::__OSResumeThreadInternal(thread, 1);
+				break;
+			}
+		}
+	}
+	__OSUnlockScheduler();
 }
 
-static void waitForBrokenThreads(std::unique_ptr<GDBServer::CommandContext> context) {
-    // This should pause all threads except trapped thread
-    // It should however wait for the trapped thread
-    // The trapped thread should be paused by the trap word instruction handler (aka the running thread)
-    std::vector<OSThread_t*> threadsList;
-    __OSLockScheduler();
-    for (sint32 i = 0; i < activeThreadCount; i++) {
-        threadsList.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
-    }
-    __OSUnlockScheduler();
+static void waitForBrokenThreads(std::unique_ptr<GDBServer::CommandContext> context)
+{
+	// This should pause all threads except trapped thread
+	// It should however wait for the trapped thread
+	// The trapped thread should be paused by the trap word instruction handler (aka the running thread)
+	std::vector<OSThread_t*> threadsList;
+	__OSLockScheduler();
+	for (sint32 i = 0; i < activeThreadCount; i++)
+	{
+		threadsList.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
+	}
+	__OSUnlockScheduler();
 
-    for (OSThread_t* thread : threadsList) {
-        while (coreinit::OSIsThreadRunning(thread)) std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    }
+	for (OSThread_t* thread : threadsList)
+	{
+		while (coreinit::OSIsThreadRunning(thread))
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
 
-    context->QueueResponse("S05");
+	context->QueueResponse("S05");
 }
 
-static void breakThreads(sint64 trappedThread) {
-    __OSLockScheduler();
-    cemu_assert_debug(activeThreadCount != 0);
+static void breakThreads(sint64 trappedThread)
+{
+	__OSLockScheduler();
+	cemu_assert_debug(activeThreadCount != 0);
 
-    // First, break other threads
-    OSThread_t* mainThread = nullptr;
-    for (sint32 i = 0; i < activeThreadCount; i++) {
-        if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) == trappedThread) {
-            mainThread = GET_THREAD_BY_ID(activeThread[i]);
-        }
-        else {
-            coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
-        }
-    }
+	// First, break other threads
+	OSThread_t* mainThread = nullptr;
+	for (sint32 i = 0; i < activeThreadCount; i++)
+	{
+		if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) == trappedThread)
+		{
+			mainThread = GET_THREAD_BY_ID(activeThread[i]);
+		}
+		else
+		{
+			coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
+		}
+	}
 
-    // Second, break trapped thread itself which should also pause execution of this handler
-    // This will temporarily lift the scheduler lock until it's resumed from its suspension
-    coreinit::__OSSuspendThreadNolock(mainThread);
+	// Second, break trapped thread itself which should also pause execution of this handler
+	// This will temporarily lift the scheduler lock until it's resumed from its suspension
+	coreinit::__OSSuspendThreadNolock(mainThread);
 
-    __OSUnlockScheduler();
+	__OSUnlockScheduler();
 }
-
 
 std::unique_ptr<GDBServer> g_gdbstub;
 
-GDBServer::GDBServer(uint16 port) : m_port(port) {
+GDBServer::GDBServer(uint16 port)
+	: m_port(port)
+{
 #if BOOST_OS_WINDOWS
 	WSADATA wsa;
 	WSAStartup(MAKEWORD(2, 2), &wsa);
 #endif
 }
 
-GDBServer::~GDBServer() {
-	if (m_client_socket != INVALID_SOCKET) {
+GDBServer::~GDBServer()
+{
+	if (m_client_socket != INVALID_SOCKET)
+	{
 		// close socket from other thread to forcefully stop accept() call
-        closesocket(m_client_socket);
+		closesocket(m_client_socket);
 		m_client_socket = INVALID_SOCKET;
 	}
 
-	if (m_server_socket != INVALID_SOCKET) {
-        closesocket(m_server_socket);
+	if (m_server_socket != INVALID_SOCKET)
+	{
+		closesocket(m_server_socket);
 	}
 #if BOOST_OS_WINDOWS
 	WSACleanup();
@@ -205,7 +246,8 @@ GDBServer::~GDBServer() {
 	m_thread.join();
 }
 
-bool GDBServer::Initialize() {
+bool GDBServer::Initialize()
+{
 	cemuLog_createLogFile(false);
 
 	if (m_server_socket = socket(PF_INET, SOCK_STREAM, 0); m_server_socket == SOCKET_ERROR)
@@ -243,7 +285,8 @@ bool GDBServer::Initialize() {
 	return true;
 }
 
-void GDBServer::ThreadFunc(const std::stop_token& stop_token) {
+void GDBServer::ThreadFunc(const std::stop_token& stop_token)
+{
 	SetThreadName("GDBServer::ThreadFunc");
 
 	while (!stop_token.stop_requested())
@@ -271,32 +314,35 @@ void GDBServer::ThreadFunc(const std::stop_token& stop_token) {
 
 			char packetPrefix = readChar();
 
-			switch (packetPrefix) {
+			switch (packetPrefix)
+			{
 			case '+':
 			case '-':
 				break;
-			case '\x03': {
-                cemuLog_logDebug(LogType::Force, "[GDBStub] Received interrupt (pressed CTRL+C?) from client!");
-                selectAndBreakThread(-1, [](OSThread_t* thread) {
-                });
-                auto thread_status = fmt::format("T05thread:{:08X};", GET_THREAD_ID(coreinit::OSGetDefaultThread(1)));
-                auto response_full = fmt::format("+${}#{:02x}", thread_status, CommandContext::CalculateChecksum(thread_status));
-                send(m_client_socket, response_full.c_str(), (int)response_full.size(), 0);
-                break;
-            }
-			case '$': {
+			case '\x03':
+			{
+				cemuLog_logDebug(LogType::Force, "[GDBStub] Received interrupt (pressed CTRL+C?) from client!");
+				selectAndBreakThread(-1, [](OSThread_t* thread) {
+				});
+				auto thread_status = fmt::format("T05thread:{:08X};", GET_THREAD_ID(coreinit::OSGetDefaultThread(1)));
+				auto response_full = fmt::format("+${}#{:02x}", thread_status, CommandContext::CalculateChecksum(thread_status));
+				send(m_client_socket, response_full.c_str(), (int)response_full.size(), 0);
+				break;
+			}
+			case '$':
+			{
 				std::string message;
 				uint8 checkedSum = 0;
-				for (uint32_t i = 1; ; i++) {
+				for (uint32_t i = 1;; i++)
+				{
 					char c = readChar();
 					if (c == '#')
 						break;
 					checkedSum += static_cast<uint8>(c);
 					message.push_back(c);
 
-					if (i >= s_maxPacketSize) {
+					if (i >= s_maxPacketSize)
 						cemuLog_logDebug(LogType::Force, "[GDBStub] Received too big of a buffer: {}", message);
-					}
 				}
 				char checkSumStr[2];
 				receiveMessage(checkSumStr, 2);
@@ -307,8 +353,8 @@ void GDBServer::ThreadFunc(const std::stop_token& stop_token) {
 				break;
 			}
 			default:
-				//cemuLog_logDebug(LogType::Force, "[GDBStub] Unknown packet start: {}", packetPrefix);
-                break;
+				// cemuLog_logDebug(LogType::Force, "[GDBStub] Unknown packet start: {}", packetPrefix);
+				break;
 			}
 		}
 	}
@@ -317,74 +363,84 @@ void GDBServer::ThreadFunc(const std::stop_token& stop_token) {
 		closesocket(m_client_socket);
 }
 
-void GDBServer::insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt) {
-    //cemuLog_logDebug(LogType::Force, "[GDBStub] Inserting breakpoint for {:08x}, restoreAfterInterrupt = {}, deleteAfterInterrupt = {}, pauseThreads = {}", address, restoreAfterInterrupt, deleteAfterInterrupt, pauseThreads);
-    if (auto bpIt = m_patchedInstructions.find(address); bpIt != m_patchedInstructions.end()) {
-        if (!bpIt->second.pauseThreads && pauseThreads) {
-            //cemuLog_logDebug(LogType::Force, "[GDBStub] Upgraded restore point to breakpoint");
-            bpIt->second.pauseThreads = true;
-            bpIt->second.restoreAfterInterrupt = restoreAfterInterrupt;
-        }
-        else {
-            // breakpoint already exists and wasn't previously restore point
-            cemu_assert_suspicious();
-            return;
-        }
-    }
+void GDBServer::insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt)
+{
+	// cemuLog_logDebug(LogType::Force, "[GDBStub] Inserting breakpoint for {:08x}, restoreAfterInterrupt = {}, deleteAfterInterrupt = {}, pauseThreads = {}", address, restoreAfterInterrupt, deleteAfterInterrupt, pauseThreads);
+	if (auto bpIt = m_patchedInstructions.find(address); bpIt != m_patchedInstructions.end())
+	{
+		if (!bpIt->second.pauseThreads && pauseThreads)
+		{
+			// cemuLog_logDebug(LogType::Force, "[GDBStub] Upgraded restore point to breakpoint");
+			bpIt->second.pauseThreads = true;
+			bpIt->second.restoreAfterInterrupt = restoreAfterInterrupt;
+		}
+		else
+		{
+			// breakpoint already exists and wasn't previously restore point
+			cemu_assert_suspicious();
+			return;
+		}
+	}
 
-    uint32 origOpCode = memory_readU32(address);
-    memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
-    PPCRecompiler_invalidateRange(address, address + 4);
+	uint32 origOpCode = memory_readU32(address);
+	memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
+	PPCRecompiler_invalidateRange(address, address + 4);
 
-    m_patchedInstructions.emplace(address, GDBServer::Breakpoint{
-        .address = address,
-        .origOpCode = origOpCode,
-        .visible = visible,
-        .pauseThreads = pauseThreads,
-        .restoreAfterInterrupt=restoreAfterInterrupt,
-        .deleteAfterInterrupt=deleteAfterInterrupt,
-        .removedAfterInterrupt=false
-    });
+	m_patchedInstructions.emplace(address, GDBServer::Breakpoint{
+											   .address = address,
+											   .origOpCode = origOpCode,
+											   .visible = visible,
+											   .pauseThreads = pauseThreads,
+											   .restoreAfterInterrupt = restoreAfterInterrupt,
+											   .deleteAfterInterrupt = deleteAfterInterrupt,
+											   .removedAfterInterrupt = false});
 }
 
-void GDBServer::restoreBreakpoint(MPTR address) {
-    //cemuLog_logDebug(LogType::Force, "[GDBStub] Restoring breakpoint for {:08x}", address);
-    if (!m_patchedInstructions.contains(address)) {
-        // Restoring a breakpoint on an address that has no breakpoints?
-        cemu_assert_suspicious();
-        return;
-    }
+void GDBServer::restoreBreakpoint(MPTR address)
+{
+	// cemuLog_logDebug(LogType::Force, "[GDBStub] Restoring breakpoint for {:08x}", address);
+	if (!m_patchedInstructions.contains(address))
+	{
+		// Restoring a breakpoint on an address that has no breakpoints?
+		cemu_assert_suspicious();
+		return;
+	}
 
-    memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
-    PPCRecompiler_invalidateRange(address, address + 4);
-    m_patchedInstructions[address].removedAfterInterrupt = false;
+	memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
+	PPCRecompiler_invalidateRange(address, address + 4);
+	m_patchedInstructions[address].removedAfterInterrupt = false;
 }
 
-void GDBServer::deleteBreakpoint(MPTR address, bool softRemove = false) {
-    //cemuLog_logDebug(LogType::Force, "[GDBStub] {} breakpoint for {:08x}", softRemove ? "Remove" : "Delete", address);
-    if (!m_patchedInstructions.contains(address)) {
-        // Removing a breakpoint on an address that has no breakpoints?
-        cemu_assert_suspicious();
-        return;
-    }
+void GDBServer::deleteBreakpoint(MPTR address, bool softRemove = false)
+{
+	// cemuLog_logDebug(LogType::Force, "[GDBStub] {} breakpoint for {:08x}", softRemove ? "Remove" : "Delete", address);
+	if (!m_patchedInstructions.contains(address))
+	{
+		// Removing a breakpoint on an address that has no breakpoints?
+		cemu_assert_suspicious();
+		return;
+	}
 
-    memory_writeU32(address, m_patchedInstructions[address].origOpCode);
-    PPCRecompiler_invalidateRange(address, address + 4);
+	memory_writeU32(address, m_patchedInstructions[address].origOpCode);
+	PPCRecompiler_invalidateRange(address, address + 4);
 
-    if (softRemove)
-        m_patchedInstructions[address].removedAfterInterrupt = true;
-    else
-        m_patchedInstructions.erase(address);
+	if (softRemove)
+		m_patchedInstructions[address].removedAfterInterrupt = true;
+	else
+		m_patchedInstructions.erase(address);
 }
 
-void GDBServer::HandleCommand(const std::string& command_str) {
+void GDBServer::HandleCommand(const std::string& command_str)
+{
 	auto context = std::make_unique<CommandContext>(this, command_str);
 
-    if (context->IsValid()) {
-        //cemuLog_logDebug(LogType::Force, "[GDBStub] Extracted Command {}", fmt::join(context->GetArgs(), ","));
-    }
+	if (context->IsValid())
+	{
+		// cemuLog_logDebug(LogType::Force, "[GDBStub] Extracted Command {}", fmt::join(context->GetArgs(), ","));
+	}
 
-	switch (context->GetType()) {
+	switch (context->GetType())
+	{
 	// Extended commands
 	case CMDType::QUERY_GET:
 	case CMDType::QUERY_SET:
@@ -393,19 +449,19 @@ void GDBServer::HandleCommand(const std::string& command_str) {
 		return HandleVCont(context);
 	// Regular commands
 	case CMDType::IS_THREAD_RUNNING:
-        return CMDIsThreadActive(context);
+		return CMDIsThreadActive(context);
 	case CMDType::SET_ACTIVE_THREAD:
 		return CMDSetActiveThread(context);
 	case CMDType::ACTIVE_THREAD_STATUS:
 		return CMDGetThreadStatus(context);
-    case CMDType::CONTINUE:
-        return CMDContinue(context);
+	case CMDType::CONTINUE:
+		return CMDContinue(context);
 	case CMDType::ACTIVE_THREAD_STEP:
 		break;
 	case CMDType::REGISTER_READ:
 		return CMDReadRegister(context);
 	case CMDType::REGISTER_SET:
-        return CMDWriteRegister(context);
+		return CMDWriteRegister(context);
 	case CMDType::REGISTERS_READ:
 		return CMDReadRegisters(context);
 	case CMDType::REGISTERS_WRITE:
@@ -413,7 +469,7 @@ void GDBServer::HandleCommand(const std::string& command_str) {
 	case CMDType::MEMORY_READ:
 		return CMDReadMemory(context);
 	case CMDType::MEMORY_WRITE:
-        return CMDWriteMemory(context);
+		return CMDWriteMemory(context);
 	case CMDType::BREAKPOINT_SET:
 		return CMDInsertBreakpoint(context);
 	case CMDType::BREAKPOINT_REMOVE:
@@ -423,437 +479,520 @@ void GDBServer::HandleCommand(const std::string& command_str) {
 		return CMDNotFound(context);
 	}
 
-    CMDNotFound(context);
+	CMDNotFound(context);
 }
 
-void GDBServer::HandleQuery(std::unique_ptr<CommandContext>& context) const {
-    if (!context->IsValid()) return context->QueueResponse(RESPONSE_EMPTY);
+void GDBServer::HandleQuery(std::unique_ptr<CommandContext>& context) const
+{
+	if (!context->IsValid())
+		return context->QueueResponse(RESPONSE_EMPTY);
 
 	const auto& query_cmd = context->GetArgs()[0];
-    const auto& query_args = context->GetArgs().begin()+1;
+	const auto& query_args = context->GetArgs().begin() + 1;
 
-    if (query_cmd == "qSupported") {
-        context->QueueResponse(s_supportedFeatures);
-    }
-    else if (query_cmd == "qAttached") {
-        context->QueueResponse("1");
-    }
-    else if (query_cmd == "qRcmd") {
-    }
-    else if (query_cmd == "qC") {
-        context->QueueResponse("QC");
-        context->QueueResponse(std::to_string(m_activeThreadContinueSelector));
-    }
-    else if (query_cmd == "qOffsets") {
-        const auto module_count = RPLLoader_GetModuleCount();
-        const auto module_list = RPLLoader_GetModuleList();
-        for (sint32 i = 0; i < module_count; i++) {
-            const RPLModule* rpl = module_list[i];
-            if (rpl->entrypoint == m_entry_point) {
-                context->QueueResponse(fmt::format("TextSeg={:08X};DataSeg={:08X}", rpl->regionMappingBase_text.GetMPTR(), rpl->regionMappingBase_data));
-            }
-        }
-    }
-    else if (query_cmd == "qfThreadInfo") {
-        std::vector<std::string> threadIds;
-        selectThread(-1, [&threadIds](OSThread_t* thread) {
-            threadIds.emplace_back(fmt::format("{:08X}", memory_getVirtualOffsetFromPointer(thread)));
-        });
-        context->QueueResponse(fmt::format("m{}", fmt::join(threadIds, ",")));
-    }
-    else if (query_cmd == "qsThreadInfo") {
-        context->QueueResponse("l");
-    }
-    else if (query_cmd == "qXfer") {
-        auto& type = query_args[0];
+	if (query_cmd == "qSupported")
+	{
+		context->QueueResponse(s_supportedFeatures);
+	}
+	else if (query_cmd == "qAttached")
+	{
+		context->QueueResponse("1");
+	}
+	else if (query_cmd == "qRcmd")
+	{
+	}
+	else if (query_cmd == "qC")
+	{
+		context->QueueResponse("QC");
+		context->QueueResponse(std::to_string(m_activeThreadContinueSelector));
+	}
+	else if (query_cmd == "qOffsets")
+	{
+		const auto module_count = RPLLoader_GetModuleCount();
+		const auto module_list = RPLLoader_GetModuleList();
+		for (sint32 i = 0; i < module_count; i++)
+		{
+			const RPLModule* rpl = module_list[i];
+			if (rpl->entrypoint == m_entry_point)
+			{
+				context->QueueResponse(fmt::format("TextSeg={:08X};DataSeg={:08X}", rpl->regionMappingBase_text.GetMPTR(), rpl->regionMappingBase_data));
+			}
+		}
+	}
+	else if (query_cmd == "qfThreadInfo")
+	{
+		std::vector<std::string> threadIds;
+		selectThread(-1, [&threadIds](OSThread_t* thread) {
+			threadIds.emplace_back(fmt::format("{:08X}", memory_getVirtualOffsetFromPointer(thread)));
+		});
+		context->QueueResponse(fmt::format("m{}", fmt::join(threadIds, ",")));
+	}
+	else if (query_cmd == "qsThreadInfo")
+	{
+		context->QueueResponse("l");
+	}
+	else if (query_cmd == "qXfer")
+	{
+		auto& type = query_args[0];
 
-        if (type == "features") {
-            auto& annex = query_args[1];
-            sint64 read_offset = std::stoul(query_args[2], nullptr, 16);
-            sint64 read_length = std::stoul(query_args[3], nullptr, 16);
-            if (annex == "target.xml") {
-                if (read_offset >= GDBTargetXML.size()) context->QueueResponse("l");
-                else {
-                    auto paginated_str = GDBTargetXML.substr(read_offset, read_length);
-                    context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
-                    context->QueueResponse(paginated_str);
-                }
-            }
-            else cemuLog_logDebug(LogType::Force, "[GDBStub] qXfer:features:read:{} isn't a known feature document", annex);
-        }
-        else if (type == "threads") {
-            sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
-            sint64 read_length = std::stoul(query_args[2], nullptr, 16);
+		if (type == "features")
+		{
+			auto& annex = query_args[1];
+			sint64 read_offset = std::stoul(query_args[2], nullptr, 16);
+			sint64 read_length = std::stoul(query_args[3], nullptr, 16);
+			if (annex == "target.xml")
+			{
+				if (read_offset >= GDBTargetXML.size())
+					context->QueueResponse("l");
+				else
+				{
+					auto paginated_str = GDBTargetXML.substr(read_offset, read_length);
+					context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+					context->QueueResponse(paginated_str);
+				}
+			}
+			else
+				cemuLog_logDebug(LogType::Force, "[GDBStub] qXfer:features:read:{} isn't a known feature document", annex);
+		}
+		else if (type == "threads")
+		{
+			sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
+			sint64 read_length = std::stoul(query_args[2], nullptr, 16);
 
-            std::string threads_res;
-            threads_res += R"(<?xml version="1.0"?>)";
-            threads_res += "<threads>";
-            // note: clion seems to default to the first thread
-            std::map<sint64, std::string> threads_list;
-            selectThread(-1, [&threads_list](OSThread_t *thread) {
-                std::string entry;
-                entry += fmt::format(R"(<thread id="{:x}" core="{}")", GET_THREAD_ID(thread), thread->context.affinity.value());
-                if (!thread->threadName.IsNull())
-                    entry += fmt::format(R"( name="{}")", CommandContext::EscapeXMLString(thread->threadName.GetPtr()));
-                // todo: could add a human-readable description of the thread here
-                entry += fmt::format("></thread>");
-                threads_list.emplace(GET_THREAD_ID(thread), entry);
-            });
-            for (auto& entry : threads_list) {
-                threads_res += entry.second;
-            }
-            threads_res += "</threads>";
+			std::string threads_res;
+			threads_res += R"(<?xml version="1.0"?>)";
+			threads_res += "<threads>";
+			// note: clion seems to default to the first thread
+			std::map<sint64, std::string> threads_list;
+			selectThread(-1, [&threads_list](OSThread_t* thread) {
+				std::string entry;
+				entry += fmt::format(R"(<thread id="{:x}" core="{}")", GET_THREAD_ID(thread), thread->context.affinity.value());
+				if (!thread->threadName.IsNull())
+					entry += fmt::format(R"( name="{}")", CommandContext::EscapeXMLString(thread->threadName.GetPtr()));
+				// todo: could add a human-readable description of the thread here
+				entry += fmt::format("></thread>");
+				threads_list.emplace(GET_THREAD_ID(thread), entry);
+			});
+			for (auto& entry : threads_list)
+			{
+				threads_res += entry.second;
+			}
+			threads_res += "</threads>";
 
-            if (read_offset >= threads_res.size()) context->QueueResponse("l");
-            else {
-                auto paginated_str = threads_res.substr(read_offset, read_length);
-                context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
-                context->QueueResponse(paginated_str);
-            }
-        }
-        else if (type == "libraries") {
-            sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
-            sint64 read_length = std::stoul(query_args[2], nullptr, 16);
+			if (read_offset >= threads_res.size())
+				context->QueueResponse("l");
+			else
+			{
+				auto paginated_str = threads_res.substr(read_offset, read_length);
+				context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+				context->QueueResponse(paginated_str);
+			}
+		}
+		else if (type == "libraries")
+		{
+			sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
+			sint64 read_length = std::stoul(query_args[2], nullptr, 16);
 
-            std::string library_list;
-            library_list += R"(<?xml version="1.0"?>)";
-            library_list += "<library-list>";
+			std::string library_list;
+			library_list += R"(<?xml version="1.0"?>)";
+			library_list += "<library-list>";
 
-            const auto module_count = RPLLoader_GetModuleCount();
-            const auto module_list = RPLLoader_GetModuleList();
-            for (sint32 i = 0; i < module_count; i++) {
-                library_list += fmt::format(R"(<library name="{}"><segment address="{:#x}"/></library>)", CommandContext::EscapeXMLString(module_list[i]->moduleName2), module_list[i]->regionMappingBase_text.GetMPTR());
-            }
-            library_list += "</library-list>";
+			const auto module_count = RPLLoader_GetModuleCount();
+			const auto module_list = RPLLoader_GetModuleList();
+			for (sint32 i = 0; i < module_count; i++)
+			{
+				library_list += fmt::format(R"(<library name="{}"><segment address="{:#x}"/></library>)", CommandContext::EscapeXMLString(module_list[i]->moduleName2), module_list[i]->regionMappingBase_text.GetMPTR());
+			}
+			library_list += "</library-list>";
 
-            if (read_offset >= library_list.size()) context->QueueResponse("l");
-            else {
-                auto paginated_str = library_list.substr(read_offset, read_length);
-                context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
-                context->QueueResponse(paginated_str);
-            }
-        }
-        else {
-            context->QueueResponse(RESPONSE_EMPTY);
-        }
-    }
-    else {
-        context->QueueResponse(RESPONSE_EMPTY);
-    }
+			if (read_offset >= library_list.size())
+				context->QueueResponse("l");
+			else
+			{
+				auto paginated_str = library_list.substr(read_offset, read_length);
+				context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+				context->QueueResponse(paginated_str);
+			}
+		}
+		else
+		{
+			context->QueueResponse(RESPONSE_EMPTY);
+		}
+	}
+	else
+	{
+		context->QueueResponse(RESPONSE_EMPTY);
+	}
 }
 
-void GDBServer::HandleVCont(std::unique_ptr<CommandContext>& context) {
-    if (!context->IsValid()) {
-        cemuLog_logDebug(LogType::Force, "[GDBStub] Received unsupported vCont command: {}", context->GetCommand());
-        //cemu_assert_unimplemented();
-        return context->QueueResponse(RESPONSE_EMPTY);
-    }
+void GDBServer::HandleVCont(std::unique_ptr<CommandContext>& context)
+{
+	if (!context->IsValid())
+	{
+		cemuLog_logDebug(LogType::Force, "[GDBStub] Received unsupported vCont command: {}", context->GetCommand());
+		// cemu_assert_unimplemented();
+		return context->QueueResponse(RESPONSE_EMPTY);
+	}
 
 	const std::string& vcont_cmd = context->GetArgs()[0];
-    if (vcont_cmd == "vCont?") {
-        return context->QueueResponse("vCont;c;C;s;S");
-    }
-    else if (vcont_cmd != "vCont;") {
-        return context->QueueResponse(RESPONSE_EMPTY);
-    }
+	if (vcont_cmd == "vCont?")
+	{
+		return context->QueueResponse("vCont;c;C;s;S");
+	}
+	else if (vcont_cmd != "vCont;")
+	{
+		return context->QueueResponse(RESPONSE_EMPTY);
+	}
 
-    m_resumed_context = std::move(context);
+	m_resumed_context = std::move(context);
 
-    bool resumedNoThreads = true;
-    for (const auto operationView : std::ranges::split_view(m_resumed_context->GetArgs()[1], ';')) {
-        const std::string_view operation{operationView.begin(), operationView.end()};
+	bool resumedNoThreads = true;
+	for (const auto operationView : std::ranges::split_view(m_resumed_context->GetArgs()[1], ';'))
+	{
+		const std::string_view operation{operationView.begin(), operationView.end()};
 
-        // todo: this might have issues with the signal versions (C/S)
-        // todo: test whether this works with multiple vCont;c:123123;c:123123
-        std::string_view operationType = operation.substr(0, operation.find(':'));
-        sint64 threadSelector = operationType.size() == operation.size() ? -1 : std::stoll(std::string(operation.substr(operationType.size()+1)), nullptr, 16);
+		// todo: this might have issues with the signal versions (C/S)
+		// todo: test whether this works with multiple vCont;c:123123;c:123123
+		std::string_view operationType = operation.substr(0, operation.find(':'));
+		sint64 threadSelector = operationType.size() == operation.size() ? -1 : std::stoll(std::string(operation.substr(operationType.size() + 1)), nullptr, 16);
 
-        if (operationType == "c" || operationType.starts_with("C")) {
-            selectAndResumeThread(threadSelector);
-            resumedNoThreads = false;
-        }
-        else if (operationType == "s" || operationType.starts_with("S")) {
-            selectThread(threadSelector, [this](OSThread_t *thread) {
-                auto nextInstructions = findNextInstruction(thread->context.srr0, thread->context.lr, thread->context.ctr);
-                for (MPTR nextInstr : nextInstructions) {
-                    if (auto bpIt = m_patchedInstructions.find(nextInstr); bpIt == m_patchedInstructions.end() || !bpIt->second.pauseThreads) {
-                        this->insertBreakpoint(nextInstr, false, true, false, true);
-                    }
-                }
-            });
-        }
-    }
+		if (operationType == "c" || operationType.starts_with("C"))
+		{
+			selectAndResumeThread(threadSelector);
+			resumedNoThreads = false;
+		}
+		else if (operationType == "s" || operationType.starts_with("S"))
+		{
+			selectThread(threadSelector, [this](OSThread_t* thread) {
+				auto nextInstructions = findNextInstruction(thread->context.srr0, thread->context.lr, thread->context.ctr);
+				for (MPTR nextInstr : nextInstructions)
+				{
+					if (auto bpIt = m_patchedInstructions.find(nextInstr); bpIt == m_patchedInstructions.end() || !bpIt->second.pauseThreads)
+					{
+						this->insertBreakpoint(nextInstr, false, true, false, true);
+					}
+				}
+			});
+		}
+	}
 
-    if (resumedNoThreads) {
-        selectAndResumeThread(-1);
-        cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed all threads after skip instructions");
-    }
+	if (resumedNoThreads)
+	{
+		selectAndResumeThread(-1);
+		cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed all threads after skip instructions");
+	}
 }
 
-void GDBServer::CMDContinue(std::unique_ptr<CommandContext>& context) {
-    m_resumed_context = std::move(context);
-    selectAndResumeThread(m_activeThreadContinueSelector);
+void GDBServer::CMDContinue(std::unique_ptr<CommandContext>& context)
+{
+	m_resumed_context = std::move(context);
+	selectAndResumeThread(m_activeThreadContinueSelector);
 }
 
-
-void GDBServer::CMDNotFound(std::unique_ptr<CommandContext>& context) {
+void GDBServer::CMDNotFound(std::unique_ptr<CommandContext>& context)
+{
 	return context->QueueResponse(RESPONSE_EMPTY);
 }
 
-void GDBServer::CMDIsThreadActive(std::unique_ptr<CommandContext>& context) {
-    sint64 threadSelector = std::stoll(context->GetArgs()[2], nullptr, 16);
-    bool foundThread = false;
-    selectThread(threadSelector, [&foundThread](OSThread_t* thread) {
-        foundThread = true;
-    });
+void GDBServer::CMDIsThreadActive(std::unique_ptr<CommandContext>& context)
+{
+	sint64 threadSelector = std::stoll(context->GetArgs()[2], nullptr, 16);
+	bool foundThread = false;
+	selectThread(threadSelector, [&foundThread](OSThread_t* thread) {
+		foundThread = true;
+	});
 
-    if (foundThread)
-        return context->QueueResponse(RESPONSE_OK);
-    else
-        return context->QueueResponse(RESPONSE_ERROR);
+	if (foundThread)
+		return context->QueueResponse(RESPONSE_OK);
+	else
+		return context->QueueResponse(RESPONSE_ERROR);
 }
 
-void GDBServer::CMDSetActiveThread(std::unique_ptr<CommandContext>& context) {
-    sint64 threadSelector = std::stoll(context->GetArgs()[2], nullptr, 16);
-    if (threadSelector >= 0) {
-        bool foundThread = false;
-        selectThread(threadSelector, [&foundThread](OSThread_t *thread) {
-            foundThread = true;
-        });
-        if (!foundThread)
-            return context->QueueResponse(RESPONSE_ERROR);
-    }
-    if (context->GetArgs()[1] == "c") m_activeThreadContinueSelector = threadSelector;
-    else m_activeThreadSelector = threadSelector;
-    return context->QueueResponse(RESPONSE_OK);
+void GDBServer::CMDSetActiveThread(std::unique_ptr<CommandContext>& context)
+{
+	sint64 threadSelector = std::stoll(context->GetArgs()[2], nullptr, 16);
+	if (threadSelector >= 0)
+	{
+		bool foundThread = false;
+		selectThread(threadSelector, [&foundThread](OSThread_t* thread) {
+			foundThread = true;
+		});
+		if (!foundThread)
+			return context->QueueResponse(RESPONSE_ERROR);
+	}
+	if (context->GetArgs()[1] == "c")
+		m_activeThreadContinueSelector = threadSelector;
+	else
+		m_activeThreadSelector = threadSelector;
+	return context->QueueResponse(RESPONSE_OK);
 }
 
-void GDBServer::CMDGetThreadStatus(std::unique_ptr<CommandContext>& context) {
-    selectThread(0, [&context](OSThread_t* thread) {
-        context->QueueResponse(fmt::format("T05thread:{:08X};", memory_getVirtualOffsetFromPointer(thread)));
-    });
+void GDBServer::CMDGetThreadStatus(std::unique_ptr<CommandContext>& context)
+{
+	selectThread(0, [&context](OSThread_t* thread) {
+		context->QueueResponse(fmt::format("T05thread:{:08X};", memory_getVirtualOffsetFromPointer(thread)));
+	});
 }
 
-void GDBServer::CMDReadRegister(std::unique_ptr<CommandContext>& context) const {
-    sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
-    selectThread(m_activeThreadSelector, [reg, &context](OSThread_t* thread) {
-        auto& cpu = thread->context;
-        if (reg >= RegisterID::R0_START && reg <= RegisterID::R31_END) {
-            return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.gpr[reg])));
-        }
-        else if (reg >= RegisterID::F0_START && reg <= RegisterID::F31_END) {
-            return context->QueueResponse(fmt::format("{:016X}", cpu.fp_ps0[reg-RegisterID::F0_START].value()));
-        }
-        else if (reg == RegisterID::FPSCR) {
-            return context->QueueResponse(fmt::format("{:08X}", cpu.fpscr.fpscr.value()));
-        }
-        else {
-            switch (reg) {
-                case RegisterID::PC: return context->QueueResponse(fmt::format("{:08X}", cpu.srr0));
-                case RegisterID::MSR: return context->QueueResponse("xxxxxxxx");
-                case RegisterID::CR: return context->QueueResponse(fmt::format("{:08X}", cpu.cr));
-                case RegisterID::LR: return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.lr)));
-                case RegisterID::CTR: return context->QueueResponse(fmt::format("{:08X}", cpu.ctr));
-                case RegisterID::XER: return context->QueueResponse(fmt::format("{:08X}", cpu.xer));
-                default: break;
-            }
-        }
-    });
+void GDBServer::CMDReadRegister(std::unique_ptr<CommandContext>& context) const
+{
+	sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
+	selectThread(m_activeThreadSelector, [reg, &context](OSThread_t* thread) {
+		auto& cpu = thread->context;
+		if (reg >= RegisterID::R0_START && reg <= RegisterID::R31_END)
+		{
+			return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.gpr[reg])));
+		}
+		else if (reg >= RegisterID::F0_START && reg <= RegisterID::F31_END)
+		{
+			return context->QueueResponse(fmt::format("{:016X}", cpu.fp_ps0[reg - RegisterID::F0_START].value()));
+		}
+		else if (reg == RegisterID::FPSCR)
+		{
+			return context->QueueResponse(fmt::format("{:08X}", cpu.fpscr.fpscr.value()));
+		}
+		else
+		{
+			switch (reg)
+			{
+			case RegisterID::PC: return context->QueueResponse(fmt::format("{:08X}", cpu.srr0));
+			case RegisterID::MSR: return context->QueueResponse("xxxxxxxx");
+			case RegisterID::CR: return context->QueueResponse(fmt::format("{:08X}", cpu.cr));
+			case RegisterID::LR: return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.lr)));
+			case RegisterID::CTR: return context->QueueResponse(fmt::format("{:08X}", cpu.ctr));
+			case RegisterID::XER: return context->QueueResponse(fmt::format("{:08X}", cpu.xer));
+			default: break;
+			}
+		}
+	});
 }
 
-void GDBServer::CMDWriteRegister(std::unique_ptr<CommandContext>& context) const {
-    sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
-    uint64 value = std::stoll(context->GetArgs()[2], nullptr, 16);
-    selectThread(m_activeThreadSelector, [reg, value, &context](OSThread_t* thread) {
-        auto& cpu = thread->context;
-        if (reg >= RegisterID::R0_START && reg <= RegisterID::R31_END) {
-            cpu.gpr[reg] = CPU_swapEndianU32(value);
-            return context->QueueResponse(RESPONSE_OK);
-        }
-        else if (reg >= RegisterID::F0_START && reg <= RegisterID::F31_END) {
-            // todo: figure out how to properly write to paired single registers
-            cpu.fp_ps0[reg-RegisterID::F0_START] = uint64be{value};
-            return context->QueueResponse(RESPONSE_OK);
-        }
-        else if (reg == RegisterID::FPSCR) {
-            cpu.fpscr.fpscr = uint32be{(uint32)value};
-            return context->QueueResponse(RESPONSE_OK);
-        }
-        else {
-            switch (reg) {
-                case RegisterID::PC:
-                    cpu.srr0 = value;
-                    return context->QueueResponse(RESPONSE_OK);
-                case RegisterID::MSR:
-                    return context->QueueResponse(RESPONSE_ERROR);
-                case RegisterID::CR:
-                    cpu.cr = value;
-                    return context->QueueResponse(RESPONSE_OK);
-                case RegisterID::LR:
-                    cpu.lr = CPU_swapEndianU32(value);
-                    return context->QueueResponse(RESPONSE_OK);
-                case RegisterID::CTR:
-                    cpu.ctr = value;
-                    return context->QueueResponse(RESPONSE_OK);
-                case RegisterID::XER:
-                    cpu.xer = value;
-                    return context->QueueResponse(RESPONSE_OK);
-                default:
-                    return context->QueueResponse(RESPONSE_ERROR);
-            }
-        }
-    });
+void GDBServer::CMDWriteRegister(std::unique_ptr<CommandContext>& context) const
+{
+	sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
+	uint64 value = std::stoll(context->GetArgs()[2], nullptr, 16);
+	selectThread(m_activeThreadSelector, [reg, value, &context](OSThread_t* thread) {
+		auto& cpu = thread->context;
+		if (reg >= RegisterID::R0_START && reg <= RegisterID::R31_END)
+		{
+			cpu.gpr[reg] = CPU_swapEndianU32(value);
+			return context->QueueResponse(RESPONSE_OK);
+		}
+		else if (reg >= RegisterID::F0_START && reg <= RegisterID::F31_END)
+		{
+			// todo: figure out how to properly write to paired single registers
+			cpu.fp_ps0[reg - RegisterID::F0_START] = uint64be{value};
+			return context->QueueResponse(RESPONSE_OK);
+		}
+		else if (reg == RegisterID::FPSCR)
+		{
+			cpu.fpscr.fpscr = uint32be{(uint32)value};
+			return context->QueueResponse(RESPONSE_OK);
+		}
+		else
+		{
+			switch (reg)
+			{
+			case RegisterID::PC:
+				cpu.srr0 = value;
+				return context->QueueResponse(RESPONSE_OK);
+			case RegisterID::MSR:
+				return context->QueueResponse(RESPONSE_ERROR);
+			case RegisterID::CR:
+				cpu.cr = value;
+				return context->QueueResponse(RESPONSE_OK);
+			case RegisterID::LR:
+				cpu.lr = CPU_swapEndianU32(value);
+				return context->QueueResponse(RESPONSE_OK);
+			case RegisterID::CTR:
+				cpu.ctr = value;
+				return context->QueueResponse(RESPONSE_OK);
+			case RegisterID::XER:
+				cpu.xer = value;
+				return context->QueueResponse(RESPONSE_OK);
+			default:
+				return context->QueueResponse(RESPONSE_ERROR);
+			}
+		}
+	});
 }
 
-void GDBServer::CMDReadRegisters(std::unique_ptr<CommandContext>& context) const {
-    selectThread(m_activeThreadSelector, [&context](OSThread_t *thread) {
-        for (uint32& reg : thread->context.gpr) {
-            context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(reg)));
-        }
-    });
+void GDBServer::CMDReadRegisters(std::unique_ptr<CommandContext>& context) const
+{
+	selectThread(m_activeThreadSelector, [&context](OSThread_t* thread) {
+		for (uint32& reg : thread->context.gpr)
+		{
+			context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(reg)));
+		}
+	});
 }
 
-void GDBServer::CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const {
-    selectThread(m_activeThreadSelector, [&context](OSThread_t *thread) {
-        auto& registers = context->GetArgs()[1];
-        for (uint32 i=0; i<32; i++) {
-            thread->context.gpr[i] = CPU_swapEndianU32(std::stoi(registers.substr(i*2, 2), nullptr, 16));
-        }
-    });
+void GDBServer::CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const
+{
+	selectThread(m_activeThreadSelector, [&context](OSThread_t* thread) {
+		auto& registers = context->GetArgs()[1];
+		for (uint32 i = 0; i < 32; i++)
+		{
+			thread->context.gpr[i] = CPU_swapEndianU32(std::stoi(registers.substr(i * 2, 2), nullptr, 16));
+		}
+	});
 }
 
-void GDBServer::CMDReadMemory(std::unique_ptr<CommandContext>& context) {
-    sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
-    sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
+void GDBServer::CMDReadMemory(std::unique_ptr<CommandContext>& context)
+{
+	sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
+	sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
 
-    // todo: handle cross-mmu-range memory requests
-    if (!memory_isAddressRangeAccessible(addr, length))
-        return context->QueueResponse(RESPONSE_ERROR);
+	// todo: handle cross-mmu-range memory requests
+	if (!memory_isAddressRangeAccessible(addr, length))
+		return context->QueueResponse(RESPONSE_ERROR);
 
-    std::string memoryRepr;
-    uint8* values = memory_getPointerFromVirtualOffset(addr);
-    for (sint64 i=0; i<length; i++) {
-        memoryRepr += fmt::format("{:02X}", values[i]);
-    }
+	std::string memoryRepr;
+	uint8* values = memory_getPointerFromVirtualOffset(addr);
+	for (sint64 i = 0; i < length; i++)
+	{
+		memoryRepr += fmt::format("{:02X}", values[i]);
+	}
 
-    auto patchesRange = m_patchedInstructions.lower_bound(addr);
-    while (patchesRange != m_patchedInstructions.end() && patchesRange->first < (addr + length)) {
-        if (!patchesRange->second.visible) {
-            auto replStr = fmt::format("{:02X}", patchesRange->second.origOpCode);
-            memoryRepr[(patchesRange->first-addr)*2] = replStr[0];
-            memoryRepr[(patchesRange->first-addr)*2+1] = replStr[1];
-        }
-        patchesRange++;
-    }
-    return context->QueueResponse(memoryRepr);
+	auto patchesRange = m_patchedInstructions.lower_bound(addr);
+	while (patchesRange != m_patchedInstructions.end() && patchesRange->first < (addr + length))
+	{
+		if (!patchesRange->second.visible)
+		{
+			auto replStr = fmt::format("{:02X}", patchesRange->second.origOpCode);
+			memoryRepr[(patchesRange->first - addr) * 2] = replStr[0];
+			memoryRepr[(patchesRange->first - addr) * 2 + 1] = replStr[1];
+		}
+		patchesRange++;
+	}
+	return context->QueueResponse(memoryRepr);
 }
 
-void GDBServer::CMDWriteMemory(std::unique_ptr<CommandContext>& context) {
-    sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
-    sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
-    auto source = context->GetArgs()[3];
+void GDBServer::CMDWriteMemory(std::unique_ptr<CommandContext>& context)
+{
+	sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
+	sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
+	auto source = context->GetArgs()[3];
 
-    // todo: handle cross-mmu-range memory requests
-    if (!memory_isAddressRangeAccessible(addr, length))
-        return context->QueueResponse(RESPONSE_ERROR);
+	// todo: handle cross-mmu-range memory requests
+	if (!memory_isAddressRangeAccessible(addr, length))
+		return context->QueueResponse(RESPONSE_ERROR);
 
-    uint8* values = memory_getPointerFromVirtualOffset(addr);
-    for (sint64 i=0; i<length; i++) {
-        uint8 hexValue;
-        const std::from_chars_result result = std::from_chars(source.data() + (i*2), (source.data() + (i*2) + 2), hexValue, 16);
-        if (result.ec == std::errc::invalid_argument || result.ec == std::errc::result_out_of_range)
-            return context->QueueResponse(RESPONSE_ERROR);
+	uint8* values = memory_getPointerFromVirtualOffset(addr);
+	for (sint64 i = 0; i < length; i++)
+	{
+		uint8 hexValue;
+		const std::from_chars_result result = std::from_chars(source.data() + (i * 2), (source.data() + (i * 2) + 2), hexValue, 16);
+		if (result.ec == std::errc::invalid_argument || result.ec == std::errc::result_out_of_range)
+			return context->QueueResponse(RESPONSE_ERROR);
 
-        if (auto it = m_patchedInstructions.find(addr + i); it != m_patchedInstructions.end()) {
-            uint32 byteIndex = 3-((addr+i)%4); // inverted because of big endian, so address 0 is the highest byte
-            it->second.origOpCode &= ~(0xFF<<(byteIndex*8)); // mask out the byte
-            it->second.origOpCode |= ((uint32)hexValue<<(byteIndex*8)); // set new byte with OR
-        }
-        else {
-            values[i] = hexValue;
-        }
-    }
-    return context->QueueResponse(RESPONSE_OK);
+		if (auto it = m_patchedInstructions.find(addr + i); it != m_patchedInstructions.end())
+		{
+			uint32 byteIndex = 3 - ((addr + i) % 4);						// inverted because of big endian, so address 0 is the highest byte
+			it->second.origOpCode &= ~(0xFF << (byteIndex * 8));			// mask out the byte
+			it->second.origOpCode |= ((uint32)hexValue << (byteIndex * 8)); // set new byte with OR
+		}
+		else
+		{
+			values[i] = hexValue;
+		}
+	}
+	return context->QueueResponse(RESPONSE_OK);
 }
 
-void GDBServer::CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context) {
-    auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
-    MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
+void GDBServer::CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context)
+{
+	auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
+	MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
 
-    if (!(type == 0 || type == 1))
-        return context->QueueResponse(RESPONSE_EMPTY);
+	if (!(type == 0 || type == 1))
+		return context->QueueResponse(RESPONSE_EMPTY);
 
-    insertBreakpoint(addr, type == 0, true, true, false);
-    return context->QueueResponse(RESPONSE_OK);
+	insertBreakpoint(addr, type == 0, true, true, false);
+	return context->QueueResponse(RESPONSE_OK);
 }
 
-void GDBServer::CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context) {
-    auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
-    MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
+void GDBServer::CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context)
+{
+	auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
+	MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
 
-    if (!(type == 0 || type == 1))
-        return context->QueueResponse(RESPONSE_EMPTY);
+	if (!(type == 0 || type == 1))
+		return context->QueueResponse(RESPONSE_EMPTY);
 
-    deleteBreakpoint(addr);
-    return context->QueueResponse(RESPONSE_OK);
+	deleteBreakpoint(addr);
+	return context->QueueResponse(RESPONSE_OK);
 }
 
 // Internal functions for control
-void GDBServer::HandleTrapInstruction(PPCInterpreter_t* hCPU) {
-    // First, restore any removed breakpoints
-    for (auto& bp : m_patchedInstructions) {
-        if (bp.second.removedAfterInterrupt) {
-            restoreBreakpoint(bp.first);
-        }
-    }
+void GDBServer::HandleTrapInstruction(PPCInterpreter_t* hCPU)
+{
+	// First, restore any removed breakpoints
+	for (auto& bp : m_patchedInstructions)
+	{
+		if (bp.second.removedAfterInterrupt)
+		{
+			restoreBreakpoint(bp.first);
+		}
+	}
 
-    // Find patched instruction that triggered trap
-    auto patchedBP = m_patchedInstructions.find(hCPU->instructionPointer);
-    if (patchedBP == m_patchedInstructions.end()) {
-        cemu_assert_suspicious();
-        return;
-    }
+	// Find patched instruction that triggered trap
+	auto patchedBP = m_patchedInstructions.find(hCPU->instructionPointer);
+	if (patchedBP == m_patchedInstructions.end())
+	{
+		cemu_assert_suspicious();
+		return;
+	}
 
-    // Secondly, delete one-shot breakpoints but also temporarily delete patched instruction to run original instruction
-    bool pauseThreads = patchedBP->second.pauseThreads;
-    if (patchedBP->second.restoreAfterInterrupt) {
-        // Insert new restore breakpoint at next possible instructions which restores breakpoints but won't pause the CPU
-        std::vector<MPTR> nextInstructions = findNextInstruction(hCPU->instructionPointer, hCPU->spr.LR, hCPU->spr.CTR);
-        for (MPTR nextInstr : nextInstructions) {
-            if (!m_patchedInstructions.contains(nextInstr)) {
-                insertBreakpoint(nextInstr, false, false, false, true);
-            }
-        }
+	// Secondly, delete one-shot breakpoints but also temporarily delete patched instruction to run original instruction
+	bool pauseThreads = patchedBP->second.pauseThreads;
+	if (patchedBP->second.restoreAfterInterrupt)
+	{
+		// Insert new restore breakpoint at next possible instructions which restores breakpoints but won't pause the CPU
+		std::vector<MPTR> nextInstructions = findNextInstruction(hCPU->instructionPointer, hCPU->spr.LR, hCPU->spr.CTR);
+		for (MPTR nextInstr : nextInstructions)
+		{
+			if (!m_patchedInstructions.contains(nextInstr))
+			{
+				insertBreakpoint(nextInstr, false, false, false, true);
+			}
+		}
 
-        // Disable current BP breakpoint to run original instruction
-        deleteBreakpoint(patchedBP->first, true);
-    }
-    else {
-        deleteBreakpoint(patchedBP->first);
-    }
+		// Disable current BP breakpoint to run original instruction
+		deleteBreakpoint(patchedBP->first, true);
+	}
+	else
+	{
+		deleteBreakpoint(patchedBP->first);
+	}
 
-    // Thirdly, delete any instructions that were generated by a skip instruction
-    for (auto it = m_patchedInstructions.cbegin(), next_it = it; it != m_patchedInstructions.cend(); it = next_it) {
-        ++next_it;
-        if (it->second.deleteAfterInterrupt) {
-            deleteBreakpoint(it->first);
-        }
-    }
+	// Thirdly, delete any instructions that were generated by a skip instruction
+	for (auto it = m_patchedInstructions.cbegin(), next_it = it; it != m_patchedInstructions.cend(); it = next_it)
+	{
+		++next_it;
+		if (it->second.deleteAfterInterrupt)
+		{
+			deleteBreakpoint(it->first);
+		}
+	}
 
-    // Fourthly, the stub can insert breakpoints that are just meant to restore patched instructions, in which case we just want to continue
-    if (pauseThreads) {
-        cemuLog_logDebug(LogType::Force, "[GDBStub] Got trapped by a breakpoint!");
-        if (m_resumed_context) {
-            // Spin up thread to signal when another GDB stub trap is found
-            ThreadPool::FireAndForget(&waitForBrokenThreads, std::move(m_resumed_context));
-        }
+	// Fourthly, the stub can insert breakpoints that are just meant to restore patched instructions, in which case we just want to continue
+	if (pauseThreads)
+	{
+		cemuLog_logDebug(LogType::Force, "[GDBStub] Got trapped by a breakpoint!");
+		if (m_resumed_context)
+		{
+			// Spin up thread to signal when another GDB stub trap is found
+			ThreadPool::FireAndForget(&waitForBrokenThreads, std::move(m_resumed_context));
+		}
 
-        breakThreads(GET_THREAD_ID(coreinitThread_getCurrentThreadDepr(hCPU)));
-        cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed from a breakpoint!");
-    }
+		breakThreads(GET_THREAD_ID(coreinitThread_getCurrentThreadDepr(hCPU)));
+		cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed from a breakpoint!");
+	}
 }
 
-void GDBServer::HandleEntryStop(uint32 entryAddress) {
-    insertBreakpoint(entryAddress, false, true, true, false);
-    m_entry_point = entryAddress;
+void GDBServer::HandleEntryStop(uint32 entryAddress)
+{
+	insertBreakpoint(entryAddress, false, true, true, false);
+	m_entry_point = entryAddress;
 }

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
@@ -1,0 +1,930 @@
+#include "GDBStub.h"
+#include "Debugger.h"
+#include "Cafe/HW/Espresso/Recompiler/PPCRecompiler.h"
+#include "util/helpers/helpers.h"
+#include "util/ThreadPool/ThreadPool.h"
+#include "Cafe/OS/RPL/rpl.h"
+#include "Cafe/OS/RPL/rpl_structs.h"
+#include "Cafe/OS/libs/coreinit/coreinit_Scheduler.h"
+#include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
+#include "Cafe/HW/Espresso/Interpreter/PPCInterpreterInternal.h"
+
+#include <ranges>
+#include <HW/Espresso/EspressoISA.h>
+
+#define GET_THREAD_ID(threadPtr) memory_getVirtualOffsetFromPointer(threadPtr)
+#define GET_THREAD_BY_ID(threadId) (OSThread_t*)memory_getPointerFromPhysicalOffset(threadId)
+
+
+template<typename F>
+static void selectThread(sint64 selectorId, F&& action_for_thread) {
+    __OSLockScheduler();
+    cemu_assert_debug(activeThreadCount != 0);
+
+    if (selectorId == -1) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            action_for_thread(GET_THREAD_BY_ID(activeThread[i]));
+        }
+    }
+    else if (selectorId == 0) {
+        // Use first thread if attempted to be stopped
+        // todo: would this work better if it used main?
+        action_for_thread(coreinit::OSGetDefaultThread(1));
+    }
+    else if (selectorId > 0) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+            if (GET_THREAD_ID(thread) == selectorId) {
+                action_for_thread(thread);
+                break;
+            }
+        }
+    }
+    __OSUnlockScheduler();
+}
+
+template<typename F>
+static void selectAndBreakThread(sint64 selectorId, F&& action_for_thread) {
+    __OSLockScheduler();
+    cemu_assert_debug(activeThreadCount != 0);
+
+    std::vector<OSThread_t*> pausedThreads;
+    if (selectorId == -1) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
+            pausedThreads.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
+        }
+    }
+    else if (selectorId == 0) {
+        // Use first thread if attempted to be stopped
+        OSThread_t* thread = GET_THREAD_BY_ID(activeThread[0]);
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) < GET_THREAD_ID(thread)) {
+                thread = GET_THREAD_BY_ID(activeThread[i]);
+            }
+        }
+        coreinit::__OSSuspendThreadNolock(thread);
+        pausedThreads.emplace_back(thread);
+    }
+    else if (selectorId > 0) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+            if (GET_THREAD_ID(thread) == selectorId) {
+                coreinit::__OSSuspendThreadNolock(thread);
+                pausedThreads.emplace_back(thread);
+                break;
+            }
+        }
+    }
+    __OSUnlockScheduler();
+
+    for (OSThread_t* thread : pausedThreads) {
+        while (coreinit::OSIsThreadRunning(thread)) std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        action_for_thread(thread);
+    }
+}
+
+static void selectAndResumeThread(sint64 selectorId) {
+    __OSLockScheduler();
+    cemu_assert_debug(activeThreadCount != 0);
+
+    if (selectorId == -1) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            coreinit::__OSResumeThreadInternal(GET_THREAD_BY_ID(activeThread[i]), 4);
+        }
+    }
+    else if (selectorId == 0) {
+        // Use first thread if attempted to be stopped
+        coreinit::__OSResumeThreadInternal(coreinit::OSGetDefaultThread(1), 1);
+    }
+    else if (selectorId > 0) {
+        for (sint32 i = 0; i < activeThreadCount; i++) {
+            auto* thread = GET_THREAD_BY_ID(activeThread[i]);
+            if (GET_THREAD_ID(thread) == selectorId) {
+                coreinit::__OSResumeThreadInternal(thread, 1);
+                break;
+            }
+        }
+    }
+    __OSUnlockScheduler();
+}
+
+static void waitForBrokenThreads(std::unique_ptr<GDBServer::CommandContext> context) {
+    // This should pause all threads except trapped thread
+    // It should however wait for the trapped thread
+    // The trapped thread should be paused by the trap word instruction handler (aka the running thread)
+    std::vector<OSThread_t*> threadsList;
+    __OSLockScheduler();
+    for (sint32 i = 0; i < activeThreadCount; i++) {
+        threadsList.emplace_back(GET_THREAD_BY_ID(activeThread[i]));
+    }
+    __OSUnlockScheduler();
+
+    for (OSThread_t* thread : threadsList) {
+        while (coreinit::OSIsThreadRunning(thread)) std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    context->QueueResponse("S05");
+}
+
+static void breakThreads(sint64 trappedThread) {
+    __OSLockScheduler();
+    cemu_assert_debug(activeThreadCount != 0);
+
+    // First, break other threads
+    OSThread_t* mainThread = nullptr;
+    for (sint32 i = 0; i < activeThreadCount; i++) {
+        if (GET_THREAD_ID(GET_THREAD_BY_ID(activeThread[i])) == trappedThread) {
+            mainThread = GET_THREAD_BY_ID(activeThread[i]);
+        }
+        else {
+            coreinit::__OSSuspendThreadNolock(GET_THREAD_BY_ID(activeThread[i]));
+        }
+    }
+
+    // Second, break trapped thread itself which should also pause execution of this handler
+    // This will temporarily lift the scheduler lock until it's resumed from its suspension
+    coreinit::__OSSuspendThreadNolock(mainThread);
+
+    __OSUnlockScheduler();
+}
+
+
+
+/* <feature name="org.gnu.gdb.power.fpu">
+        <reg name="f0" bitsize="64" type="ieee_double" regnum="71"/>
+        <reg name="f1" bitsize="64" type="ieee_double"/>
+        <reg name="f2" bitsize="64" type="ieee_double"/>
+        <reg name="f3" bitsize="64" type="ieee_double"/>
+        <reg name="f4" bitsize="64" type="ieee_double"/>
+        <reg name="f5" bitsize="64" type="ieee_double"/>
+        <reg name="f6" bitsize="64" type="ieee_double"/>
+        <reg name="f7" bitsize="64" type="ieee_double"/>
+        <reg name="f8" bitsize="64" type="ieee_double"/>
+        <reg name="f9" bitsize="64" type="ieee_double"/>
+        <reg name="f10" bitsize="64" type="ieee_double"/>
+        <reg name="f11" bitsize="64" type="ieee_double"/>
+        <reg name="f12" bitsize="64" type="ieee_double"/>
+        <reg name="f13" bitsize="64" type="ieee_double"/>
+        <reg name="f14" bitsize="64" type="ieee_double"/>
+        <reg name="f15" bitsize="64" type="ieee_double"/>
+        <reg name="f16" bitsize="64" type="ieee_double"/>
+        <reg name="f17" bitsize="64" type="ieee_double"/>
+        <reg name="f18" bitsize="64" type="ieee_double"/>
+        <reg name="f19" bitsize="64" type="ieee_double"/>
+        <reg name="f20" bitsize="64" type="ieee_double"/>
+        <reg name="f21" bitsize="64" type="ieee_double"/>
+        <reg name="f22" bitsize="64" type="ieee_double"/>
+        <reg name="f23" bitsize="64" type="ieee_double"/>
+        <reg name="f24" bitsize="64" type="ieee_double"/>
+        <reg name="f25" bitsize="64" type="ieee_double"/>
+        <reg name="f26" bitsize="64" type="ieee_double"/>
+        <reg name="f27" bitsize="64" type="ieee_double"/>
+        <reg name="f28" bitsize="64" type="ieee_double"/>
+        <reg name="f29" bitsize="64" type="ieee_double"/>
+        <reg name="f30" bitsize="64" type="ieee_double"/>
+        <reg name="f31" bitsize="64" type="ieee_double"/>
+        <reg name="fpscr" bitsize="32" group="float"/>
+    </feature>
+ * */
+static constexpr std::string_view GDBTargetXML = R"(<?xml version="1.0"?>
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target version="1.0">
+    <architecture>powerpc:common</architecture>
+    <feature name="org.gnu.gdb.power.core">
+        <reg name="r0" bitsize="32" type="uint32"/>
+        <reg name="r1" bitsize="32" type="uint32"/>
+        <reg name="r2" bitsize="32" type="uint32"/>
+        <reg name="r3" bitsize="32" type="uint32"/>
+        <reg name="r4" bitsize="32" type="uint32"/>
+        <reg name="r5" bitsize="32" type="uint32"/>
+        <reg name="r6" bitsize="32" type="uint32"/>
+        <reg name="r7" bitsize="32" type="uint32"/>
+        <reg name="r8" bitsize="32" type="uint32"/>
+        <reg name="r9" bitsize="32" type="uint32"/>
+        <reg name="r10" bitsize="32" type="uint32"/>
+        <reg name="r11" bitsize="32" type="uint32"/>
+        <reg name="r12" bitsize="32" type="uint32"/>
+        <reg name="r13" bitsize="32" type="uint32"/>
+        <reg name="r14" bitsize="32" type="uint32"/>
+        <reg name="r15" bitsize="32" type="uint32"/>
+        <reg name="r16" bitsize="32" type="uint32"/>
+        <reg name="r17" bitsize="32" type="uint32"/>
+        <reg name="r18" bitsize="32" type="uint32"/>
+        <reg name="r19" bitsize="32" type="uint32"/>
+        <reg name="r20" bitsize="32" type="uint32"/>
+        <reg name="r21" bitsize="32" type="uint32"/>
+        <reg name="r22" bitsize="32" type="uint32"/>
+        <reg name="r23" bitsize="32" type="uint32"/>
+        <reg name="r24" bitsize="32" type="uint32"/>
+        <reg name="r25" bitsize="32" type="uint32"/>
+        <reg name="r26" bitsize="32" type="uint32"/>
+        <reg name="r27" bitsize="32" type="uint32"/>
+        <reg name="r28" bitsize="32" type="uint32"/>
+        <reg name="r29" bitsize="32" type="uint32"/>
+        <reg name="r30" bitsize="32" type="uint32"/>
+        <reg name="r31" bitsize="32" type="uint32"/>
+        <reg name="pc" bitsize="32" type="code_ptr" regnum="64"/>
+        <reg name="msr" bitsize="32" type="uint32"/>
+        <reg name="cr" bitsize="32" type="uint32"/>
+        <reg name="lr" bitsize="32" type="code_ptr"/>
+        <reg name="ctr" bitsize="32" type="uint32"/>
+        <reg name="xer" bitsize="32" type="uint32"/>
+    </feature>
+</target>)";
+
+
+std::unique_ptr<GDBServer> g_gdbstub;
+
+GDBServer::GDBServer(uint16 port) : m_port(port) {
+#if BOOST_OS_WINDOWS
+	WSADATA wsa;
+	WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+}
+
+GDBServer::~GDBServer() {
+	if (m_client_socket != INVALID_SOCKET) {
+		// close socket from other thread to forcefully stop accept() call
+        closesocket(m_client_socket);
+		m_client_socket = INVALID_SOCKET;
+	}
+
+	if (m_server_socket != INVALID_SOCKET) {
+        closesocket(m_server_socket);
+	}
+#if BOOST_OS_WINDOWS
+	WSACleanup();
+#endif
+
+	m_thread.request_stop();
+	m_thread.join();
+}
+
+bool GDBServer::Initialize() {
+	cemuLog_createLogFile(false);
+
+	if (m_server_socket = socket(PF_INET, SOCK_STREAM, 0); m_server_socket == SOCKET_ERROR)
+		return false;
+
+	int reuseEnabled = TRUE;
+	if (setsockopt(m_server_socket, SOL_SOCKET, SO_REUSEADDR, (char*)&reuseEnabled, sizeof(reuseEnabled)) == SOCKET_ERROR)
+	{
+		closesocket(m_server_socket);
+		m_server_socket = INVALID_SOCKET;
+		return false;
+	}
+
+	memset(&m_server_addr, 0, sizeof(m_server_addr));
+	m_server_addr.sin_family = AF_INET;
+	m_server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	m_server_addr.sin_port = htons(m_port);
+
+	if (bind(m_server_socket, (sockaddr*)&m_server_addr, sizeof(m_server_addr)) == SOCKET_ERROR)
+	{
+		closesocket(m_server_socket);
+		m_server_socket = INVALID_SOCKET;
+		return false;
+	}
+
+	if (listen(m_server_socket, s_maxGDBClients) == SOCKET_ERROR)
+	{
+		closesocket(m_server_socket);
+		m_server_socket = INVALID_SOCKET;
+		return false;
+	}
+
+	m_thread = std::jthread(std::bind(&GDBServer::ThreadFunc, this, std::placeholders::_1));
+
+	return true;
+}
+
+void GDBServer::ThreadFunc(const std::stop_token& stop_token) {
+	SetThreadName("GDBServer::ThreadFunc");
+
+	while (!stop_token.stop_requested())
+	{
+		if (!m_client_connected)
+		{
+			cemuLog_logDebug(LogType::Force, "[GDBStub] Waiting for client to connect on port {}...", m_port);
+			int client_addr_size = sizeof(m_client_addr);
+			m_client_socket = accept(m_server_socket, (struct sockaddr*)&m_client_addr, &client_addr_size);
+			m_client_connected = m_client_socket != SOCKET_ERROR;
+		}
+		else
+		{
+			auto receiveMessage = [&](char* buffer, const int32_t length) -> bool {
+				if (recv(m_client_socket, buffer, length, 0) != SOCKET_ERROR)
+					return false;
+				return true;
+			};
+
+			auto readChar = [&]() -> char {
+				char ret = 0;
+				recv(m_client_socket, &ret, 1, 0);
+				return ret;
+			};
+
+			char packetPrefix = readChar();
+
+			switch (packetPrefix) {
+			case '+':
+			case '-':
+				break;
+			case '\x03': {
+                cemuLog_logDebug(LogType::Force, "[GDBStub] Received interrupt (pressed CTRL+C?) from client!");
+                selectAndBreakThread(-1, [](OSThread_t* thread) {
+                });
+                auto thread_status = fmt::format("T05thread:{:08X};", GET_THREAD_ID(coreinit::OSGetDefaultThread(1)));
+                auto response_full = fmt::format("+${}#{:02x}", thread_status, CommandContext::CalculateChecksum(thread_status));
+                send(m_client_socket, response_full.c_str(), (int)response_full.size(), 0);
+                break;
+            }
+			case '$': {
+				std::string message;
+				uint8 checkedSum = 0;
+				for (uint32_t i = 1; ; i++) {
+					char c = readChar();
+					if (c == '#')
+						break;
+					checkedSum += static_cast<uint8>(c);
+					message.push_back(c);
+
+					if (i >= s_maxPacketSize) {
+						cemuLog_logDebug(LogType::Force, "[GDBStub] Received too big of a buffer: {}", message);
+					}
+				}
+				char checkSumStr[2];
+				receiveMessage(checkSumStr, 2);
+				uint32_t checkSum = std::stoi(checkSumStr, nullptr, 16);
+				assert((checkedSum & 0xFF) == checkSum);
+
+				HandleCommand(message);
+				break;
+			}
+			default:
+				//cemuLog_logDebug(LogType::Force, "[GDBStub] Unknown packet start: {}", packetPrefix);
+                break;
+			}
+		}
+	}
+
+	if (m_client_socket != INVALID_SOCKET)
+		closesocket(m_client_socket);
+}
+
+struct GDBBreakpoint {
+    MPTR address;
+    uint32 origOpCode;
+    bool visible;
+    bool pauseThreads;
+    // type
+    bool restoreAfterInterrupt;
+    bool deleteAfterInterrupt;
+    bool removedAfterInterrupt;
+};
+
+std::map<MPTR, GDBBreakpoint> patchedInstructions;
+
+static void insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt) {
+    //cemuLog_logDebug(LogType::Force, "[GDBStub] Inserting breakpoint for {:08x}, restoreAfterInterrupt = {}, deleteAfterInterrupt = {}, pauseThreads = {}", address, restoreAfterInterrupt, deleteAfterInterrupt, pauseThreads);
+    if (auto bpIt = patchedInstructions.find(address); bpIt != patchedInstructions.end()) {
+        if (!bpIt->second.pauseThreads && pauseThreads) {
+            //cemuLog_logDebug(LogType::Force, "[GDBStub] Upgraded restore point to breakpoint");
+            bpIt->second.pauseThreads = true;
+            bpIt->second.restoreAfterInterrupt = restoreAfterInterrupt;
+        }
+        else {
+            // breakpoint already exists and wasn't previously restore point
+            cemu_assert_suspicious();
+            return;
+        }
+    }
+
+    uint32 origOpCode = memory_readU32(address);
+    memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
+    PPCRecompiler_invalidateRange(address, address + 4);
+
+    patchedInstructions.emplace(address, GDBBreakpoint{
+        .address = address,
+        .origOpCode = origOpCode,
+        .visible = visible,
+        .pauseThreads = pauseThreads,
+        .restoreAfterInterrupt=restoreAfterInterrupt,
+        .deleteAfterInterrupt=deleteAfterInterrupt,
+        .removedAfterInterrupt=false
+    });
+}
+
+static void restoreBreakpoint(MPTR address) {
+    //cemuLog_logDebug(LogType::Force, "[GDBStub] Restoring breakpoint for {:08x}", address);
+    if (!patchedInstructions.contains(address)) {
+        // Restoring a breakpoint on an address that has no breakpoints?
+        cemu_assert_suspicious();
+        return;
+    }
+
+    memory_writeU32(address, DEBUGGER_BP_T_GDBSTUB_TW);
+    PPCRecompiler_invalidateRange(address, address + 4);
+    patchedInstructions[address].removedAfterInterrupt = false;
+}
+
+static void deleteBreakpoint(MPTR address, bool softRemove = false) {
+    //cemuLog_logDebug(LogType::Force, "[GDBStub] {} breakpoint for {:08x}", softRemove ? "Remove" : "Delete", address);
+    if (!patchedInstructions.contains(address)) {
+        // Removing a breakpoint on an address that has no breakpoints?
+        cemu_assert_suspicious();
+        return;
+    }
+
+    memory_writeU32(address, patchedInstructions[address].origOpCode);
+    PPCRecompiler_invalidateRange(address, address + 4);
+
+    if (softRemove)
+        patchedInstructions[address].removedAfterInterrupt = true;
+    else
+        patchedInstructions.erase(address);
+}
+
+static std::vector<MPTR> findNextInstruction(MPTR currAddress, uint32 lr, uint32 ctr) {
+    using namespace Espresso;
+
+    uint32 nextInstr = memory_readU32(currAddress);
+    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::B) {
+        uint32 LI;
+        bool AA, LK;
+        decodeOp_B(nextInstr, LI, AA, LK);
+        if (!AA)
+            LI += currAddress;
+        return {LI};
+    }
+    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::BC) {
+        uint32 BD, BI;
+        BOField BO{};
+        bool AA, LK;
+        decodeOp_BC(nextInstr, BD, BO, BI, AA, LK);
+        if (!LK)
+            BD += currAddress;
+        return {currAddress+4, BD};
+    }
+    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCLR) {
+        return {currAddress+4, lr};
+    }
+    if (GetPrimaryOpcode(nextInstr) == PrimaryOpcode::GROUP_19 && GetGroup19Opcode(nextInstr) == Opcode19::BCCTR) {
+        return {currAddress+4, ctr};
+    }
+    return {currAddress+4};
+}
+
+
+void GDBServer::HandleCommand(const std::string& command_str) {
+	auto context = std::make_unique<CommandContext>(this, command_str);
+
+    if (context->IsValid()) {
+        //cemuLog_logDebug(LogType::Force, "[GDBStub] Extracted Command {}", fmt::join(context->GetArgs(), ","));
+    }
+
+	switch (context->GetType()) {
+	// Extended commands
+	case CmdType::QUERY_GET:
+	case CmdType::QUERY_SET:
+		return HandleQuery(context);
+	case CmdType::VCONT:
+		return HandleVCont(context);
+	// Regular commands
+	case CmdType::IS_THREAD_RUNNING:
+        break;//return CMD
+	case CmdType::SET_ACTIVE_THREAD:
+		return CMDSetActiveThread(context);
+	case CmdType::ACTIVE_THREAD_STATUS:
+		return CMDGetThreadStatus(context);
+    case CmdType::CONTINUE:
+        return CMDContinue(context);
+	case CmdType::ACTIVE_THREAD_STEP:
+		break;
+	case CmdType::REGISTER_READ:
+		return CMDReadRegister(context);
+	case CmdType::REGISTER_SET:
+        return CMDWriteRegister(context);
+	case CmdType::REGISTERS_READ:
+		return CMDReadRegisters(context);
+	case CmdType::REGISTERS_WRITE:
+		return CMDWriteRegisters(context);
+	case CmdType::MEMORY_READ:
+		return CMDReadMemory(context);
+	case CmdType::MEMORY_WRITE:
+        return CMDWriteMemory(context);
+	case CmdType::BREAKPOINT_SET:
+		return CMDInsertBreakpoint(context);
+	case CmdType::BREAKPOINT_REMOVE:
+		return CMDDeleteBreakpoint(context);
+	case CmdType::INVALID:
+	default:
+		return CMDNotFound(context);
+	}
+
+    CMDNotFound(context);
+}
+
+void GDBServer::HandleQuery(std::unique_ptr<CommandContext>& context) const {
+    if (!context->IsValid()) return context->QueueResponse(RESPONSE_EMPTY);
+
+	const auto& query_cmd = context->GetArgs()[0];
+    const auto& query_args = context->GetArgs().begin()+1;
+
+    if (query_cmd == "qSupported") {
+        context->QueueResponse(s_supportedFeatures);
+    }
+    else if (query_cmd == "qAttached") {
+        context->QueueResponse("1");
+    }
+    else if (query_cmd == "qRcmd") {
+    }
+    else if (query_cmd == "qC") {
+        context->QueueResponse("QC");
+        context->QueueResponse(std::to_string(m_activeThreadContinueSelector));
+    }
+    else if (query_cmd == "qOffsets") {
+        const auto module_count = RPLLoader_GetModuleCount();
+        const auto module_list = RPLLoader_GetModuleList();
+        for (sint32 i = 0; i < module_count; i++) {
+            const RPLModule* rpl = module_list[i];
+            if (rpl->entrypoint == m_entry_point) {
+                context->QueueResponse(fmt::format("TextSeg={:08X};DataSeg={:08X}", rpl->regionMappingBase_text.GetMPTR(), rpl->regionMappingBase_data));
+            }
+        }
+    }
+    else if (query_cmd == "qfThreadInfo") {
+        std::vector<std::string> threadIds;
+        selectThread(-1, [&threadIds](OSThread_t* thread) {
+            threadIds.emplace_back(fmt::format("{:08X}", memory_getVirtualOffsetFromPointer(thread)));
+        });
+        context->QueueResponse(fmt::format("m{}", fmt::join(threadIds, ",")));
+    }
+    else if (query_cmd == "qsThreadInfo") {
+        context->QueueResponse("l");
+    }
+    else if (query_cmd == "qXfer") {
+        auto& type = query_args[0];
+
+        if (type == "features") {
+            auto& annex = query_args[1];
+            sint64 read_offset = std::stoul(query_args[2], nullptr, 16);
+            sint64 read_length = std::stoul(query_args[3], nullptr, 16);
+            if (annex == "target.xml") {
+                if (read_offset >= GDBTargetXML.size()) context->QueueResponse("l");
+                else {
+                    auto paginated_str = GDBTargetXML.substr(read_offset, read_length);
+                    context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+                    context->QueueResponse(paginated_str);
+                }
+            }
+            else cemuLog_logDebug(LogType::Force, "[GDBStub] qXfer:features:read:{} isn't a known feature document", annex);
+        }
+        else if (type == "threads") {
+            sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
+            sint64 read_length = std::stoul(query_args[2], nullptr, 16);
+
+            std::string threads_res;
+            threads_res += R"(<?xml version="1.0"?>)";
+            threads_res += "<threads>";
+            // note: clion seems to default to the first thread
+            std::map<sint64, std::string> threads_list;
+            selectThread(-1, [&threads_list](OSThread_t *thread) {
+                std::string entry;
+                entry += fmt::format(R"(<thread id="{:x}" core="{}")", GET_THREAD_ID(thread), thread->context.affinity.value());
+                if (!thread->threadName.IsNull())
+                    entry += fmt::format(R"( name="{}")", CommandContext::EscapeXMLString(thread->threadName.GetPtr()));
+                // todo: could add a human readable description of the thread here
+                entry += fmt::format("></thread>");
+                threads_list.emplace(GET_THREAD_ID(thread), entry);
+            });
+            for (auto& entry : threads_list) {
+                threads_res += entry.second;
+            }
+            threads_res += "</threads>";
+
+            if (read_offset >= threads_res.size()) context->QueueResponse("l");
+            else {
+                auto paginated_str = threads_res.substr(read_offset, read_length);
+                context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+                context->QueueResponse(paginated_str);
+            }
+        }
+        else if (type == "libraries") {
+            sint64 read_offset = std::stoul(query_args[1], nullptr, 16);
+            sint64 read_length = std::stoul(query_args[2], nullptr, 16);
+
+            std::string library_list;
+            library_list += R"(<?xml version="1.0"?>)";
+            library_list += "<library-list>";
+
+            const auto module_count = RPLLoader_GetModuleCount();
+            const auto module_list = RPLLoader_GetModuleList();
+            for (sint32 i = 0; i < module_count; i++) {
+                library_list += fmt::format(R"(<library name="{}"><segment address="{:#x}"/></library>)", CommandContext::EscapeXMLString(module_list[i]->moduleName2), module_list[i]->regionMappingBase_text.GetMPTR());
+            }
+            library_list += "</library-list>";
+
+            if (read_offset >= library_list.size()) context->QueueResponse("l");
+            else {
+                auto paginated_str = library_list.substr(read_offset, read_length);
+                context->QueueResponse((paginated_str.size() == read_length) ? "m" : "l");
+                context->QueueResponse(paginated_str);
+            }
+        }
+        else {
+            context->QueueResponse(RESPONSE_EMPTY);
+        }
+    }
+    else {
+        context->QueueResponse(RESPONSE_EMPTY);
+    }
+}
+
+void GDBServer::HandleVCont(std::unique_ptr<CommandContext>& context) {
+    if (!context->IsValid()) {
+        cemuLog_logDebug(LogType::Force, "[GDBStub] Received unsupported vCont command: {}", context->GetCommand());
+        //cemu_assert_unimplemented();
+        return context->QueueResponse(RESPONSE_EMPTY);
+    }
+
+	const std::string& vcont_cmd = context->GetArgs()[0];
+    if (vcont_cmd == "vCont?") {
+        return context->QueueResponse("vCont;c;C;s;S");
+    }
+    else if (vcont_cmd != "vCont;") {
+        return context->QueueResponse(RESPONSE_EMPTY);
+    }
+
+    m_resumed_context = std::move(context);
+
+    bool resumedNoThreads = true;
+    for (const auto operationView : std::ranges::split_view(m_resumed_context->GetArgs()[1], ';')) {
+        std::string_view operation{operationView.begin(), operationView.end()};
+
+        // todo: this might have issues with the signal versions (C/S)
+        // todo: test whether this works with multiple vCont;c:123123;c:123123
+        std::string_view operationType = operation.substr(0, operation.find(':'));
+        sint64 threadSelector = operationType.size() == operation.size() ? -1 : std::stoll(std::string(operation.substr(operationType.size()+1)), nullptr, 16);
+
+        if (operationType == "c" || operationType.starts_with("C")) {
+            selectAndResumeThread(threadSelector);
+            resumedNoThreads = false;
+        }
+        else if (operationType == "s" || operationType.starts_with("S")) {
+            selectThread(threadSelector, [](OSThread_t *thread) {
+                auto nextInstructions = findNextInstruction(thread->context.srr0, thread->context.lr, thread->context.ctr);
+                for (MPTR nextInstr : nextInstructions) {
+                    if (auto bpIt = patchedInstructions.find(nextInstr); bpIt == patchedInstructions.end() || !bpIt->second.pauseThreads) {
+                        insertBreakpoint(nextInstr, false, true, false, true);
+                    }
+                }
+            });
+        }
+    }
+
+    if (resumedNoThreads) {
+        selectAndResumeThread(-1);
+        cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed all threads after skip instructions");
+    }
+}
+
+void GDBServer::CMDContinue(std::unique_ptr<CommandContext>& context) const {
+    selectAndResumeThread(m_activeThreadContinueSelector);
+}
+
+
+void GDBServer::CMDNotFound(std::unique_ptr<CommandContext>& context) {
+	return context->QueueResponse(RESPONSE_EMPTY);
+}
+
+void GDBServer::CMDSetActiveThread(std::unique_ptr<CommandContext>& context) {
+    sint64 threadSelector = std::stoll(context->GetArgs()[2], nullptr, 16);
+    if (threadSelector >= 0) {
+        bool foundThread = false;
+        selectThread(threadSelector, [&foundThread](OSThread_t *thread) {
+            foundThread = true;
+        });
+        if (!foundThread)
+            return context->QueueResponse(RESPONSE_ERROR);
+    }
+    if (context->GetArgs()[1] == "c") m_activeThreadContinueSelector = threadSelector;
+    else m_activeThreadSelector = threadSelector;
+    context->QueueResponse(RESPONSE_OK);
+}
+
+void GDBServer::CMDGetThreadStatus(std::unique_ptr<CommandContext>& context) {
+    selectThread(0, [&context](OSThread_t* thread) {
+        context->QueueResponse(fmt::format("T05thread:{:08X};", memory_getVirtualOffsetFromPointer(thread)));
+    });
+}
+
+void GDBServer::CMDReadRegister(std::unique_ptr<CommandContext>& context) const {
+    sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
+    selectThread(m_activeThreadSelector, [reg, &context](OSThread_t* thread) {
+        auto& cpu = thread->context;
+        if (reg < 32) {
+            return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.gpr[reg])));
+        }
+        else {
+            switch (reg) {
+                case RegisterID::PC: return context->QueueResponse(fmt::format("{:08X}", cpu.srr0));
+                case RegisterID::MSR: return context->QueueResponse("xxxxxxxx"); // return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.state)));
+                case RegisterID::CR: return context->QueueResponse(fmt::format("{:08X}", cpu.cr));
+                case RegisterID::LR: return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.lr)));
+                case RegisterID::CTR: return context->QueueResponse(fmt::format("{:08X}", cpu.ctr));
+                case RegisterID::XER: return context->QueueResponse(fmt::format("{:08X}", cpu.xer));
+                default: break;
+            }
+        }
+    });
+}
+
+void GDBServer::CMDWriteRegister(std::unique_ptr<CommandContext>& context) const {
+    sint32 reg = std::stoi(context->GetArgs()[1], nullptr, 16);
+    uint32 value = std::stoi(context->GetArgs()[2], nullptr, 16);
+    selectThread(m_activeThreadSelector, [reg, value, &context](OSThread_t* thread) {
+        auto& cpu = thread->context;
+        if (reg < 32) {
+            cpu.gpr[reg] = CPU_swapEndianU32(value);
+            return context->QueueResponse(RESPONSE_OK);
+        }
+        else {
+            switch (reg) {
+                case RegisterID::PC:
+                    cpu.srr0 = value;
+                    return context->QueueResponse(RESPONSE_OK);
+                case RegisterID::MSR:
+                    return context->QueueResponse(RESPONSE_ERROR); // return context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(cpu.state)));
+                case RegisterID::CR:
+                    cpu.cr = value;
+                    return context->QueueResponse(RESPONSE_OK);
+                case RegisterID::LR:
+                    cpu.lr = CPU_swapEndianU32(value);
+                    return context->QueueResponse(RESPONSE_OK);
+                case RegisterID::CTR:
+                    cpu.ctr = value;
+                    return context->QueueResponse(RESPONSE_OK);
+                case RegisterID::XER:
+                    cpu.xer = value;
+                    return context->QueueResponse(RESPONSE_OK);
+                default:
+                    return context->QueueResponse(RESPONSE_ERROR);
+            }
+        }
+    });
+}
+
+void GDBServer::CMDReadRegisters(std::unique_ptr<CommandContext>& context) const {
+    selectThread(m_activeThreadSelector, [&context](OSThread_t *thread) {
+        for (uint32& reg : thread->context.gpr) {
+            context->QueueResponse(fmt::format("{:08X}", CPU_swapEndianU32(reg)));
+        }
+    });
+}
+
+void GDBServer::CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const {
+    auto& registers = context->GetArgs()[1];
+    selectThread(m_activeThreadSelector, [&registers, &context](OSThread_t *thread) {
+        for (uint32 i=0; i<32; i++) {
+            thread->context.gpr[i] = CPU_swapEndianU32(std::stoi(registers.substr(i*2, 2), nullptr, 16));
+        }
+    });
+}
+
+void GDBServer::CMDReadMemory(std::unique_ptr<CommandContext>& context) {
+    sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
+    sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
+
+    // todo: handle cross-mmu-range memory requests
+    if (!memory_isAddressRangeAccessible(addr, length))
+        return context->QueueResponse(RESPONSE_ERROR);
+
+    std::string memoryRepr;
+    uint8* values = memory_getPointerFromVirtualOffset(addr);
+    for (sint64 i=0; i<length; i++) {
+        memoryRepr += fmt::format("{:02X}", values[i]);
+    }
+
+    auto patchesRange = patchedInstructions.lower_bound(addr);
+    while (patchesRange != patchedInstructions.end() && patchesRange->first < (addr+length)) {
+        if (!patchesRange->second.visible) {
+            auto replStr = fmt::format("{:02X}", patchesRange->second.origOpCode);
+            memoryRepr[(patchesRange->first-addr)*2] = replStr[0];
+            memoryRepr[(patchesRange->first-addr)*2+1] = replStr[1];
+        }
+        patchesRange++;
+    }
+    return context->QueueResponse(memoryRepr);
+}
+
+void GDBServer::CMDWriteMemory(std::unique_ptr<CommandContext>& context) {
+    sint64 addr = std::stoul(context->GetArgs()[1], nullptr, 16);
+    sint64 length = std::stoul(context->GetArgs()[2], nullptr, 16);
+    auto source = context->GetArgs()[3];
+
+    // todo: handle cross-mmu-range memory requests
+    if (!memory_isAddressRangeAccessible(addr, length))
+        return context->QueueResponse(RESPONSE_ERROR);
+
+    uint8* values = memory_getPointerFromVirtualOffset(addr);
+    for (sint64 i=0; i<length; i++) {
+        uint8 hexValue;
+        const std::from_chars_result result = std::from_chars(source.data() + (i*2), (source.data() + (i*2) + 2), hexValue, 16);
+        if (result.ec == std::errc::invalid_argument || result.ec == std::errc::result_out_of_range)
+            return context->QueueResponse(RESPONSE_ERROR);
+
+        if (auto it = patchedInstructions.find(addr+i); it != patchedInstructions.end()) {
+            uint32 byteIndex = 3-((addr+i)%4); // inverted because of big endian, so address 0 is the highest byte
+            it->second.origOpCode &= ~(0xFF<<(byteIndex*8)); // mask out the byte
+            it->second.origOpCode |= ((uint32)hexValue<<(byteIndex*8)); // set new byte with OR
+        }
+        else {
+            values[i] = hexValue;
+        }
+    }
+    return context->QueueResponse(RESPONSE_OK);
+}
+
+void GDBServer::CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context) {
+    auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
+    MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
+
+    if (!(type == 0 || type == 1))
+        return context->QueueResponse(RESPONSE_EMPTY);
+
+    insertBreakpoint(addr, type == 0, true, true, false);
+    context->QueueResponse(RESPONSE_OK);
+}
+
+void GDBServer::CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context) {
+    auto type = std::stoul(context->GetArgs()[1], nullptr, 16);
+    MPTR addr = static_cast<MPTR>(std::stoul(context->GetArgs()[2], nullptr, 16));
+
+    if (!(type == 0 || type == 1))
+        return context->QueueResponse(RESPONSE_EMPTY);
+
+    deleteBreakpoint(addr);
+    context->QueueResponse(RESPONSE_OK);
+}
+
+// Internal functions for control
+void GDBServer::HandleTrapInstruction(PPCInterpreter_t* hCPU) {
+    // First, restore any removed breakpoints
+    for (auto& bp : patchedInstructions) {
+        if (bp.second.removedAfterInterrupt) {
+            restoreBreakpoint(bp.first);
+        }
+    }
+
+    // Find patched instruction that triggered trap
+    auto patchedBP = patchedInstructions.find(hCPU->instructionPointer);
+    if (patchedBP == patchedInstructions.end()) {
+        cemu_assert_suspicious();
+        return;
+    }
+
+    // Secondly, delete one-shot breakpoints but also temporarily delete patched instruction to run original instruction
+    bool pauseThreads = patchedBP->second.pauseThreads;
+    if (patchedBP->second.restoreAfterInterrupt) {
+        // Insert new restore breakpoint at next possible instructions which restores breakpoints but won't pause the CPU
+        std::vector<MPTR> nextInstructions = findNextInstruction(hCPU->instructionPointer, hCPU->spr.LR, hCPU->spr.CTR);
+        for (MPTR nextInstr : nextInstructions) {
+            if (!patchedInstructions.contains(nextInstr)) {
+                insertBreakpoint(nextInstr, false, false, false, true);
+            }
+        }
+
+        // Disable current BP breakpoint to run original instruction
+        deleteBreakpoint(patchedBP->first, true);
+    }
+    else {
+        deleteBreakpoint(patchedBP->first);
+    }
+
+    // Thirdly, delete any instructions that were generated by a skip instruction
+    for (auto it = patchedInstructions.cbegin(), next_it = it; it != patchedInstructions.cend(); it = next_it) {
+        ++next_it;
+        if (it->second.deleteAfterInterrupt) {
+            deleteBreakpoint(it->first);
+        }
+    }
+
+    // Fourthly, the stub can insert breakpoints that are just meant to restore patched instructions, in which case we just want to continue
+    if (pauseThreads) {
+        cemuLog_logDebug(LogType::Force, "[GDBStub] Got trapped by a breakpoint!");
+        if (m_resumed_context) {
+            // Spin up thread to signal when another GDB stub trap is found
+            ThreadPool::FireAndForget(&waitForBrokenThreads, std::move(m_resumed_context));
+        }
+
+        breakThreads(GET_THREAD_ID(coreinitThread_getCurrentThreadDepr(hCPU)));
+        cemuLog_logDebug(LogType::Force, "[GDBStub] Resumed from a breakpoint!");
+    }
+}
+
+void GDBServer::HandleEntryStop(uint32 entryAddress) {
+    insertBreakpoint(entryAddress, false, true, true, false);
+    m_entry_point = entryAddress;
+}

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
@@ -244,7 +244,7 @@ GDBServer::~GDBServer()
 	WSACleanup();
 #endif
 
-	m_thread.request_stop();
+	m_stopRequested = false;
 	m_thread.join();
 }
 
@@ -282,16 +282,16 @@ bool GDBServer::Initialize()
 		return false;
 	}
 
-	m_thread = std::jthread(std::bind(&GDBServer::ThreadFunc, this, std::placeholders::_1));
+	m_thread = std::thread(std::bind(&GDBServer::ThreadFunc, this));
 
 	return true;
 }
 
-void GDBServer::ThreadFunc(const std::stop_token& stop_token)
+void GDBServer::ThreadFunc()
 {
 	SetThreadName("GDBServer::ThreadFunc");
 
-	while (!stop_token.stop_requested())
+	while (!m_stopRequested)
 	{
 		if (!m_client_connected)
 		{

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -196,7 +196,8 @@ private:
 	static constexpr std::string_view RESPONSE_OK = "OK";
 	static constexpr std::string_view RESPONSE_ERROR = "E01";
 
-	void ThreadFunc(const std::stop_token& stop_token);
+	void ThreadFunc();
+	std::atomic_bool m_stopRequested;
 	void HandleCommand(const std::string& command_str);
 	void HandleQuery(std::unique_ptr<CommandContext>& context) const;
 	void HandleVCont(std::unique_ptr<CommandContext>& context);
@@ -219,7 +220,7 @@ private:
 	void CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context);
 	void CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context);
 
-	std::jthread m_thread;
+	std::thread m_thread;
 	std::atomic_bool m_resume_startup = false;
 	MPTR m_entry_point{};
 	std::unique_ptr<CommandContext> m_resumed_context;

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <numeric>
-#include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
 #include "Common/precompiled.h"
+#include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
+
+#include <numeric>
 
 class GDBServer
 {
 public:
-	GDBServer(uint16 port);
+	explicit GDBServer(uint16 port);
 	~GDBServer();
 
 	bool Initialize();
@@ -44,12 +45,17 @@ private:
 	};
 
     enum RegisterID {
+        R0_START = 0,
+        R31_END = 0+31,
         PC = 64,
         MSR = 65,
         CR = 66,
         LR = 67,
         CTR = 68,
         XER = 69,
+        F0_START = 71,
+        F31_END = 71+31,
+        FPSCR = 103
     };
 
 	static constexpr std::string_view RESPONSE_EMPTY = "";
@@ -161,10 +167,11 @@ private:
     // Commands
     sint64 m_activeThreadSelector = 0;
     sint64 m_activeThreadContinueSelector = 0;
-    void CMDSetActiveThread(std::unique_ptr<CommandContext>& context); // H
-    void CMDGetThreadStatus(std::unique_ptr<CommandContext>& context); // ?
     void CMDContinue(std::unique_ptr<CommandContext>& context) const;
     void CMDNotFound(std::unique_ptr<CommandContext>& context);
+    void CMDIsThreadActive(std::unique_ptr<CommandContext>& context);
+    void CMDSetActiveThread(std::unique_ptr<CommandContext>& context); // H
+    void CMDGetThreadStatus(std::unique_ptr<CommandContext>& context); // ?
 
     void CMDReadRegister(std::unique_ptr<CommandContext>& context) const;
     void CMDWriteRegister(std::unique_ptr<CommandContext>& context) const;

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <numeric>
+#include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
+#include "Common/precompiled.h"
+
+class GDBServer
+{
+public:
+	GDBServer(uint16 port);
+	~GDBServer();
+
+	bool Initialize();
+	bool IsConnected() { return m_client_connected; }
+
+    void HandleEntryStop(uint32 entryAddress);
+    void HandleTrapInstruction(PPCInterpreter_t* hCPU);
+private:
+	static constexpr int s_maxGDBClients = 1;
+	static constexpr std::string_view s_supportedFeatures = "PacketSize=4096;qXfer:features:read+;qXfer:threads:read+;qXfer:libraries:read+;swbreak+;hwbreak+;vContSupported+";
+	static constexpr size_t s_maxPacketSize = 1024*4;
+	const uint16 m_port;
+
+	enum class CmdType : char {
+		INVALID = '\0',
+		// Extended commands
+		QUERY_GET = 'q',
+		QUERY_SET = 'Q',
+		VCONT = 'v',
+		// Normal commands
+		CONTINUE = 'c',
+		IS_THREAD_RUNNING = 'T',
+		SET_ACTIVE_THREAD = 'H',
+		ACTIVE_THREAD_STATUS = '?',
+		ACTIVE_THREAD_STEP = 's',
+		REGISTER_READ = 'p',
+		REGISTER_SET = 'P',
+		REGISTERS_READ = 'g',
+		REGISTERS_WRITE = 'G',
+		MEMORY_READ = 'm',
+		MEMORY_WRITE = 'M',
+		BREAKPOINT_SET = 'Z',
+		BREAKPOINT_REMOVE = 'z',
+	};
+
+    enum RegisterID {
+        PC = 64,
+        MSR = 65,
+        CR = 66,
+        LR = 67,
+        CTR = 68,
+        XER = 69,
+    };
+
+	static constexpr std::string_view RESPONSE_EMPTY = "";
+	static constexpr std::string_view RESPONSE_ACK = "+";
+	static constexpr std::string_view RESPONSE_NACK = "+";
+	static constexpr std::string_view RESPONSE_OK = "OK";
+	static constexpr std::string_view RESPONSE_ERROR = "E01";
+
+public:
+	class CommandContext {
+    public:
+		CommandContext(const GDBServer* server, const std::string& command) : m_server(server), m_command(command) {
+			std::smatch matches;
+			std::regex_match(command, matches, m_regex);
+			for (size_t i = 1; i < matches.size(); i++) {
+				auto matchStr = matches[i].str();
+                if (!matchStr.empty())
+                    m_args.emplace_back(std::move(matchStr));
+			}
+            send(m_server->m_client_socket, RESPONSE_ACK.data(), (int)RESPONSE_ACK.size(), 0);
+		};
+		~CommandContext() {
+			//cemuLog_logDebug(LogType::Force, "[GDBStub] Received: {}", m_command);
+			//cemuLog_logDebug(LogType::Force, "[GDBStub] Responded: {}", m_response);
+            auto response_data = EscapeMessage(m_response);
+            auto response_full = fmt::format("${}#{:02x}", response_data, CalculateChecksum(response_data));
+            send(m_server->m_client_socket, response_full.c_str(), (int) response_full.size(), 0);
+		}
+        CommandContext(const CommandContext&) = delete;
+
+        [[nodiscard]] const std::string& GetCommand() const { return m_command; };
+		[[nodiscard]] const std::vector<std::string>& GetArgs() const { return m_args; };
+		[[nodiscard]] bool IsValid() const { return !m_args.empty(); };
+        [[nodiscard]] GDBServer::CmdType GetType() const { return static_cast<GDBServer::CmdType>(m_command[0]); };
+
+        // Respond Utils
+        static uint8 CalculateChecksum(std::string_view message_data) {
+            return std::accumulate(message_data.begin(), message_data.end(), (uint8)0, std::plus<>());
+        }
+        static std::string EscapeXMLString(std::string_view xml_data) {
+            std::string escaped;
+            escaped.reserve(xml_data.size());
+            for (char c : xml_data) {
+                switch (c) {
+                    case '<': escaped += "&lt;"; break;
+                    case '>': escaped += "&gt;"; break;
+                    case '&': escaped += "&amp;"; break;
+                    case '"': escaped += "&quot;"; break;
+                    case '\'': escaped += "&apos;"; break;
+                    default: escaped += c; break;
+                }
+            }
+            return escaped;
+        }
+        static std::string EscapeMessage(std::string_view message) {
+            std::string escaped;
+            escaped.reserve(message.size());
+            for (char c : message) {
+                if (c == '#' || c == '$' || c == '}' || c == '*') {
+                    escaped.push_back('}');
+                    escaped.push_back((char)(c ^ 0x20));
+                }
+                else escaped.push_back(c);
+            }
+            return escaped;
+        }
+
+		void QueueResponse(std::string_view data) {
+			m_response += data;
+		}
+	private:
+		const std::regex m_regex{
+			R"((?:)"
+				R"((\?))"
+                R"(|(vCont\?))"
+                R"(|(vCont;)([a-zA-Z0-9-+=,\+:;]+))"
+				R"(|(qAttached))"
+				R"(|(qSupported):([a-zA-Z0-9-+=,\+;]+))"
+                R"(|(qTStatus))"
+                R"(|(qC))"
+                R"(|(qXfer):((?:features)|(?:threads)|(?:libraries)):read:([\w\.]*):([0-9a-zA-Z]+),([0-9a-zA-Z]+))"
+                R"(|(qfThreadInfo))"
+                R"(|(qsThreadInfo))"
+				R"(|(D))" // Detach
+                R"(|(H)(c|g)((?:-1)|(?:[0-9A-Fa-f]+)))" // Set active thread for other operations (not c)
+				R"(|(c)([0-9A-Fa-f]+)?)" // (Legacy, supported by vCont) Continue all for active thread
+				R"(|([Zz])([0-4]),([0-9A-Fa-f]+),([0-9]))" // Insert/delete breakpoints
+				R"(|(g))" // Read registers for active thread
+				R"(|(G)([0-9A-Fa-f]+))" // Write registers for active thread
+                R"(|(p)([0-9A-Fa-f]+))" // Read register for active thread
+                R"(|(P)([0-9A-Fa-f]+)=([0-9A-Fa-f]+))" // Write register for active thread
+				R"(|(m)([0-9A-Fa-f]+),([0-9A-Fa-f]+))" // Read memory
+				R"(|(M)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
+                //R"(|(X)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
+			R"())"
+		};
+		const GDBServer* m_server;
+		const std::string m_command;
+		std::vector<std::string> m_args;
+		std::string m_response;
+	};
+private:
+
+	void ThreadFunc(const std::stop_token& stop_token);
+	void HandleCommand(const std::string& command_str);
+	void HandleQuery(std::unique_ptr<CommandContext>& context) const;
+	void HandleVCont(std::unique_ptr<CommandContext>& context);
+
+    // Commands
+    sint64 m_activeThreadSelector = 0;
+    sint64 m_activeThreadContinueSelector = 0;
+    void CMDSetActiveThread(std::unique_ptr<CommandContext>& context); // H
+    void CMDGetThreadStatus(std::unique_ptr<CommandContext>& context); // ?
+    void CMDContinue(std::unique_ptr<CommandContext>& context) const;
+    void CMDNotFound(std::unique_ptr<CommandContext>& context);
+
+    void CMDReadRegister(std::unique_ptr<CommandContext>& context) const;
+    void CMDWriteRegister(std::unique_ptr<CommandContext>& context) const;
+    void CMDReadRegisters(std::unique_ptr<CommandContext>& context) const;
+    void CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const;
+    void CMDReadMemory(std::unique_ptr<CommandContext>& context);
+    void CMDWriteMemory(std::unique_ptr<CommandContext>& context);
+    void CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context);
+    void CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context);
+
+	std::jthread m_thread;
+    std::atomic_bool m_resume_startup = false;
+    MPTR m_entry_point{};
+    std::unique_ptr<CommandContext> m_resumed_context;
+
+	std::atomic_bool m_client_connected;
+	SOCKET m_server_socket = INVALID_SOCKET;
+	sockaddr_in m_server_addr{};
+	SOCKET m_client_socket = INVALID_SOCKET;
+	sockaddr_in m_client_addr{};
+};
+
+
+extern std::unique_ptr<GDBServer> g_gdbstub;

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -160,21 +160,8 @@ class GDBServer {
 		std::string m_response;
 	};
 
-	struct Breakpoint
-	{
-		MPTR address;
-		uint32 origOpCode;
-		bool visible;
-		bool pauseThreads;
-		// type
-		bool restoreAfterInterrupt;
-		bool deleteAfterInterrupt;
-		bool removedAfterInterrupt;
-	};
-	std::map<MPTR, Breakpoint> m_patchedInstructions;
-	void insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt);
-	void restoreBreakpoint(MPTR address);
-	void deleteBreakpoint(MPTR address, bool softRemove);
+	class ExecutionBreakpoint;
+	std::map<MPTR, ExecutionBreakpoint> m_patchedInstructions;
 
   private:
 	static constexpr int s_maxGDBClients = 1;

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -5,167 +5,197 @@
 
 #include <numeric>
 
-class GDBServer
-{
-public:
+class GDBServer {
+  public:
 	explicit GDBServer(uint16 port);
 	~GDBServer();
 
 	bool Initialize();
-	bool IsConnected() { return m_client_connected; }
+	bool IsConnected()
+	{
+		return m_client_connected;
+	}
 
-    void HandleEntryStop(uint32 entryAddress);
-    void HandleTrapInstruction(PPCInterpreter_t* hCPU);
+	void HandleEntryStop(uint32 entryAddress);
+	void HandleTrapInstruction(PPCInterpreter_t* hCPU);
 
-    enum class CMDType : char {
-        INVALID = '\0',
-        // Extended commands
-        QUERY_GET = 'q',
-        QUERY_SET = 'Q',
-        VCONT = 'v',
-        // Normal commands
-        CONTINUE = 'c',
-        IS_THREAD_RUNNING = 'T',
-        SET_ACTIVE_THREAD = 'H',
-        ACTIVE_THREAD_STATUS = '?',
-        ACTIVE_THREAD_STEP = 's',
-        REGISTER_READ = 'p',
-        REGISTER_SET = 'P',
-        REGISTERS_READ = 'g',
-        REGISTERS_WRITE = 'G',
-        MEMORY_READ = 'm',
-        MEMORY_WRITE = 'M',
-        BREAKPOINT_SET = 'Z',
-        BREAKPOINT_REMOVE = 'z',
-    };
+	enum class CMDType : char
+	{
+		INVALID = '\0',
+		// Extended commands
+		QUERY_GET = 'q',
+		QUERY_SET = 'Q',
+		VCONT = 'v',
+		// Normal commands
+		CONTINUE = 'c',
+		IS_THREAD_RUNNING = 'T',
+		SET_ACTIVE_THREAD = 'H',
+		ACTIVE_THREAD_STATUS = '?',
+		ACTIVE_THREAD_STEP = 's',
+		REGISTER_READ = 'p',
+		REGISTER_SET = 'P',
+		REGISTERS_READ = 'g',
+		REGISTERS_WRITE = 'G',
+		MEMORY_READ = 'm',
+		MEMORY_WRITE = 'M',
+		BREAKPOINT_SET = 'Z',
+		BREAKPOINT_REMOVE = 'z',
+	};
 
-    class CommandContext {
-    public:
-        CommandContext(const GDBServer* server, const std::string& command) : m_server(server), m_command(command) {
-            std::smatch matches;
-            std::regex_match(command, matches, m_regex);
-            for (size_t i = 1; i < matches.size(); i++) {
-                auto matchStr = matches[i].str();
-                if (!matchStr.empty())
-                    m_args.emplace_back(std::move(matchStr));
-            }
-            // send acknowledgement ahead of response
-            send(m_server->m_client_socket, RESPONSE_ACK.data(), (int)RESPONSE_ACK.size(), 0);
-        };
-        ~CommandContext() {
-            //cemuLog_logDebug(LogType::Force, "[GDBStub] Received: {}", m_command);
-            //cemuLog_logDebug(LogType::Force, "[GDBStub] Responded: +{}", m_response);
-            auto response_data = EscapeMessage(m_response);
-            auto response_full = fmt::format("${}#{:02x}", response_data, CalculateChecksum(response_data));
-            send(m_server->m_client_socket, response_full.c_str(), (int) response_full.size(), 0);
-        }
-        CommandContext(const CommandContext&) = delete;
+	class CommandContext {
+	  public:
+		CommandContext(const GDBServer* server, const std::string& command)
+			: m_server(server), m_command(command)
+		{
+			std::smatch matches;
+			std::regex_match(command, matches, m_regex);
+			for (size_t i = 1; i < matches.size(); i++)
+			{
+				auto matchStr = matches[i].str();
+				if (!matchStr.empty())
+					m_args.emplace_back(std::move(matchStr));
+			}
+			// send acknowledgement ahead of response
+			send(m_server->m_client_socket, RESPONSE_ACK.data(), (int)RESPONSE_ACK.size(), 0);
+		};
+		~CommandContext()
+		{
+			// cemuLog_logDebug(LogType::Force, "[GDBStub] Received: {}", m_command);
+			// cemuLog_logDebug(LogType::Force, "[GDBStub] Responded: +{}", m_response);
+			auto response_data = EscapeMessage(m_response);
+			auto response_full = fmt::format("${}#{:02x}", response_data, CalculateChecksum(response_data));
+			send(m_server->m_client_socket, response_full.c_str(), (int)response_full.size(), 0);
+		}
+		CommandContext(const CommandContext&) = delete;
 
-        [[nodiscard]] const std::string& GetCommand() const { return m_command; };
-        [[nodiscard]] const std::vector<std::string>& GetArgs() const { return m_args; };
-        [[nodiscard]] bool IsValid() const { return !m_args.empty(); };
-        [[nodiscard]] CMDType GetType() const { return static_cast<CMDType>(m_command[0]); };
+		[[nodiscard]] const std::string& GetCommand() const
+		{
+			return m_command;
+		};
+		[[nodiscard]] const std::vector<std::string>& GetArgs() const
+		{
+			return m_args;
+		};
+		[[nodiscard]] bool IsValid() const
+		{
+			return !m_args.empty();
+		};
+		[[nodiscard]] CMDType GetType() const
+		{
+			return static_cast<CMDType>(m_command[0]);
+		};
 
-        // Respond Utils
-        static uint8 CalculateChecksum(std::string_view message_data) {
-            return std::accumulate(message_data.begin(), message_data.end(), (uint8)0, std::plus<>());
-        }
-        static std::string EscapeXMLString(std::string_view xml_data) {
-            std::string escaped;
-            escaped.reserve(xml_data.size());
-            for (char c : xml_data) {
-                switch (c) {
-                    case '<': escaped += "&lt;"; break;
-                    case '>': escaped += "&gt;"; break;
-                    case '&': escaped += "&amp;"; break;
-                    case '"': escaped += "&quot;"; break;
-                    case '\'': escaped += "&apos;"; break;
-                    default: escaped += c; break;
-                }
-            }
-            return escaped;
-        }
-        static std::string EscapeMessage(std::string_view message) {
-            std::string escaped;
-            escaped.reserve(message.size());
-            for (char c : message) {
-                if (c == '#' || c == '$' || c == '}' || c == '*') {
-                    escaped.push_back('}');
-                    escaped.push_back((char)(c ^ 0x20));
-                }
-                else escaped.push_back(c);
-            }
-            return escaped;
-        }
-        void QueueResponse(std::string_view data) {
-            m_response += data;
-        }
-    private:
-        const std::regex m_regex{
-                R"((?:)"
-                R"((\?))"
-                R"(|(vCont\?))"
-                R"(|(vCont;)([a-zA-Z0-9-+=,\+:;]+))"
-                R"(|(qAttached))"
-                R"(|(qSupported):([a-zA-Z0-9-+=,\+;]+))"
-                R"(|(qTStatus))"
-                R"(|(qC))"
-                R"(|(qXfer):((?:features)|(?:threads)|(?:libraries)):read:([\w\.]*):([0-9a-zA-Z]+),([0-9a-zA-Z]+))"
-                R"(|(qfThreadInfo))"
-                R"(|(qsThreadInfo))"
-                R"(|(D))" // Detach
-                R"(|(H)(c|g)((?:-1)|(?:[0-9A-Fa-f]+)))" // Set active thread for other operations (not c)
-                R"(|(c)([0-9A-Fa-f]+)?)" // (Legacy, supported by vCont) Continue all for active thread
-                R"(|([Zz])([0-4]),([0-9A-Fa-f]+),([0-9]))" // Insert/delete breakpoints
-                R"(|(g))" // Read registers for active thread
-                R"(|(G)([0-9A-Fa-f]+))" // Write registers for active thread
-                R"(|(p)([0-9A-Fa-f]+))" // Read register for active thread
-                R"(|(P)([0-9A-Fa-f]+)=([0-9A-Fa-f]+))" // Write register for active thread
-                R"(|(m)([0-9A-Fa-f]+),([0-9A-Fa-f]+))" // Read memory
-                R"(|(M)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
-                //R"(|(X)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
-                R"())"
-        };
-        const GDBServer* m_server;
-        const std::string m_command;
-        std::vector<std::string> m_args;
-        std::string m_response;
-    };
+		// Respond Utils
+		static uint8 CalculateChecksum(std::string_view message_data)
+		{
+			return std::accumulate(message_data.begin(), message_data.end(), (uint8)0, std::plus<>());
+		}
+		static std::string EscapeXMLString(std::string_view xml_data)
+		{
+			std::string escaped;
+			escaped.reserve(xml_data.size());
+			for (char c : xml_data)
+			{
+				switch (c)
+				{
+				case '<': escaped += "&lt;"; break;
+				case '>': escaped += "&gt;"; break;
+				case '&': escaped += "&amp;"; break;
+				case '"': escaped += "&quot;"; break;
+				case '\'': escaped += "&apos;"; break;
+				default: escaped += c; break;
+				}
+			}
+			return escaped;
+		}
+		static std::string EscapeMessage(std::string_view message)
+		{
+			std::string escaped;
+			escaped.reserve(message.size());
+			for (char c : message)
+			{
+				if (c == '#' || c == '$' || c == '}' || c == '*')
+				{
+					escaped.push_back('}');
+					escaped.push_back((char)(c ^ 0x20));
+				}
+				else
+					escaped.push_back(c);
+			}
+			return escaped;
+		}
+		void QueueResponse(std::string_view data)
+		{
+			m_response += data;
+		}
 
-    struct Breakpoint {
-        MPTR address;
-        uint32 origOpCode;
-        bool visible;
-        bool pauseThreads;
-        // type
-        bool restoreAfterInterrupt;
-        bool deleteAfterInterrupt;
-        bool removedAfterInterrupt;
-    };
-    std::map<MPTR, Breakpoint> m_patchedInstructions;
-    void insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt);
-    void restoreBreakpoint(MPTR address);
-    void deleteBreakpoint(MPTR address, bool softRemove);
+	  private:
+		const std::regex m_regex{
+			R"((?:)"
+			R"((\?))"
+			R"(|(vCont\?))"
+			R"(|(vCont;)([a-zA-Z0-9-+=,\+:;]+))"
+			R"(|(qAttached))"
+			R"(|(qSupported):([a-zA-Z0-9-+=,\+;]+))"
+			R"(|(qTStatus))"
+			R"(|(qC))"
+			R"(|(qXfer):((?:features)|(?:threads)|(?:libraries)):read:([\w\.]*):([0-9a-zA-Z]+),([0-9a-zA-Z]+))"
+			R"(|(qfThreadInfo))"
+			R"(|(qsThreadInfo))"
+			R"(|(D))"											  // Detach
+			R"(|(H)(c|g)((?:-1)|(?:[0-9A-Fa-f]+)))"				  // Set active thread for other operations (not c)
+			R"(|(c)([0-9A-Fa-f]+)?)"							  // (Legacy, supported by vCont) Continue all for active thread
+			R"(|([Zz])([0-4]),([0-9A-Fa-f]+),([0-9]))"			  // Insert/delete breakpoints
+			R"(|(g))"											  // Read registers for active thread
+			R"(|(G)([0-9A-Fa-f]+))"								  // Write registers for active thread
+			R"(|(p)([0-9A-Fa-f]+))"								  // Read register for active thread
+			R"(|(P)([0-9A-Fa-f]+)=([0-9A-Fa-f]+))"				  // Write register for active thread
+			R"(|(m)([0-9A-Fa-f]+),([0-9A-Fa-f]+))"				  // Read memory
+			R"(|(M)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
+			// R"(|(X)([0-9A-Fa-f]+),([0-9A-Fa-f]+):([0-9A-Fa-f]+))" // Write memory
+			R"())"};
+		const GDBServer* m_server;
+		const std::string m_command;
+		std::vector<std::string> m_args;
+		std::string m_response;
+	};
 
-private:
+	struct Breakpoint
+	{
+		MPTR address;
+		uint32 origOpCode;
+		bool visible;
+		bool pauseThreads;
+		// type
+		bool restoreAfterInterrupt;
+		bool deleteAfterInterrupt;
+		bool removedAfterInterrupt;
+	};
+	std::map<MPTR, Breakpoint> m_patchedInstructions;
+	void insertBreakpoint(MPTR address, bool visible, bool pauseThreads, bool restoreAfterInterrupt, bool deleteAfterInterrupt);
+	void restoreBreakpoint(MPTR address);
+	void deleteBreakpoint(MPTR address, bool softRemove);
+
+  private:
 	static constexpr int s_maxGDBClients = 1;
 	static constexpr std::string_view s_supportedFeatures = "PacketSize=4096;qXfer:features:read+;qXfer:threads:read+;qXfer:libraries:read+;swbreak+;hwbreak+;vContSupported+";
-	static constexpr size_t s_maxPacketSize = 1024*4;
+	static constexpr size_t s_maxPacketSize = 1024 * 4;
 	const uint16 m_port;
 
-    enum RegisterID {
-        R0_START = 0,
-        R31_END = 0+31,
-        PC = 64,
-        MSR = 65,
-        CR = 66,
-        LR = 67,
-        CTR = 68,
-        XER = 69,
-        F0_START = 71,
-        F31_END = 71+31,
-        FPSCR = 103
-    };
+	enum RegisterID
+	{
+		R0_START = 0,
+		R31_END = 0 + 31,
+		PC = 64,
+		MSR = 65,
+		CR = 66,
+		LR = 67,
+		CTR = 68,
+		XER = 69,
+		F0_START = 71,
+		F31_END = 71 + 31,
+		FPSCR = 103
+	};
 
 	static constexpr std::string_view RESPONSE_EMPTY = "";
 	static constexpr std::string_view RESPONSE_ACK = "+";
@@ -178,28 +208,28 @@ private:
 	void HandleQuery(std::unique_ptr<CommandContext>& context) const;
 	void HandleVCont(std::unique_ptr<CommandContext>& context);
 
-    // Commands
-    sint64 m_activeThreadSelector = 0;
-    sint64 m_activeThreadContinueSelector = 0;
-    void CMDContinue(std::unique_ptr<CommandContext>& context);
-    void CMDNotFound(std::unique_ptr<CommandContext>& context);
-    void CMDIsThreadActive(std::unique_ptr<CommandContext>& context);
-    void CMDSetActiveThread(std::unique_ptr<CommandContext>& context);
-    void CMDGetThreadStatus(std::unique_ptr<CommandContext>& context);
+	// Commands
+	sint64 m_activeThreadSelector = 0;
+	sint64 m_activeThreadContinueSelector = 0;
+	void CMDContinue(std::unique_ptr<CommandContext>& context);
+	void CMDNotFound(std::unique_ptr<CommandContext>& context);
+	void CMDIsThreadActive(std::unique_ptr<CommandContext>& context);
+	void CMDSetActiveThread(std::unique_ptr<CommandContext>& context);
+	void CMDGetThreadStatus(std::unique_ptr<CommandContext>& context);
 
-    void CMDReadRegister(std::unique_ptr<CommandContext>& context) const;
-    void CMDWriteRegister(std::unique_ptr<CommandContext>& context) const;
-    void CMDReadRegisters(std::unique_ptr<CommandContext>& context) const;
-    void CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const;
-    void CMDReadMemory(std::unique_ptr<CommandContext>& context);
-    void CMDWriteMemory(std::unique_ptr<CommandContext>& context);
-    void CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context);
-    void CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context);
+	void CMDReadRegister(std::unique_ptr<CommandContext>& context) const;
+	void CMDWriteRegister(std::unique_ptr<CommandContext>& context) const;
+	void CMDReadRegisters(std::unique_ptr<CommandContext>& context) const;
+	void CMDWriteRegisters(std::unique_ptr<CommandContext>& context) const;
+	void CMDReadMemory(std::unique_ptr<CommandContext>& context);
+	void CMDWriteMemory(std::unique_ptr<CommandContext>& context);
+	void CMDInsertBreakpoint(std::unique_ptr<CommandContext>& context);
+	void CMDDeleteBreakpoint(std::unique_ptr<CommandContext>& context);
 
 	std::jthread m_thread;
-    std::atomic_bool m_resume_startup = false;
-    MPTR m_entry_point{};
-    std::unique_ptr<CommandContext> m_resumed_context;
+	std::atomic_bool m_resume_startup = false;
+	MPTR m_entry_point{};
+	std::unique_ptr<CommandContext> m_resumed_context;
 
 	std::atomic_bool m_client_connected;
 	SOCKET m_server_socket = INVALID_SOCKET;
@@ -288,6 +318,5 @@ static constexpr std::string_view GDBTargetXML = R"(<?xml version="1.0"?>
         <reg name="fpscr" bitsize="32" group="float"/>
     </feature>
 </target>)";
-
 
 extern std::unique_ptr<GDBServer> g_gdbstub;

--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.h
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Common/precompiled.h"
+#include "Common/socket.h"
 #include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
 
 #include <numeric>

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterImpl.cpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterImpl.cpp
@@ -1,6 +1,7 @@
 #include "PPCInterpreterInternal.h"
 #include "PPCInterpreterHelper.h"
 #include "Cafe/HW/Espresso/Debugger/Debugger.h"
+#include "Cafe/HW/Espresso/Debugger/GDBStub.h"
 
 class PPCItpCafeOSUsermode
 {

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.hpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.hpp
@@ -65,9 +65,12 @@ static void PPCInterpreter_MFTB(PPCInterpreter_t* hCPU, uint32 opcode)
 static void PPCInterpreter_TW(PPCInterpreter_t* hCPU, uint32 opcode)
 {
 	sint32 to, rA, rB;
-	PPC_OPC_TEMPL_X(opcode, to, rB, rA);
+	PPC_OPC_TEMPL_X(opcode, to, rA, rB);
 
 	cemu_assert_debug(to == 0);
 
-	debugger_enterTW(hCPU);
+    if (rA == DEBUGGER_BP_T_DEBUGGER)
+	    debugger_enterTW(hCPU);
+    else if (rA == DEBUGGER_BP_T_GDBSTUB)
+        g_gdbstub->HandleTrapInstruction(hCPU);
 }

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -671,6 +671,11 @@ namespace coreinit
 		__OSUnlockScheduler();
 	}
 
+    void __OSSuspendThreadNolock(OSThread_t* thread)
+    {
+        __OSSuspendThreadInternal(thread);
+    }
+
 	void OSSleepThread(OSThreadQueue* threadQueue)
 	{
 		__OSLockScheduler();
@@ -798,7 +803,18 @@ namespace coreinit
 		return suspendCounter > 0;
 	}
 
-	void OSCancelThread(OSThread_t* thread)
+    bool OSIsThreadRunning(OSThread_t* thread)
+    {
+        bool isRunning = false;
+        __OSLockScheduler();
+        if (thread->state == OSThread_t::THREAD_STATE::STATE_RUNNING)
+            isRunning = true;
+        __OSUnlockScheduler();
+        return isRunning;
+    }
+
+
+void OSCancelThread(OSThread_t* thread)
 	{
 		__OSLockScheduler();
 		cemu_assert_debug(thread->requestFlags == 0 || thread->requestFlags == OSThread_t::REQUEST_FLAG_CANCEL); // todo - how to handle cases where other flags are already set?
@@ -1315,6 +1331,7 @@ namespace coreinit
 		cafeExportRegister("coreinit", OSResumeThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSContinueThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSSuspendThread, LogType::CoreinitThread);
+        cafeExportRegister("coreinit", __OSSuspendThreadNolock, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSSleepThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSWakeupThread, LogType::CoreinitThread);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -1331,7 +1331,7 @@ namespace coreinit
 		cafeExportRegister("coreinit", OSResumeThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSContinueThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSSuspendThread, LogType::CoreinitThread);
-        cafeExportRegister("coreinit", __OSSuspendThreadNolock, LogType::CoreinitThread);
+		cafeExportRegister("coreinit", __OSSuspendThreadNolock, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSSleepThread, LogType::CoreinitThread);
 		cafeExportRegister("coreinit", OSWakeupThread, LogType::CoreinitThread);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -814,7 +814,7 @@ namespace coreinit
     }
 
 
-void OSCancelThread(OSThread_t* thread)
+    void OSCancelThread(OSThread_t* thread)
 	{
 		__OSLockScheduler();
 		cemu_assert_debug(thread->requestFlags == 0 || thread->requestFlags == OSThread_t::REQUEST_FLAG_CANCEL); // todo - how to handle cases where other flags are already set?

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
@@ -514,7 +514,7 @@ namespace coreinit
 	sint32 OSResumeThread(OSThread_t* thread);
 	void OSContinueThread(OSThread_t* thread);
 	void __OSSuspendThreadInternal(OSThread_t* thread);
-    void __OSSuspendThreadNolock(OSThread_t* thread);
+	void __OSSuspendThreadNolock(OSThread_t* thread);
 	void OSSuspendThread(OSThread_t* thread);
 	void OSSleepThread(OSThreadQueue* threadQueue);
 	void OSWakeupThread(OSThreadQueue* threadQueue);
@@ -526,7 +526,7 @@ namespace coreinit
 
 	bool OSIsThreadTerminated(OSThread_t* thread);
 	bool OSIsThreadSuspended(OSThread_t* thread);
-    bool OSIsThreadRunning(OSThread_t* thread);
+	bool OSIsThreadRunning(OSThread_t* thread);
 
 	// OSThreadQueue
 	void OSInitThreadQueue(OSThreadQueue* threadQueue);

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
@@ -461,10 +461,10 @@ struct OSThread_t
 	/* +0x628 */ uint64								wakeTimeRelatedUkn2;
 
 	// set via OSSetExceptionCallback
-	/* +0x630 */ MPTR								ukn630Callback[Espresso::CORE_COUNT];
-	/* +0x63C */ MPTR								ukn63CCallback[Espresso::CORE_COUNT];
-	/* +0x648 */ MPTR								ukn648Callback[Espresso::CORE_COUNT];
-	/* +0x654 */ MPTR								ukn654Callback[Espresso::CORE_COUNT];
+	/* +0x630 */ MPTR								dsiCallback[Espresso::CORE_COUNT];
+	/* +0x63C */ MPTR								isiCallback[Espresso::CORE_COUNT];
+	/* +0x648 */ MPTR								programCallback[Espresso::CORE_COUNT];
+	/* +0x654 */ MPTR								perfMonCallback[Espresso::CORE_COUNT];
 
 	/* +0x660 */ uint32								ukn660;
 
@@ -514,6 +514,7 @@ namespace coreinit
 	sint32 OSResumeThread(OSThread_t* thread);
 	void OSContinueThread(OSThread_t* thread);
 	void __OSSuspendThreadInternal(OSThread_t* thread);
+    void __OSSuspendThreadNolock(OSThread_t* thread);
 	void OSSuspendThread(OSThread_t* thread);
 	void OSSleepThread(OSThreadQueue* threadQueue);
 	void OSWakeupThread(OSThreadQueue* threadQueue);
@@ -525,6 +526,7 @@ namespace coreinit
 
 	bool OSIsThreadTerminated(OSThread_t* thread);
 	bool OSIsThreadSuspended(OSThread_t* thread);
+    bool OSIsThreadRunning(OSThread_t* thread);
 
 	// OSThreadQueue
 	void OSInitThreadQueue(OSThreadQueue* threadQueue);

--- a/src/Cafe/OS/libs/coreinit/coreinit_ThreadQueue.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_ThreadQueue.cpp
@@ -135,7 +135,7 @@ namespace coreinit
 		while (OSThread_t* thread = takeFirstFromQueue(offsetof(OSThread_t, waitQueueLink)))
 		{
 			cemu_assert_debug(thread->state == OSThread_t::THREAD_STATE::STATE_WAITING);
-			cemu_assert_debug(thread->suspendCounter == 0);
+			//cemu_assert_debug(thread->suspendCounter == 0);
 			thread->state = OSThread_t::THREAD_STATE::STATE_READY;
 			thread->currentWaitQueue = nullptr;
 			coreinit::__OSAddReadyThreadToRunQueue(thread);

--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -73,6 +73,15 @@ void nsysnetExport_socket_lib_init(PPCInterpreter_t* hCPU)
 	osLib_returnFromFunction(hCPU, 0); // 0 -> Success
 }
 
+void nsysnetExport_socket_lib_finish(PPCInterpreter_t* hCPU)
+{
+	sockLibReady = false;
+#if BOOST_OS_WINDOWS
+	WSACleanup();
+#endif // BOOST_OS_WINDOWS
+	osLib_returnFromFunction(hCPU, 0); // 0 -> Success
+}
+
 uint32* __gh_errno_ptr()
 {
 	OSThread_t* osThread = coreinitThread_getCurrentThreadDepr(PPCInterpreter_getCurrentInstance());
@@ -2120,6 +2129,7 @@ void nsysnet_load()
 {
 	
 	osLib_addFunction("nsysnet", "socket_lib_init", nsysnetExport_socket_lib_init);
+	osLib_addFunction("nsysnet", "socket_lib_finish", nsysnetExport_socket_lib_finish);
 	
 	// socket API
 	osLib_addFunction("nsysnet", "socket", nsysnetExport_socket);

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -69,11 +69,12 @@
 #include <filesystem>
 #include <memory>
 #include <chrono>
-#include <time.h>
+#include <ctime>
 #include <regex>
 #include <type_traits>
 #include <optional>
 #include <span>
+#include <ranges>
 
 #include <boost/predef.h>
 #include <boost/nowide/convert.hpp>

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -209,6 +209,21 @@ typedef union _LARGE_INTEGER {
     inline T& operator^= (T& a, T b) { return reinterpret_cast<T&>( reinterpret_cast<std::underlying_type<T>::type&>(a) ^= static_cast<std::underlying_type<T>::type>(b) ); }
 #endif
 
+template<typename T>
+inline T GetBits(T value, uint32 index, uint32 numBits)
+{
+	T mask = (1<<numBits)-1;
+	return (value>>index) & mask;
+}
+
+template<typename T>
+inline void SetBits(T& value, uint32 index, uint32 numBits, uint32 bitValue)
+{
+	T mask = (1<<numBits)-1;
+	value &= ~(mask << index);
+	value |= (bitValue << index);
+}
+
 #if !defined(_MSC_VER) || defined(__clang__) // clang-cl does not have built-in _udiv128
 inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, uint64 *remainder)
 {
@@ -256,7 +271,7 @@ inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, 
 
 inline void _mm_pause()
 {
-    asm volatile("yield");   
+    asm volatile("yield");
 }
 
 inline uint64 __rdtsc()

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -336,6 +336,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 #elif BOOST_OS_UNIX
 	crash_dump = debug.get("CrashDumpUnix", crash_dump);
 #endif
+	gdb_port = debug.get("GDBPort", 1337);
 
 	// input
 	auto input = parser.get("Input");
@@ -515,6 +516,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 #elif BOOST_OS_UNIX
 	debug.set("CrashDumpUnix", crash_dump.GetValue());
 #endif
+	debug.set("GDBPort", gdb_port);
 
 	// input
 	auto input = config.set("Input");

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -484,6 +484,7 @@ struct CemuConfig
 
 	// debug
 	ConfigValueBounds<CrashDump> crash_dump{ CrashDump::Disabled };
+	ConfigValue<uint16> gdb_port{ 1337 };
 
 	void Load(XMLConfigParser& parser);
 	void Save(XMLConfigParser& parser);

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -68,7 +68,7 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 		("account,a", po::value<std::string>(), "Persistent id of account")
 
 		("force-interpreter", po::value<bool>()->implicit_value(true), "Force interpreter CPU emulation, disables recompiler")
-		("enable-gdbstub", po::value<bool>()->implicit_value(true), "Enable GDBStub to debug Cemu using an external debugger")
+		("enable-gdbstub", po::value<bool>()->implicit_value(true), "Enable GDB stub to debug executables inside Cemu using an external debugger")
 
 		("act-url", po::value<std::string>(), "URL prefix for account server")
 		("ecs-url", po::value<std::string>(), "URL for ECS service");

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -68,6 +68,7 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 		("account,a", po::value<std::string>(), "Persistent id of account")
 
 		("force-interpreter", po::value<bool>()->implicit_value(true), "Force interpreter CPU emulation, disables recompiler")
+		("enable-gdbstub", po::value<bool>()->implicit_value(true), "Enable GDBStub to debug Cemu using an external debugger")
 
 		("act-url", po::value<std::string>(), "URL prefix for account server")
 		("ecs-url", po::value<std::string>(), "URL for ECS service");
@@ -162,6 +163,9 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 
 		if(vm.count("force-interpreter"))
 			s_force_interpreter = vm["force-interpreter"].as<bool>();
+		
+		if (vm.count("enable-gdbstub"))
+			s_enable_gdbstub = vm["enable-gdbstub"].as<bool>();
 
 		std::wstring extract_path, log_path;
 		std::string output_path;

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -21,6 +21,7 @@ public:
 	static std::optional<bool> RenderUpsideDownEnabled() { return s_render_upside_down; }
 	static std::optional<bool> FullscreenEnabled() { return s_fullscreen; }
 
+	static bool GDBStubEnabled() { return s_enable_gdbstub; }
 	static bool NSightModeEnabled() { return s_nsight_mode; }
 	static bool ForceIntelLegacyEnabled() { return s_force_intel_legacy; }
 
@@ -39,6 +40,7 @@ private:
 	inline static std::optional<bool> s_render_upside_down{};
 	inline static std::optional<bool> s_fullscreen{};
 	
+	inline static bool s_enable_gdbstub = false;
 	inline static bool s_nsight_mode = false;
 	inline static bool s_force_intel_legacy = false;
 

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -770,27 +770,42 @@ wxPanel* GeneralSettings2::AddDebugPage(wxNotebook* notebook)
 	auto* panel = new wxPanel(notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 	auto* debug_panel_sizer = new wxBoxSizer(wxVERTICAL);
 
-	auto* debug_row = new wxFlexGridSizer(0, 2, 0, 0);
-	debug_row->SetFlexibleDirection(wxBOTH);
-	debug_row->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+	{
+		auto* debug_row = new wxFlexGridSizer(0, 2, 0, 0);
+		debug_row->SetFlexibleDirection(wxBOTH);
+		debug_row->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
-	debug_row->Add(new wxStaticText(panel, wxID_ANY, _("Crash dump"), wxDefaultPosition, wxDefaultSize, 0), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+		debug_row->Add(new wxStaticText(panel, wxID_ANY, _("Crash dump"), wxDefaultPosition, wxDefaultSize, 0), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 #if BOOST_OS_WINDOWS
-	wxString dump_choices[] = { _("Disabled"), _("Lite"), _("Full") };
+		wxString dump_choices[] = {_("Disabled"), _("Lite"), _("Full")};
 #elif BOOST_OS_UNIX
-	wxString dump_choices[] = { _("Disabled"), _("Enabled") };
+		wxString dump_choices[] = {_("Disabled"), _("Enabled")};
 #endif
-	m_crash_dump = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, std::size(dump_choices), dump_choices);
-	m_crash_dump->SetSelection(0);
+		m_crash_dump = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, std::size(dump_choices), dump_choices);
+		m_crash_dump->SetSelection(0);
 #if BOOST_OS_WINDOWS
-	m_crash_dump->SetToolTip(_("Creates a dump when Cemu crashes\nOnly enable when requested by a developer!\nThe Full option will create a very large dump file (includes a full RAM dump of the Cemu process)"));
+		m_crash_dump->SetToolTip(_("Creates a dump when Cemu crashes\nOnly enable when requested by a developer!\nThe Full option will create a very large dump file (includes a full RAM dump of the Cemu process)"));
 #elif BOOST_OS_UNIX
-	m_crash_dump->SetToolTip(_("Creates a core dump when Cemu crashes\nOnly enable when requested by a developer!"));
+		m_crash_dump->SetToolTip(_("Creates a core dump when Cemu crashes\nOnly enable when requested by a developer!"));
 #endif
-	debug_row->Add(m_crash_dump, 0, wxALL | wxEXPAND, 5);
+		debug_row->Add(m_crash_dump, 0, wxALL | wxEXPAND, 5);
+		debug_panel_sizer->Add(debug_row, 0, wxALL | wxEXPAND, 5);
+	}
 
-	debug_panel_sizer->Add(debug_row, 0, wxALL | wxEXPAND, 5);
+	{
+		auto* debug_row = new wxFlexGridSizer(0, 2, 0, 0);
+		debug_row->SetFlexibleDirection(wxBOTH);
+		debug_row->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+		debug_row->Add(new wxStaticText(panel, wxID_ANY, _("GDB Stub port"), wxDefaultPosition, wxDefaultSize, 0), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+		m_gdb_port = new wxSpinCtrl(panel, wxID_ANY, wxT("1337"), wxDefaultPosition, wxDefaultSize, 0, 1000, 65535);
+		m_gdb_port->SetToolTip(_("Changes the port that the GDB stub will use, which you can use by either starting Cemu with the --enable-gdbstub option or by enabling it the Debug tab."));
+
+		debug_row->Add(m_gdb_port, 0, wxALL | wxEXPAND, 5);
+		debug_panel_sizer->Add(debug_row, 0, wxALL | wxEXPAND, 5);
+	}
 
 	panel->SetSizerAndFit(debug_panel_sizer);
 
@@ -1002,6 +1017,7 @@ void GeneralSettings2::StoreConfig()
 
 	// debug
 	config.crash_dump = (CrashDump)m_crash_dump->GetSelection();
+	config.gdb_port = m_gdb_port->GetValue();
 
 	g_config.Save();
 }
@@ -1619,6 +1635,7 @@ void GeneralSettings2::ApplyConfig()
 
 	// debug
 	m_crash_dump->SetSelection((int)config.crash_dump.GetValue());
+	m_gdb_port->SetValue(config.gdb_port.GetValue());
 }
 
 void GeneralSettings2::OnOnlineEnable(wxCommandEvent& event)

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -74,6 +74,7 @@ private:
 
 	// Debug
 	wxChoice* m_crash_dump;
+	wxSpinCtrl* m_gdb_port;
 
 	void OnAccountCreate(wxCommandEvent& event);
 	void OnAccountDelete(wxCommandEvent& event);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -344,6 +344,10 @@ MainWindow::MainWindow()
 	{
 		MainWindow::RequestLaunchGame(LaunchSettings::GetLoadFile().value(), wxLaunchGameEvent::INITIATED_BY::COMMAND_LINE);
 	}
+	if (LaunchSettings::GDBStubEnabled())
+	{
+		g_gdbstub = std::make_unique<GDBServer>(1337);
+	}
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -107,6 +107,7 @@ public:
 	void OnDebugDumpUsedTextures(wxCommandEvent& event);
 	void OnDebugDumpUsedShaders(wxCommandEvent& event);
 	void OnLoggingWindow(wxCommandEvent& event);
+	void OnGDBStubToggle(wxCommandEvent& event);
 	void OnDebugViewPPCThreads(wxCommandEvent& event);
 	void OnDebugViewPPCDebugger(wxCommandEvent& event);
 	void OnDebugViewAudioDebugger(wxCommandEvent& event);
@@ -172,6 +173,7 @@ private:
 
 	std::string m_launched_game_name;
 
+	wxMenuItem* m_gdbstub_toggle{};
 	DebuggerWindow2* m_debugger_window = nullptr;
 	LoggingWindow* m_logging_window = nullptr;
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -14,6 +14,7 @@
 #include "gui/components/wxGameList.h"
 
 #include <future>
+#include "Cafe/HW/Espresso/Debugger/GDBStub.h"
 
 class DebuggerWindow2;
 struct GameEntry;

--- a/src/gui/debugger/DebuggerWindow2.cpp
+++ b/src/gui/debugger/DebuggerWindow2.cpp
@@ -558,9 +558,7 @@ void DebuggerWindow2::OnOptionsInput(wxCommandEvent& event)
 
 			if (debuggerState.breakOnEntry)
 			{
-				while (!g_gdbstub->IsConnected()) {
-					std::this_thread::sleep_for(std::chrono::milliseconds(100));
-				}
+				while (!g_gdbstub->IsConnected()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
 			}
 		}
 		else

--- a/src/gui/debugger/DebuggerWindow2.cpp
+++ b/src/gui/debugger/DebuggerWindow2.cpp
@@ -26,6 +26,7 @@ enum
 	// file
 	MENU_ID_FILE_EXIT = wxID_HIGHEST + 8000,
 	// settings
+	MENU_ID_OPTIONS_ENABLE_GDBSTUB,
 	MENU_ID_OPTIONS_PIN_TO_MAINWINDOW,
 	MENU_ID_OPTIONS_BREAK_ON_START,
 	// window
@@ -67,7 +68,7 @@ wxBEGIN_EVENT_TABLE(DebuggerWindow2, wxFrame)
 	// file menu
 	EVT_MENU(MENU_ID_FILE_EXIT, DebuggerWindow2::OnExit)
 	// setting
-	EVT_MENU(MENU_ID_OPTIONS_PIN_TO_MAINWINDOW, DebuggerWindow2::OnOptionsInput)
+	EVT_MENU(MENU_ID_OPTIONS_ENABLE_GDBSTUB, DebuggerWindow2::OnOptionsInput)
 	// window
 	EVT_MENU_RANGE(MENU_ID_WINDOW_REGISTERS, MENU_ID_WINDOW_MODULE, DebuggerWindow2::OnWindowMenu)
 wxEND_EVENT_TABLE()
@@ -76,8 +77,13 @@ DebuggerWindow2* g_debugger_window;
 
 void DebuggerConfig::Load(XMLConfigParser& parser)
 {
+	auto gdbstub_parser = parser.get("GDBStub");
+	gdbstub_enabled = parser.get("Enabled", false);
+	gdbstub_port = parser.get("Port", 1337);
+	
 	pin_to_main = parser.get("PinToMainWindow", true);
 	break_on_start = parser.get("break_on_start", true);
+	
 
 	auto window_parser = parser.get("Windows");
 	show_register = window_parser.get("Registers", true);
@@ -90,6 +96,10 @@ void DebuggerConfig::Load(XMLConfigParser& parser)
 
 void DebuggerConfig::Save(XMLConfigParser& parser)
 {
+	auto gdbstub_parser = parser.set("GDBStub");
+	gdbstub_parser.set("gdbstub_enabled", gdbstub_enabled);
+	gdbstub_parser.set("gdbstub_port", gdbstub_port);
+	
 	parser.set("PinToMainWindow", pin_to_main);
 	parser.set("break_on_start", break_on_start);
 	
@@ -324,6 +334,11 @@ DebuggerWindow2::DebuggerWindow2(wxFrame& parent, const wxRect& display_size)
 	m_module_window = new ModuleWindow(*this, m_main_position, m_main_size);
 	m_symbol_window = new SymbolWindow(*this, m_main_position, m_main_size);
 
+	if (m_config.data().gdbstub_enabled)
+	{
+		g_gdbstub = std::make_unique<GDBServer>(m_config.data().gdbstub_port);
+	}
+
 	const bool value = m_config.data().pin_to_main;
 	m_config.data().pin_to_main = true;
 	OnParentMove(m_main_position, m_main_size);
@@ -529,24 +544,48 @@ void DebuggerWindow2::OnBreakpointChange(wxCommandEvent& event)
 
 void DebuggerWindow2::OnOptionsInput(wxCommandEvent& event)
 {
-	switch(event.GetId())
+	switch (event.GetId())
 	{
-	case MENU_ID_OPTIONS_PIN_TO_MAINWINDOW:
+	case MENU_ID_OPTIONS_ENABLE_GDBSTUB:
+	{
+		const bool enabled = !m_config.data().gdbstub_enabled;
+		m_config.data().gdbstub_enabled = enabled;
+		
+		if (enabled && !g_gdbstub)
 		{
-			const bool value = !m_config.data().pin_to_main;
-			m_config.data().pin_to_main = value;
-			if(value)
-				OnParentMove(m_main_position, m_main_size);
-			
-			break;
+            g_gdbstub = std::make_unique<GDBServer>(m_config.data().gdbstub_port);
+            g_gdbstub->Initialize();
+
+			if (debuggerState.breakOnEntry)
+			{
+				while (!g_gdbstub->IsConnected()) {
+					std::this_thread::sleep_for(std::chrono::milliseconds(100));
+				}
+			}
 		}
-	case MENU_ID_OPTIONS_BREAK_ON_START:
+		else
 		{
+            g_gdbstub.reset();
+		}
+		
+		break;
+	}
+	case MENU_ID_OPTIONS_PIN_TO_MAINWINDOW:
+	{
+		const bool value = !m_config.data().pin_to_main;
+		m_config.data().pin_to_main = value;
+		if (value)
+			OnParentMove(m_main_position, m_main_size);
+
+		break;
+	}
+	case MENU_ID_OPTIONS_BREAK_ON_START:
+	{
 		const bool value = !m_config.data().break_on_start;
 		m_config.data().break_on_start = value;
 		debuggerState.breakOnEntry = value;
 		break;
-		}
+	}
 	default:
 		return;
 	}
@@ -636,6 +675,7 @@ void DebuggerWindow2::CreateMenuBar()
 
 	// options
 	wxMenu* options_menu = new wxMenu;
+	options_menu->Append(MENU_ID_OPTIONS_ENABLE_GDBSTUB, _("&Enable GDB Server"), wxEmptyString, wxITEM_CHECK)->Check(m_config.data().gdbstub_enabled);
 	options_menu->Append(MENU_ID_OPTIONS_PIN_TO_MAINWINDOW, _("&Pin to main window"), wxEmptyString, wxITEM_CHECK)->Check(m_config.data().pin_to_main);
 	options_menu->Append(MENU_ID_OPTIONS_BREAK_ON_START, _("Break on &entry point"), wxEmptyString, wxITEM_CHECK)->Check(m_config.data().break_on_start);
 	menu_bar->Append(options_menu, _("&Options"));

--- a/src/gui/debugger/DebuggerWindow2.h
+++ b/src/gui/debugger/DebuggerWindow2.h
@@ -4,6 +4,7 @@
 #include "config/XMLConfig.h"
 #include "Cafe/HW/Espresso/Debugger/Debugger.h"
 #include "Cafe/OS/RPL/rpl.h"
+#include "Cafe/HW/Espresso/Debugger/GDBStub.h"
 
 #include <wx/bitmap.h>
 #include <wx/frame.h>
@@ -26,10 +27,12 @@ wxDECLARE_EVENT(wxEVT_NOTIFY_MODULE_UNLOADED, wxCommandEvent);
 struct DebuggerConfig
 {
 	DebuggerConfig()
-	: pin_to_main(true), break_on_start(true), show_register(true), show_dump(true), show_stack(true), show_breakpoints(true), show_modules(true) {}
-
+	: gdbstub_enabled(false), gdbstub_port(1337), pin_to_main(true), break_on_start(true), show_register(true), show_dump(true), show_stack(true), show_breakpoints(true), show_modules(true), show_symbols(true) {}
+	
+	bool gdbstub_enabled;
+	uint16_t gdbstub_port;
+	
 	bool pin_to_main;
-
 	bool break_on_start;
 
 	bool show_register;
@@ -95,7 +98,7 @@ private:
 
 	wxPoint m_main_position;
 	wxSize m_main_size;
-
+	
 	RegisterWindow* m_register_window;
 	DumpWindow* m_dump_window;
 	BreakpointWindow* m_breakpoint_window;

--- a/src/gui/debugger/DebuggerWindow2.h
+++ b/src/gui/debugger/DebuggerWindow2.h
@@ -27,10 +27,7 @@ wxDECLARE_EVENT(wxEVT_NOTIFY_MODULE_UNLOADED, wxCommandEvent);
 struct DebuggerConfig
 {
 	DebuggerConfig()
-	: gdbstub_enabled(false), gdbstub_port(1337), pin_to_main(true), break_on_start(true), show_register(true), show_dump(true), show_stack(true), show_breakpoints(true), show_modules(true), show_symbols(true) {}
-	
-	bool gdbstub_enabled;
-	uint16_t gdbstub_port;
+	: pin_to_main(true), break_on_start(true), show_register(true), show_dump(true), show_stack(true), show_breakpoints(true), show_modules(true), show_symbols(true) {}
 	
 	bool pin_to_main;
 	bool break_on_start;

--- a/src/gui/wxgui.h
+++ b/src/gui/wxgui.h
@@ -12,6 +12,7 @@
 #include <wx/slider.h>
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
+#include <wx/spinctrl.h>
 #include <wx/listbase.h>
 #include <wx/display.h>
 #include <wx/aboutdlg.h>


### PR DESCRIPTION
This GDB stub allows a developer to connect existing development tools like IDA Pro, Ghidra, Clion, GDB etc. to Cemu, which allows you to set breakpoints, read and write memory and various other things in those applications. Basically provides an easier experience for reverse engineering or debugging Wii U applications if setup correctly.

This was already tested to work with IDA Pro, Clion and GDB, and seems to work pretty well. Some things I want to improve before merging:

- [X] Add some examples/documentation on how to use this GDB stub with the applications I mentioned above
- [X] Add read/write breakpoints to existing code execution breakpoints

### How To Use

By default this GDB stub will use port 1337. You can optionally change this in the `Options`->`General Settings`->`Debug` tab.
Then, to start a game with GDB debugging you can either use the GUI option in the `Debug`->`Launch with GDB Stub` or you can launch Cemu using the --enable-gdbstub command line option.

#### CLion (for homebrew development & debugging)

I think it's best to refer to my CLion guide for Wii U homebrew development that I've updated with information on how to use Cemu's GDB stub. See [https://rentry.co/clion-wiiu-dev](https://rentry.co/clion-wiiu-dev) on how to do this. Since some homebrew might rely on exploits it depends on whether this'll be usable, but it should be fine for testing homebrew games and the like.

#### IDA Pro (useful for reverse engineering games)

If you're a non-ghidra user it's pretty easy to setup Cemu with IDA Pro so that you can dump the state when some code is run, or maybe aid with understanding a part of code.

1. Open up your existing IDA Pro database for the game you want to modify.
   - Make sure that you're using a database made from the update of the game if there's any updates, and that you don't open the base game.
2. Change your debugger to the "Remote GDB debugger" using the `Debugger`->`Switch Debugger...` dropdown at the top of IDA.  
3. Go to `Debugger`->`Debugger Options...` and then click on the `Set specific options` button at the bottom.  
4. Enable the `Run a program before starting debugging` option and then change the Command line option to `"C:/Your/Cemu/Folder/Cemu.exe" --enable-gdbstub -g "C:/UpdateOrBaseGameFolder/code/rpx-filename.rpx"`.
5. After closing this option menu, go to `Debugger`->`Process options...`.
   - Change the Application and Input file to the .rpx that you made your database with.
   - Change the IP to localhost and the port to 1337, unless you changed the default GDB port.

You should now be able to run the game using the Play button at the top or using the `Debugger`->`Start process` option at the top.

#### Standalone GDB (useful for advanced users/scripting)

You could use e.g. a python library to interact with Cemu's GDB stub to do advanced scripting, but I'll just be giving instructions for the normal standalone GDB client.

For this, you can either use a multiarch version of GDB or use a powerpc-specific GDB version. I installed one from [here](https://gnutoolchains.com/powerpc-eabi) to get a PowerPC GDB 7.7, which seems to be the highest easily available one around. I'm not sure if a multiarch one works worse, but it probably doesn't. So just use those if you already have access to it.

You'd probably want to setup a bash/batch script to automate launching Cemu using something like:
```batch
"C:/Your/Cemu/Folder/Cemu.exe" --enable-gdbstub -g "C:/UpdateOrBaseGameFolder/code/rpx-filename.rpx" & "C:/Your/GCC/Folder/powerpc-eabi-gdb.exe" -x gdbstub-script.txt"
```

The GDB script I refer to above could look something like:
```
set arch powerpc:750
set tcp connect-timeout 60
set remote hardware-watchpoint-limit 1
set disassemble-next-line on
set print thread-events on
target remote :1337
```