### PR TITLE
Add back missing flag to keep background image in background

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -183,7 +183,8 @@ void LatteShaderCache_drawBackgroundImage(ImTextureID texture, int width, int he
 	// clear framebuffers and clean up
 	const auto kPopupFlags =
 			ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings |
-			ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize;
+			ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize |
+			ImGuiWindowFlags_NoBringToFrontOnFocus;
 	auto& io = ImGui::GetIO();
 	ImGui::SetNextWindowPos({0, 0}, ImGuiCond_Always);
 	ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -369,7 +369,6 @@ void LatteShaderCache_load()
 
 void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateFunc, bool isPipelines)
 {
-	auto& io = ImGui::GetIO();
 	const auto kPopupFlags = ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_AlwaysAutoResize;
 	const auto textColor = 0xFF888888;
 	
@@ -396,6 +395,8 @@ void LatteShaderCache_ShowProgress(const std::function <bool(void)>& loadUpdateF
 		g_renderer->BeginFrame(true);
 		if (g_renderer->ImguiBegin(true))
 		{
+			auto& io = ImGui::GetIO();
+
 			// render background texture
 			LatteShaderCache_drawBackgroundImage(g_shaderCacheLoaderState.textureTVId, 1280, 720);
 


### PR DESCRIPTION
Fixes: #666
I did not look at the flags closely enough.
Also fix a bug where the progress bar would size according to the gamepad context. Fixed by getting the context IO after ImguiBegin switches to the correct context.