### PR TITLE
Fix building with cubeb disabled

### DIFF
--- a/src/audio/IAudioAPI.cpp
+++ b/src/audio/IAudioAPI.cpp
@@ -6,7 +6,9 @@
 #include "DirectSoundAPI.h"
 #endif
 #include "config/CemuConfig.h"
+#if HAS_CUBEB
 #include "CubebAPI.h"
+#endif
 
 std::shared_mutex g_audioMutex;
 AudioAPIPtr g_tvAudio;
@@ -80,7 +82,9 @@ void IAudioAPI::InitializeStatic()
 	if(!s_availableApis[XAudio2]) // don't try to initialize the older lib if the newer version is available
 		s_availableApis[XAudio27] = XAudio27API::InitializeStatic();
 #endif
+#if HAS_CUBEB
 	s_availableApis[Cubeb] = CubebAPI::InitializeStatic();
+#endif
 }
 
 bool IAudioAPI::IsAudioAPIAvailable(AudioAPI api)
@@ -118,11 +122,13 @@ AudioAPIPtr IAudioAPI::CreateDevice(AudioAPI api, const DeviceDescriptionPtr& de
 		return std::make_unique<XAudio2API>(tmp->GetDeviceId(), samplerate, channels, samples_per_block, bits_per_sample);
 	}
 #endif
+#if HAS_CUBEB
     case Cubeb:
     {
         const auto tmp = std::dynamic_pointer_cast<CubebAPI::CubebDeviceDescription>(device);
         return std::make_unique<CubebAPI>(tmp->GetDeviceId(), samplerate, channels, samples_per_block, bits_per_sample);
     }
+#endif
 	default:
 		throw std::runtime_error(fmt::format("invalid audio api: {}", api));
 	}
@@ -149,10 +155,12 @@ std::vector<IAudioAPI::DeviceDescriptionPtr> IAudioAPI::GetDevices(AudioAPI api)
 		return XAudio2API::GetDevices();
 	}
 #endif
+#if HAS_CUBEB
 	case Cubeb:
 	{
 		return CubebAPI::GetDevices();
 	}
+#endif
 	default:
 		throw std::runtime_error(fmt::format("invalid audio api: {}", api));
 	}

--- a/src/audio/IAudioInputAPI.cpp
+++ b/src/audio/IAudioInputAPI.cpp
@@ -1,5 +1,7 @@
 #include "IAudioInputAPI.h"
+#if HAS_CUBEB
 #include "CubebInputAPI.h"
+#endif
 
 std::shared_mutex g_audioInputMutex;
 AudioInputAPIPtr g_inputAudio;
@@ -20,7 +22,9 @@ void IAudioInputAPI::PrintLogging()
 
 void IAudioInputAPI::InitializeStatic()
 {
+#if HAS_CUBEB
 	s_availableApis[Cubeb] = CubebInputAPI::InitializeStatic();
+#endif
 }
 
 bool IAudioInputAPI::IsAudioInputAPIAvailable(AudioInputAPI api)
@@ -39,11 +43,13 @@ AudioInputAPIPtr IAudioInputAPI::CreateDevice(AudioInputAPI api, const DeviceDes
 
 	switch(api)
 	{
+#if HAS_CUBEB
 	case Cubeb:
 	{
 		const auto tmp = std::dynamic_pointer_cast<CubebInputAPI::CubebDeviceDescription>(device);
 		return std::make_unique<CubebInputAPI>(tmp->GetDeviceId(), samplerate, channels, samples_per_block, bits_per_sample);
 	}
+#endif
 	default:
 		throw std::runtime_error(fmt::format("invalid audio api: {}", api));
 	}
@@ -56,10 +62,12 @@ std::vector<IAudioInputAPI::DeviceDescriptionPtr> IAudioInputAPI::GetDevices(Aud
 	
 	switch(api)
 	{
+#if HAS_CUBEB
 	case Cubeb:
 	{
 		return CubebInputAPI::GetDevices();
 	}
+#endif
 	default:
 		throw std::runtime_error(fmt::format("invalid audio api: {}", api));
 	}


### PR DESCRIPTION
This PR fixes Cemu builds with `ENABLE_CUBEB=OFF` by adding a couple of missing ifdefs. I've had to disable cubeb as it caused the build to fail on my Ubuntu 22.04/amd64 PC.