### PR TITLE
Delete dead EmulatedController::find_controller method

### DIFF
--- a/src/input/emulated/EmulatedController.cpp
+++ b/src/input/emulated/EmulatedController.cpp
@@ -207,16 +207,6 @@ glm::vec2 EmulatedController::get_prev_position() const
 	return {};
 }
 
-std::shared_ptr<ControllerBase> EmulatedController::find_controller(std::string_view uuid, InputAPI::Type type) const
-{
-	std::scoped_lock lock(m_mutex);
-	const auto it = std::find_if(m_controllers.cbegin(), m_controllers.cend(), [uuid, type](const auto& c) { return c->api() == type && c->uuid() == uuid; });
-	if (it != m_controllers.cend())
-		return *it;
-
-	return {};
-}
-
 void EmulatedController::add_controller(std::shared_ptr<ControllerBase> controller)
 {
 	controller->connect();

--- a/src/input/emulated/EmulatedController.h
+++ b/src/input/emulated/EmulatedController.h
@@ -67,8 +67,7 @@ public:
 	bool has_position() const;
 	glm::vec2 get_position() const;
 	glm::vec2 get_prev_position() const;
-	
-	std::shared_ptr<ControllerBase> find_controller(std::string_view uuid, InputAPI::Type type) const;
+
 	void add_controller(std::shared_ptr<ControllerBase> controller);
 	void remove_controller(const std::shared_ptr<ControllerBase>& controller);
 	void clear_controllers();


### PR DESCRIPTION
I noticed that the `EmulatedController::find_controller` method is dead code. I figure that we'd like it removed?

Here's the github search showing that it's dead code.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3466499/221365199-eb8644c1-2e84-46c7-8f62-39c1f74af36c.png">

I've compiled this change and played around with it in the input settings screen just to confirm that nothing is broken.
