### PR TITLE
Separate imgui contexts for TV and Pad windows.

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
@@ -80,7 +80,7 @@ void LatteOverlay_renderOverlay(ImVec2& position, ImVec2& pivot, sint32 directio
 	{
 		ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 		ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-		if (ImGui_BeginPadDistinct("Stats overlay", nullptr, kPopupFlags, pad))
+		if (ImGui::Begin("Stats overlay", nullptr, kPopupFlags))
 		{
 			if (config.overlay.fps)
 				ImGui::Text("FPS: %.2lf", g_state.fps);
@@ -141,7 +141,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 				// active account
 				ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 				ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-				if (ImGui_BeginPadDistinct("Active account", nullptr, kPopupFlags, pad))
+				if (ImGui::Begin("Active account", nullptr, kPopupFlags))
 				{
 					ImGui::TextUnformatted((const char*)ICON_FA_USER);
 					ImGui::SameLine();
@@ -179,7 +179,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 				{
 					ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 					ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-					if (ImGui_BeginPadDistinct("Controller profile names", nullptr, kPopupFlags, pad))
+					if (ImGui::Begin("Controller profile names", nullptr, kPopupFlags))
 					{
 						auto it = profiles.cbegin();
 						ImGui::TextUnformatted((const char*)ICON_FA_GAMEPAD);
@@ -227,7 +227,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 		{
 			ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 			ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-			if (ImGui_BeginPadDistinct("Friends overlay", nullptr, kPopupFlags, pad))
+			if (ImGui::Begin("Friends overlay", nullptr, kPopupFlags))
 			{
 				const auto tick = tick_cached();
 				for (auto it = s_friend_list.cbegin(); it != s_friend_list.cend();)
@@ -274,7 +274,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 
 			ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 			ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-			if (ImGui_BeginPadDistinct("Low battery overlay", nullptr, kPopupFlags, pad))
+			if (ImGui::Begin("Low battery overlay", nullptr, kPopupFlags))
 			{
 				auto it = batteries.cbegin();
 				ImGui::TextUnformatted((const char*)(s_blink_state ? ICON_FA_BATTERY_EMPTY : ICON_FA_BATTERY_QUARTER));
@@ -322,7 +322,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 			{
 				ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 				ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-				if (ImGui_BeginPadDistinct("Compiling shaders overlay", nullptr, kPopupFlags, pad))
+				if (ImGui::Begin("Compiling shaders overlay", nullptr, kPopupFlags))
 				{
 					ImRotateStart();
 					ImGui::TextUnformatted((const char*)ICON_FA_SPINNER);
@@ -377,7 +377,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 			{
 				ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 				ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-				if (ImGui_BeginPadDistinct("Compiling pipeline overlay", nullptr, kPopupFlags, pad))
+				if (ImGui::Begin("Compiling pipeline overlay", nullptr, kPopupFlags))
 				{
 					ImRotateStart();
 					ImGui::TextUnformatted((const char*)ICON_FA_SPINNER);
@@ -446,7 +446,7 @@ void LatteOverlay_RenderNotifications(ImVec2& position, ImVec2& pivot, sint32 di
 	{
 		ImGui::SetNextWindowPos(position, ImGuiCond_Always, pivot);
 		ImGui::SetNextWindowBgAlpha(kBackgroundAlpha);
-		if (ImGui_BeginPadDistinct("Misc notifications", nullptr, kPopupFlags, pad))
+		if (ImGui::Begin("Misc notifications", nullptr, kPopupFlags))
 		{
 			const auto tick = tick_cached();
 			for (auto it = s_misc_notifications.cbegin(); it != s_misc_notifications.cend();)

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -268,7 +268,7 @@ void LatteShaderCache_load()
 	g_shaderCacheLoaderState.loadedShaderFiles = 0;
 
 	// get game background loading image
-	auto loadBackroundTexture = [](bool isTV, ImTextureID& out)
+	auto loadBackgroundTexture = [](bool isTV, ImTextureID& out)
 	{
 		TGAFILE file{};
 		out = nullptr;
@@ -295,8 +295,8 @@ void LatteShaderCache_load()
 		}
 	};
 
-	loadBackroundTexture(true, g_shaderCacheLoaderState.textureTVId);
-	loadBackroundTexture(false, g_shaderCacheLoaderState.textureDRCId);
+	loadBackgroundTexture(true, g_shaderCacheLoaderState.textureTVId);
+	loadBackgroundTexture(false, g_shaderCacheLoaderState.textureDRCId);
 
 	sint32 numLoadedShaders = 0;
 	uint32 loadIndex = 0;
@@ -346,13 +346,13 @@ void LatteShaderCache_load()
 
 
 	g_renderer->BeginFrame(true);
-	if(g_renderer->ImguiBegin(true))
+	if (g_renderer->ImguiBegin(true))
 	{
 		LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureTVId, 1280, 720);
 		g_renderer->ImguiEnd();
 	}
 	g_renderer->BeginFrame(false);
-	if(g_renderer->ImguiBegin(false))
+	if (g_renderer->ImguiBegin(false))
 	{
 		LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureDRCId, 854, 480);
 		g_renderer->ImguiEnd();
@@ -483,7 +483,7 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 		}
 
 		g_renderer->BeginFrame(false);
-		if(g_renderer->ImguiBegin(false))
+		if (g_renderer->ImguiBegin(false))
 		{
 			LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureDRCId, 854, 480);
 			g_renderer->ImguiEnd();

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -178,6 +178,43 @@ uint32 LatteShaderCache_getPipelineCacheExtraVersion(uint64 titleId)
 	return extraVersion;
 }
 
+void LatteShaderCache_drawBackgroundImage(ImTextureID texture, int width, int height)
+{
+	// clear framebuffers and clean up
+	const auto kPopupFlags =
+			ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
+			ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize;
+	auto& io = ImGui::GetIO();
+	ImGui::SetNextWindowPos({0, 0}, ImGuiCond_Always);
+	ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+	if (ImGui::Begin("Background texture", nullptr, kPopupFlags))
+	{
+		if (texture)
+		{
+			float imageDisplayWidth = io.DisplaySize.x;
+			float imageDisplayHeight = height * imageDisplayWidth / width;
+
+			float paddingLeftAndRight = 0.0f;
+			float paddingTopAndBottom = (io.DisplaySize.y - imageDisplayHeight) / 2.0f;
+			if (imageDisplayHeight > io.DisplaySize.y)
+			{
+				imageDisplayHeight = io.DisplaySize.y;
+				imageDisplayWidth = width * imageDisplayHeight / height;
+				paddingLeftAndRight = (io.DisplaySize.x - imageDisplayWidth) / 2.0f;
+				paddingTopAndBottom = 0.0f;
+			}
+
+			ImGui::GetWindowDrawList()->AddImage(texture, ImVec2(paddingLeftAndRight, paddingTopAndBottom),
+												 ImVec2(io.DisplaySize.x - paddingLeftAndRight,
+														io.DisplaySize.y - paddingTopAndBottom), {0, 1}, {1, 0});
+		}
+	}
+	ImGui::End();
+	ImGui::PopStyleVar(2);
+}
+
 void LatteShaderCache_load()
 {
 	shaderCacheScreenStats.compiledShaderCount = 0;
@@ -231,48 +268,36 @@ void LatteShaderCache_load()
 	g_shaderCacheLoaderState.loadedShaderFiles = 0;
 
 	// get game background loading image
-	TGAFILE TVfile{};
-	g_shaderCacheLoaderState.textureTVId = nullptr;
-
-	std::string tvTexPath = fmt::format("{}/meta/bootTvTex.tga", CafeSystem::GetMlcStoragePath(CafeSystem::GetForegroundTitleId()));
-	sint32 statusTV;
-	auto fscfile = fsc_open(tvTexPath.c_str(), FSC_ACCESS_FLAG::OPEN_FILE | FSC_ACCESS_FLAG::READ_PERMISSION, &statusTV);
-	if (fscfile)
+	auto loadBackroundTexture = [](bool isTV, ImTextureID& out)
 	{
-		uint32 size = fsc_getFileSize(fscfile);
-		if (size > 0)
+		TGAFILE file{};
+		out = nullptr;
+
+		std::string fileName = isTV ? "bootTvTex.tga" : "bootDRCTex.tga";
+
+		std::string texPath = fmt::format("{}/meta/{}", CafeSystem::GetMlcStoragePath(CafeSystem::GetForegroundTitleId()), fileName);
+		sint32 status;
+		auto fscfile = fsc_open(texPath.c_str(), FSC_ACCESS_FLAG::OPEN_FILE | FSC_ACCESS_FLAG::READ_PERMISSION, &status);
+		if (fscfile)
 		{
-			std::vector<uint8> tmpData(size);
-			fsc_readFile(fscfile, tmpData.data(), size);
-			const bool backgroundLoaded = LoadTGAFile(tmpData, &TVfile);
+			uint32 size = fsc_getFileSize(fscfile);
+			if (size > 0)
+			{
+				std::vector<uint8> tmpData(size);
+				fsc_readFile(fscfile, tmpData.data(), size);
+				const bool backgroundLoaded = LoadTGAFile(tmpData, &file);
 
-			if (backgroundLoaded)
-				g_shaderCacheLoaderState.textureTVId = g_renderer->GenerateTexture(TVfile.imageData, { TVfile.imageWidth, TVfile.imageHeight });
+				if (backgroundLoaded)
+					out = g_renderer->GenerateTexture(file.imageData, { file.imageWidth, file.imageHeight });
+			}
+
+			fsc_close(fscfile);
 		}
+	};
 
-		fsc_close(fscfile);
-	}
-	//get game background loading image for DRC
-	TGAFILE DRCfile{};
-	g_shaderCacheLoaderState.textureDRCId = nullptr;
+	loadBackroundTexture(true, g_shaderCacheLoaderState.textureTVId);
+	loadBackroundTexture(false, g_shaderCacheLoaderState.textureDRCId);
 
-	std::string drcTexPath = fmt::format("{}/meta/bootDRCTex.tga", CafeSystem::GetMlcStoragePath(CafeSystem::GetForegroundTitleId()));
-	sint32 statusDRC;
-	auto fscfile2 = fsc_open(drcTexPath.c_str(), FSC_ACCESS_FLAG::OPEN_FILE | FSC_ACCESS_FLAG::READ_PERMISSION, &statusDRC);
-	if (fscfile2)
-	{
-		uint32 size = fsc_getFileSize(fscfile2);
-		if (size > 0)
-		{
-			std::vector<uint8> tmpData(size);
-			fsc_readFile(fscfile2, tmpData.data(), size);
-			const bool backgroundLoaded = LoadTGAFile(tmpData, &DRCfile);
-
-			if (backgroundLoaded)
-				g_shaderCacheLoaderState.textureDRCId = g_renderer->GenerateTexture(DRCfile.imageData, { DRCfile.imageWidth, DRCfile.imageHeight });
-		}
-		fsc_close(fscfile2);
-	}
 	sint32 numLoadedShaders = 0;
 	uint32 loadIndex = 0;
 
@@ -319,78 +344,21 @@ void LatteShaderCache_load()
 	if (g_renderer->GetType() == RendererAPI::Vulkan)
 		LatteShaderCache_loadVulkanPipelineCache(cacheTitleId);
 
-	// clear framebuffers and clean up
-	auto& io = ImGui::GetIO();
-	const auto kPopupFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize;
-	for (int i = 0; i < 2; ++i)
+
+	g_renderer->BeginFrame(true);
+	if(g_renderer->ImguiBegin(true))
 	{
-		g_renderer->BeginFrame(true);
-		if (g_renderer->ImguiBegin(true))
-		{
-			ImGui::SetNextWindowPos({ 0,0 }, ImGuiCond_Always);
-			ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0,0 });
-			if (ImGui::Begin("Background texture", nullptr, kPopupFlags))
-			{
-				if (g_shaderCacheLoaderState.textureTVId)
-				{
-					float imageDisplayWidth = io.DisplaySize.x;
-					float imageDisplayHeight = 720 * imageDisplayWidth / 1280;
-
-					float paddingLeftAndRight = 0.0f;
-					float paddingTopAndBottom = (io.DisplaySize.y - imageDisplayHeight)/2.0f;
-					if (imageDisplayHeight > io.DisplaySize.y)
-					{
-						imageDisplayHeight = io.DisplaySize.y;
-						imageDisplayWidth = 1280 * imageDisplayHeight / 720;
-						paddingLeftAndRight = (io.DisplaySize.x - imageDisplayWidth)/2.0f;
-						paddingTopAndBottom = 0.0f;
-					}
-
-					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureTVId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
-				}
-			}
-			ImGui::End();
-			ImGui::PopStyleVar(2);
-			g_renderer->ImguiEnd();
-		}
-
-		g_renderer->BeginFrame(false);
-		if (g_renderer->ImguiBegin(false)) 
-		{
-			ImGui::SetNextWindowPos({ 0,0 }, ImGuiCond_Always);
-			ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0,0 });
-
-			if (ImGui::Begin("Background texture2", nullptr, kPopupFlags))
-			{
-				if (g_shaderCacheLoaderState.textureDRCId)
-				{
-					float imageDisplayWidth = io.DisplaySize.x;
-					float imageDisplayHeight = 480 * imageDisplayWidth / 854;
-
-					float paddingLeftAndRight = 0.0f;
-					float paddingTopAndBottom = (io.DisplaySize.y - imageDisplayHeight)/2.0f;
-					if (imageDisplayHeight > io.DisplaySize.y)
-					{
-						imageDisplayHeight = io.DisplaySize.y;
-						imageDisplayWidth = 854 * imageDisplayHeight / 480;
-						paddingLeftAndRight = (io.DisplaySize.x - imageDisplayWidth)/2.0f;
-						paddingTopAndBottom = 0.0f;
-					}
-
-					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureDRCId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
-				}
-			}
-			ImGui::End();
-			ImGui::PopStyleVar(2);
-			g_renderer->ImguiEnd();
-		}
-				
-		g_renderer->SwapBuffers(true, true);
+		LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureTVId, 1280, 720);
+		g_renderer->ImguiEnd();
 	}
+	g_renderer->BeginFrame(false);
+	if(g_renderer->ImguiBegin(false))
+	{
+		LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureDRCId, 854, 480);
+		g_renderer->ImguiEnd();
+	}
+
+	g_renderer->SwapBuffers(true, true);
 
 	if (g_shaderCacheLoaderState.textureTVId)
 		g_renderer->DeleteTexture(g_shaderCacheLoaderState.textureTVId);
@@ -427,35 +395,11 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 		g_renderer->BeginFrame(true);
 		if (g_renderer->ImguiBegin(true))
 		{
+			// render background texture
+			LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureTVId, 1280, 720);
+
 			const auto progress_font = ImGui_GetFont(window_size.y / 32.0f); // = 24 by default
 			const auto shader_count_font = ImGui_GetFont(window_size.y / 48.0f); // = 16
-			// render background texture
-			if (g_shaderCacheLoaderState.textureTVId)
-			{
-				ImGui::SetNextWindowPos({ 0, 0 }, ImGuiCond_Always);
-				ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
-				ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
-				ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
-				if (ImGui::Begin("Background texture", nullptr, kPopupFlags | ImGuiWindowFlags_NoBringToFrontOnFocus))
-				{
-					float imageDisplayWidth = io.DisplaySize.x;
-					float imageDisplayHeight = 720 * imageDisplayWidth / 1280;
-
-					float paddingLeftAndRight = 0.0f;
-					float paddingTopAndBottom = (io.DisplaySize.y - imageDisplayHeight) / 2.0f;
-					if (imageDisplayHeight > io.DisplaySize.y)
-					{
-						imageDisplayHeight = io.DisplaySize.y;
-						imageDisplayWidth = 1280 * imageDisplayHeight / 720;
-						paddingLeftAndRight = (io.DisplaySize.x - imageDisplayWidth) / 2.0f;
-						paddingTopAndBottom = 0.0f;
-					}
-
-					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureTVId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
-				}
-				ImGui::End();
-				ImGui::PopStyleVar(2);
-			}
 
 			ImVec2 position = { window_size.x / 2.0f, window_size.y / 2.0f };
 			ImVec2 pivot = { 0.5f, 0.5f };
@@ -539,33 +483,9 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 		}
 
 		g_renderer->BeginFrame(false);
-		if (g_renderer->ImguiBegin(false))
+		if(g_renderer->ImguiBegin(false))
 		{
-			ImGui::SetNextWindowPos({ 0,0 }, ImGuiCond_Always);
-			ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0);
-			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0,0 });
-			if (ImGui::Begin("Background texture2", nullptr, kPopupFlags))
-			{
-				if (g_shaderCacheLoaderState.textureDRCId)
-				{
-					float imageDisplayWidth = io.DisplaySize.x;
-					float imageDisplayHeight = 480 * imageDisplayWidth / 854;
-
-					float paddingLeftAndRight = 0.0f;
-					float paddingTopAndBottom = (io.DisplaySize.y - imageDisplayHeight)/2.0f;
-					if (imageDisplayHeight > io.DisplaySize.y)
-					{
-						imageDisplayHeight = io.DisplaySize.y;
-						imageDisplayWidth = 854 * imageDisplayHeight / 480;
-						paddingLeftAndRight = (io.DisplaySize.x - imageDisplayWidth)/2.0f;
-						paddingTopAndBottom = 0.0f;
-					}
-					ImGui::GetWindowDrawList()->AddImage(g_shaderCacheLoaderState.textureDRCId, ImVec2(paddingLeftAndRight, paddingTopAndBottom), ImVec2(io.DisplaySize.x-paddingLeftAndRight, io.DisplaySize.y-paddingTopAndBottom), { 0,1 }, { 1,0 });
-				}
-			}
-			ImGui::End();
-			ImGui::PopStyleVar(2);
+			LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureDRCId, 854, 480);
 			g_renderer->ImguiEnd();
 		}
 

--- a/src/Cafe/HW/Latte/Core/LatteThread.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteThread.cpp
@@ -119,17 +119,9 @@ int Latte_ThreadEntry()
 	sint32 w,h;
 	gui_getWindowPhysSize(w,h);
 
-	// imgui
-	ImGui::CreateContext();
-	ImGuiIO& io = ImGui::GetIO();
-	io.WantSaveIniSettings = false;
-	io.IniFilename = nullptr;
-	io.Fonts->AddFontDefault();
-
 	// renderer
 	g_renderer->Initialize();
 	RendererOutputShader::InitializeStatic();
-	io.DisplaySize = ImVec2((float)w, (float)h);
 
 	LatteTiming_Init();
 	LatteTexture_init();

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -252,6 +252,7 @@ void LoadOpenGLImports()
 
 void OpenGLRenderer::Initialize()
 {
+	Renderer::Initialize();
 	auto lock = cafeLog_acquire();
 	forceLog_printf("------- Init OpenGL graphics backend -------");
 

--- a/src/Cafe/HW/Latte/Renderer/Renderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Renderer.cpp
@@ -44,15 +44,17 @@ void Renderer::Initialize()
 	imguiFontAtlas = new ImFontAtlas();
 	imguiFontAtlas->AddFontDefault();
 
-	auto setupContext = [](ImGuiIO& io){
+	auto setupContext = [](ImGuiContext* context){
+		ImGui::SetCurrentContext(context);
+		ImGuiIO& io = ImGui::GetIO();
 		io.WantSaveIniSettings = false;
 		io.IniFilename = nullptr;
 	};
 
 	imguiTVContext = ImGui::CreateContext(imguiFontAtlas);
-	setupContext(ImGui::GetIO());
 	imguiPadContext = ImGui::CreateContext(imguiFontAtlas);
-	setupContext(ImGui::GetIO());
+	setupContext(imguiTVContext);
+	setupContext(imguiPadContext);
 }
 
 void Renderer::Shutdown()

--- a/src/Cafe/HW/Latte/Renderer/Renderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Renderer.cpp
@@ -37,6 +37,32 @@ bool Renderer::GetVRAMInfo(int& usageInMB, int& totalInMB) const
 	return false;
 }
 
+
+void Renderer::Initialize()
+{
+	// imgui
+	imguiFontAtlas = new ImFontAtlas();
+	imguiFontAtlas->AddFontDefault();
+
+	auto setupContext = [](ImGuiIO& io){
+		io.WantSaveIniSettings = false;
+		io.IniFilename = nullptr;
+	};
+
+	imguiTVContext = ImGui::CreateContext(imguiFontAtlas);
+	setupContext(ImGui::GetIO());
+	imguiPadContext = ImGui::CreateContext(imguiFontAtlas);
+	setupContext(ImGui::GetIO());
+}
+
+void Renderer::Shutdown()
+{
+	// imgui
+	ImGui::DestroyContext(imguiTVContext);
+	ImGui::DestroyContext(imguiPadContext);
+	delete imguiFontAtlas;
+}
+
 bool Renderer::ImguiBegin(bool mainWindow)
 {
 	sint32 w = 0, h = 0;
@@ -49,6 +75,9 @@ bool Renderer::ImguiBegin(bool mainWindow)
 		
 	if (w == 0 || h == 0)
 		return false;
+
+	// select the right context
+	ImGui::SetCurrentContext(mainWindow ? imguiTVContext : imguiPadContext);
 
 	const Vector2f window_size{ (float)w,(float)h };
 	auto& io = ImGui::GetIO();

--- a/src/Cafe/HW/Latte/Renderer/Renderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Renderer.h
@@ -7,11 +7,14 @@
 #include "Cafe/HW/Latte/Core/LatteTextureReadbackInfo.h"
 #include "Cafe/HW/Latte/Core/LatteQueryObject.h"
 #include "Cafe/HW/Latte/Renderer/RendererOuputShader.h"
-#include <imgui.h>
 
 #if BOOST_OS_WINDOWS
 #include "util/DXGIWrapper/DXGIWrapper.h"
 #endif
+
+// imgui forward declarations
+struct ImFontAtlas;
+struct ImGuiContext;
 
 enum class GfxVendor
 {

--- a/src/Cafe/HW/Latte/Renderer/Renderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Renderer.h
@@ -7,6 +7,7 @@
 #include "Cafe/HW/Latte/Core/LatteTextureReadbackInfo.h"
 #include "Cafe/HW/Latte/Core/LatteQueryObject.h"
 #include "Cafe/HW/Latte/Renderer/RendererOuputShader.h"
+#include <imgui.h>
 
 #if BOOST_OS_WINDOWS
 #include "util/DXGIWrapper/DXGIWrapper.h"
@@ -51,8 +52,8 @@ public:
 
 	virtual RendererAPI GetType() = 0;
 
-	virtual void Initialize() {}
-	virtual void Shutdown() {}
+	virtual void Initialize();
+	virtual void Shutdown();
 	virtual bool IsPadWindowActive() = 0;
 
 	virtual bool GetVRAMInfo(int& usageInMB, int& totalInMB) const;
@@ -169,6 +170,11 @@ protected:
 	};
 	ScreenshotState m_screenshot_state = ScreenshotState::None;
 	void SaveScreenshot(const std::vector<uint8>& rgb_data, int width, int height, bool mainWindow) const;
+
+
+	ImFontAtlas* imguiFontAtlas{};
+	ImGuiContext* imguiTVContext{};
+	ImGuiContext* imguiPadContext{};
 
 #if BOOST_OS_WINDOWS
 	std::unique_ptr<DXGIWrapper> m_dxgi_wrapper{};

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1517,6 +1517,7 @@ void VulkanRenderer::ImguiInit()
 
 void VulkanRenderer::Initialize()
 {
+	Renderer::Initialize();
 	CreatePipelineCache();
 	ImguiInit();
 	CreateNullObjects();
@@ -1524,6 +1525,7 @@ void VulkanRenderer::Initialize()
 
 void VulkanRenderer::Shutdown()
 {
+	Renderer::Shutdown();
 	SubmitCommandBuffer();
 	WaitDeviceIdle();
 }

--- a/src/imgui/imgui_extension.cpp
+++ b/src/imgui/imgui_extension.cpp
@@ -50,14 +50,6 @@ extern char const g_fontawesome_data[];
 std::unordered_map<int, ImFont*> g_imgui_fonts;
 std::stack<int> g_font_requests;
 
-bool ImGui_BeginPadDistinct(const char* name, bool* p_open, ImGuiWindowFlags flags, bool pad)
-{
-	std::string distinctName = name;
-	if (pad)
-		distinctName += "##pad";
-	return ImGui::Begin(distinctName.c_str(), p_open, flags);
-}
-
 void ImGui_PrecacheFonts()
 {
 	while (!g_font_requests.empty())


### PR DESCRIPTION
Does what the title says and also removes some duplicate code from the cache loading screen.
Feedback very welcome.
Perhaps the context initialization code should go in the Renderer Constructor/destructor instead of Initialize and Shutdown?
Fixes: #651