### PR TITLE
Utilize VK_KHR_SHADER_FLOAT_CONTROLS if available

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -1,19 +1,24 @@
 #include "Cafe/HW/Latte/Core/LatteConst.h"
 #include "Cafe/HW/Latte/Core/LatteShaderAssembly.h"
 #include "Cafe/HW/Latte/ISA/RegDefines.h"
-#include "Cafe/OS/libs/gx2/GX2.h" // todo - remove dependency
 #include "Cafe/HW/Latte/ISA/LatteReg.h"
 #include "Cafe/HW/Latte/Core/LatteShader.h"
 #include "Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h"
 #include "Cafe/HW/Latte/Core/FetchShader.h"
 #include "Cafe/HW/Latte/Core/LattePerformanceMonitor.h"
+#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h"
+#include "Cafe/OS/libs/gx2/GX2.h" // todo - remove dependency
 #include "Cafe/GraphicPack/GraphicPack2.h"
 #include "util/helpers/StringParser.h"
 #include "config/ActiveSettings.h"
-#include "util/Zir/EmitterGLSL/ZpIREmitGLSL.h"
-#include "util/Zir/Core/ZpIRDebug.h"
 #include "util/containers/flat_hash_map.hpp"
 #include <cinttypes>
+
+// experimental new decompiler (WIP)
+#include "util/Zir/EmitterGLSL/ZpIREmitGLSL.h"
+#include "util/Zir/Core/ZpIRDebug.h"
+#include "Cafe/HW/Latte/Transcompiler/LatteTC.h"
+#include "Cafe/HW/Latte/ShaderInfo/ShaderInfo.h"
 
 struct _ShaderHashCache
 {
@@ -672,10 +677,18 @@ LatteDecompilerShader* LatteShader_CreateShaderFromDecompilerOutput(LatteDecompi
 	return shader;
 }
 
-#include "Cafe/HW/Latte/Transcompiler/LatteTC.h"
-#include "Cafe/HW/Latte/ShaderInfo/ShaderInfo.h"
+void LatteShader_GetDecompilerOptions(LatteDecompilerOptions& options, LatteConst::ShaderType shaderType, bool geometryShaderEnabled)
+{
+	options.usesGeometryShader = geometryShaderEnabled;
+	options.spirvInstrinsics.hasRoundingModeRTEFloat32 = false;
+	if (g_renderer->GetType() == RendererAPI::Vulkan)
+	{
+		options.useTFViaSSBO = VulkanRenderer::GetInstance()->UseTFViaSSBO();
+		options.spirvInstrinsics.hasRoundingModeRTEFloat32 = VulkanRenderer::GetInstance()->HasSPRIVRoundingModeRTE32();
+	}
+}
 
-LatteDecompilerShader* LatteShader_compileSeparableVertexShader(uint64 baseHash, uint64& vsAuxHash, uint8* vertexShaderPtr, uint32 vertexShaderSize, bool usesGeometryShader, LatteFetchShader* fetchShader)
+LatteDecompilerShader* LatteShader_CompileSeparableVertexShader2(uint64 baseHash, uint64& vsAuxHash, uint8* vertexShaderPtr, uint32 vertexShaderSize, bool usesGeometryShader, LatteFetchShader* fetchShader)
 {
 	/* Analyze shader to gather general information about inputs/outputs */
 	Latte::ShaderDescription shaderDescription;
@@ -725,14 +738,17 @@ LatteDecompilerShader* LatteShader_compileSeparableVertexShader(uint64 baseHash,
 // compile new vertex shader (relies partially on current state)
 LatteDecompilerShader* LatteShader_CompileSeparableVertexShader(uint64 baseHash, uint64& vsAuxHash, uint8* vertexShaderPtr, uint32 vertexShaderSize, bool usesGeometryShader, LatteFetchShader* fetchShader)
 {
-	// new decompiler
-	//LatteShader_compileSeparableVertexShader(baseHash, vsAuxHash, vertexShaderPtr, vertexShaderSize, usesGeometryShader, fetchShader);
+	// new decompiler test
+	//LatteShader_CompileSeparableVertexShader2(baseHash, vsAuxHash, vertexShaderPtr, vertexShaderSize, usesGeometryShader, fetchShader);
 
 	// legacy decompiler
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Vertex, usesGeometryShader);
+
 	LatteDecompilerOutput_t decompilerOutput{};
 	LatteFetchShader* fetchShaderList[1];
 	fetchShaderList[0] = fetchShader;
-	LatteDecompiler_DecompileVertexShader(_shaderBaseHash_vs, LatteGPUState.contextRegister, vertexShaderPtr, vertexShaderSize, fetchShaderList, 1, LatteGPUState.contextNew.GetSpecialStateValues(), usesGeometryShader, &decompilerOutput);
+	LatteDecompiler_DecompileVertexShader(_shaderBaseHash_vs, LatteGPUState.contextRegister, vertexShaderPtr, vertexShaderSize, fetchShaderList, 1, LatteGPUState.contextNew.GetSpecialStateValues(), options, &decompilerOutput);
 	LatteDecompilerShader* vertexShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	vsAuxHash = vertexShader->auxHash;
 	if (vertexShader->hasError == false)
@@ -759,10 +775,13 @@ LatteDecompilerShader* LatteShader_CompileSeparableVertexShader(uint64 baseHash,
 
 LatteDecompilerShader* LatteShader_CompileSeparableGeometryShader(uint64 baseHash, uint8* geometryShaderPtr, uint32 geometryShaderSize, uint8* geometryCopyShader, uint32 geometryCopyShaderSize)
 {
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Geometry, true);
+
 	LatteDecompilerOutput_t decompilerOutput{};
 	LatteFetchShader* fetchShaderList[1];
 	fetchShaderList[0] = _activeFetchShader;
-	LatteDecompiler_DecompileGeometryShader(_shaderBaseHash_gs, LatteGPUState.contextRegister, geometryShaderPtr, geometryShaderSize, geometryCopyShader, geometryCopyShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), _activeVertexShader->ringParameterCount, &decompilerOutput);
+	LatteDecompiler_DecompileGeometryShader(_shaderBaseHash_gs, LatteGPUState.contextRegister, geometryShaderPtr, geometryShaderSize, geometryCopyShader, geometryCopyShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), _activeVertexShader->ringParameterCount, options, &decompilerOutput);
 	LatteDecompilerShader* geometryShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	if (geometryShader->hasError == false)
 	{
@@ -787,8 +806,11 @@ LatteDecompilerShader* LatteShader_CompileSeparableGeometryShader(uint64 baseHas
 
 LatteDecompilerShader* LatteShader_CompileSeparablePixelShader(uint64 baseHash, uint64& psAuxHash, uint8* pixelShaderPtr, uint32 pixelShaderSize, bool usesGeometryShader)
 {
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Pixel, usesGeometryShader);
+
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompilePixelShader(baseHash, LatteGPUState.contextRegister, pixelShaderPtr, pixelShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), usesGeometryShader, &decompilerOutput);
+	LatteDecompiler_DecompilePixelShader(baseHash, LatteGPUState.contextRegister, pixelShaderPtr, pixelShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), options, &decompilerOutput);
 	LatteDecompilerShader* pixelShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	psAuxHash = pixelShader->auxHash;
 	LatteShader_DumpShader(_shaderBaseHash_ps, psAuxHash, pixelShader);

--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -549,7 +549,7 @@ uint64 LatteSHRC_CalcVSAuxHash(LatteDecompilerShader* vertexShader, uint32* cont
 		// hash stride for streamout buffers
 		for (uint32 i = 0; i < LATTE_NUM_STREAMOUT_BUFFER; i++)
 		{
-			if(!vertexShader->streamoutBufferWriteMask2[i])
+			if(!vertexShader->streamoutBufferWriteMask[i])
 				continue;
 			uint32 bufferStride = contextRegisters[mmVGT_STRMOUT_VTX_STRIDE_0 + i * 4];
 			auxHash = std::rotl<uint64>(auxHash, 7);
@@ -617,7 +617,7 @@ LatteDecompilerShader* LatteShader_CreateShaderFromDecompilerOutput(LatteDecompi
 	// copy texture info
 	shader->textureUnitMask2 = decompilerOutput.textureUnitMask;
 	// copy streamout info
-	shader->streamoutBufferWriteMask2 = decompilerOutput.streamoutBufferWriteMask;
+	shader->streamoutBufferWriteMask = decompilerOutput.streamoutBufferWriteMask;
 	shader->hasStreamoutBufferWrite = decompilerOutput.streamoutBufferWriteMask.any();
 	// copy uniform offsets
 	// for OpenGL these are retrieved in _prepareSeparableUniforms()
@@ -746,9 +746,7 @@ LatteDecompilerShader* LatteShader_CompileSeparableVertexShader(uint64 baseHash,
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Vertex, usesGeometryShader);
 
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteFetchShader* fetchShaderList[1];
-	fetchShaderList[0] = fetchShader;
-	LatteDecompiler_DecompileVertexShader(_shaderBaseHash_vs, LatteGPUState.contextRegister, vertexShaderPtr, vertexShaderSize, fetchShaderList, 1, LatteGPUState.contextNew.GetSpecialStateValues(), options, &decompilerOutput);
+	LatteDecompiler_DecompileVertexShader(_shaderBaseHash_vs, LatteGPUState.contextRegister, vertexShaderPtr, vertexShaderSize, fetchShader, options, &decompilerOutput);
 	LatteDecompilerShader* vertexShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	vsAuxHash = vertexShader->auxHash;
 	if (vertexShader->hasError == false)
@@ -779,9 +777,7 @@ LatteDecompilerShader* LatteShader_CompileSeparableGeometryShader(uint64 baseHas
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Geometry, true);
 
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteFetchShader* fetchShaderList[1];
-	fetchShaderList[0] = _activeFetchShader;
-	LatteDecompiler_DecompileGeometryShader(_shaderBaseHash_gs, LatteGPUState.contextRegister, geometryShaderPtr, geometryShaderSize, geometryCopyShader, geometryCopyShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), _activeVertexShader->ringParameterCount, options, &decompilerOutput);
+	LatteDecompiler_DecompileGeometryShader(_shaderBaseHash_gs, LatteGPUState.contextRegister, geometryShaderPtr, geometryShaderSize, geometryCopyShader, geometryCopyShaderSize, _activeVertexShader->ringParameterCount, options, &decompilerOutput);
 	LatteDecompilerShader* geometryShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	if (geometryShader->hasError == false)
 	{
@@ -810,7 +806,7 @@ LatteDecompilerShader* LatteShader_CompileSeparablePixelShader(uint64 baseHash, 
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Pixel, usesGeometryShader);
 
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompilePixelShader(baseHash, LatteGPUState.contextRegister, pixelShaderPtr, pixelShaderSize, LatteGPUState.contextNew.GetSpecialStateValues(), options, &decompilerOutput);
+	LatteDecompiler_DecompilePixelShader(baseHash, LatteGPUState.contextRegister, pixelShaderPtr, pixelShaderSize, options, &decompilerOutput);
 	LatteDecompilerShader* pixelShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, baseHash, true, 0, LatteGPUState.contextRegister);
 	psAuxHash = pixelShader->auxHash;
 	LatteShader_DumpShader(_shaderBaseHash_ps, psAuxHash, pixelShader);

--- a/src/Cafe/HW/Latte/Core/LatteShader.h
+++ b/src/Cafe/HW/Latte/Core/LatteShader.h
@@ -94,6 +94,7 @@ extern uint64 _shaderBaseHash_vs;
 extern uint64 _shaderBaseHash_gs;
 extern uint64 _shaderBaseHash_ps;
 
+void LatteShader_GetDecompilerOptions(struct LatteDecompilerOptions& options, LatteConst::ShaderType shaderType, bool geometryShaderEnabled);
 LatteDecompilerShader* LatteShader_CreateShaderFromDecompilerOutput(LatteDecompilerOutput_t& decompilerOutput, uint64 baseHash, bool calculateAuxHash, uint64 optionalAuxHash, uint32* contextRegister);
 
 void LatteShader_CreateRendererShader(LatteDecompilerShader* shader, bool compileAsync);

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -651,15 +651,12 @@ bool LatteShaderCache_readSeparableVertexShader(MemStreamReader& streamReader, u
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Vertex, usesGeometryShader);
 	// decompile vertex shader
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteFetchShader* fetchShaderList[1];
-	fetchShaderList[0] = fetchShader;
-	LatteDecompiler_DecompileVertexShader(shaderBaseHash, lcr->GetRawView(), vertexShaderData.data(), vertexShaderData.size(), fetchShaderList, 1, lcr->GetSpecialStateValues(), options, &decompilerOutput);
+	LatteDecompiler_DecompileVertexShader(shaderBaseHash, lcr->GetRawView(), vertexShaderData.data(), vertexShaderData.size(), fetchShader, options, &decompilerOutput);
 	LatteDecompilerShader* vertexShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, vertexShader);
 	LatteShader_DumpRawShader(shaderBaseHash, shaderAuxHash, SHADER_DUMP_TYPE_VERTEX, vertexShaderData.data(), vertexShaderData.size());
 	LatteShaderCache_loadOrCompileSeparableShader(vertexShader, shaderBaseHash, shaderAuxHash);
-	catchOpenGLError();
 	LatteSHRC_RegisterShader(vertexShader, shaderBaseHash, shaderAuxHash);
 	return true;
 }
@@ -696,7 +693,7 @@ bool LatteShaderCache_readSeparableGeometryShader(MemStreamReader& streamReader,
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Geometry, true);
 	// decompile geometry shader
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompileGeometryShader(shaderBaseHash, lcr->GetRawView(), geometryShaderData.data(), geometryShaderData.size(), geometryCopyShaderData.data(), geometryCopyShaderData.size(), lcr->GetSpecialStateValues(), vsRingParameterCount, options, &decompilerOutput);
+	LatteDecompiler_DecompileGeometryShader(shaderBaseHash, lcr->GetRawView(), geometryShaderData.data(), geometryShaderData.size(), geometryCopyShaderData.data(), geometryCopyShaderData.size(), vsRingParameterCount, options, &decompilerOutput);
 	LatteDecompilerShader* geometryShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, geometryShader);
@@ -734,13 +731,12 @@ bool LatteShaderCache_readSeparablePixelShader(MemStreamReader& streamReader, ui
 	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Pixel, usesGeometryShader);
 	// decompile pixel shader
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompilePixelShader(shaderBaseHash, lcr->GetRawView(), pixelShaderData.data(), pixelShaderData.size(), lcr->GetSpecialStateValues(), options, &decompilerOutput);
+	LatteDecompiler_DecompilePixelShader(shaderBaseHash, lcr->GetRawView(), pixelShaderData.data(), pixelShaderData.size(), options, &decompilerOutput);
 	LatteDecompilerShader* pixelShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, pixelShader);
 	LatteShader_DumpRawShader(shaderBaseHash, shaderAuxHash, SHADER_DUMP_TYPE_PIXEL, pixelShaderData.data(), pixelShaderData.size());
 	LatteShaderCache_loadOrCompileSeparableShader(pixelShader, shaderBaseHash, shaderAuxHash);
-	catchOpenGLError();
 	LatteSHRC_RegisterShader(pixelShader, shaderBaseHash, shaderAuxHash);
 	return true;
 }

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -641,16 +641,19 @@ bool LatteShaderCache_readSeparableVertexShader(MemStreamReader& streamReader, u
 		return false;
 	if (streamReader.hasError() || !streamReader.isEndOfStream())
 		return false;
-	// update PS inputs (influence VS shader outputs)
+	// update PS inputs (affects VS shader outputs)
 	LatteShader_UpdatePSInputs(lcr->GetRawView());
 	// get fetch shader
 	LatteFetchShader::CacheHash fsHash = LatteFetchShader::CalculateCacheHash((uint32*)fetchShaderData.data(), fetchShaderData.size());
 	LatteFetchShader* fetchShader = LatteShaderRecompiler_createFetchShader(fsHash, lcr->GetRawView(), (uint32*)fetchShaderData.data(), fetchShaderData.size());
+	// determine decompiler options
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Vertex, usesGeometryShader);
 	// decompile vertex shader
 	LatteDecompilerOutput_t decompilerOutput{};
 	LatteFetchShader* fetchShaderList[1];
 	fetchShaderList[0] = fetchShader;
-	LatteDecompiler_DecompileVertexShader(shaderBaseHash, lcr->GetRawView(), vertexShaderData.data(), vertexShaderData.size(), fetchShaderList, 1, lcr->GetSpecialStateValues(), usesGeometryShader, &decompilerOutput);
+	LatteDecompiler_DecompileVertexShader(shaderBaseHash, lcr->GetRawView(), vertexShaderData.data(), vertexShaderData.size(), fetchShaderList, 1, lcr->GetSpecialStateValues(), options, &decompilerOutput);
 	LatteDecompilerShader* vertexShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, vertexShader);
@@ -688,15 +691,17 @@ bool LatteShaderCache_readSeparableGeometryShader(MemStreamReader& streamReader,
 		return false;
 	// update PS inputs
 	LatteShader_UpdatePSInputs(lcr->GetRawView());
+	// determine decompiler options
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Geometry, true);
 	// decompile geometry shader
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompileGeometryShader(shaderBaseHash, lcr->GetRawView(), geometryShaderData.data(), geometryShaderData.size(), geometryCopyShaderData.data(), geometryCopyShaderData.size(), lcr->GetSpecialStateValues(), vsRingParameterCount, &decompilerOutput);
+	LatteDecompiler_DecompileGeometryShader(shaderBaseHash, lcr->GetRawView(), geometryShaderData.data(), geometryShaderData.size(), geometryCopyShaderData.data(), geometryCopyShaderData.size(), lcr->GetSpecialStateValues(), vsRingParameterCount, options, &decompilerOutput);
 	LatteDecompilerShader* geometryShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, geometryShader);
 	LatteShader_DumpRawShader(shaderBaseHash, shaderAuxHash, SHADER_DUMP_TYPE_GEOMETRY, geometryShaderData.data(), geometryShaderData.size());
 	LatteShaderCache_loadOrCompileSeparableShader(geometryShader, shaderBaseHash, shaderAuxHash);
-	catchOpenGLError();
 	LatteSHRC_RegisterShader(geometryShader, shaderBaseHash, shaderAuxHash);
 	return true;
 }
@@ -724,9 +729,12 @@ bool LatteShaderCache_readSeparablePixelShader(MemStreamReader& streamReader, ui
 		return false;
 	// update PS inputs
 	LatteShader_UpdatePSInputs(lcr->GetRawView());
+	// determine decompiler options
+	LatteDecompilerOptions options;
+	LatteShader_GetDecompilerOptions(options, LatteConst::ShaderType::Pixel, usesGeometryShader);
 	// decompile pixel shader
 	LatteDecompilerOutput_t decompilerOutput{};
-	LatteDecompiler_DecompilePixelShader(shaderBaseHash, lcr->GetRawView(), pixelShaderData.data(), pixelShaderData.size(), lcr->GetSpecialStateValues(), usesGeometryShader, &decompilerOutput);
+	LatteDecompiler_DecompilePixelShader(shaderBaseHash, lcr->GetRawView(), pixelShaderData.data(), pixelShaderData.size(), lcr->GetSpecialStateValues(), options, &decompilerOutput);
 	LatteDecompilerShader* pixelShader = LatteShader_CreateShaderFromDecompilerOutput(decompilerOutput, shaderBaseHash, false, shaderAuxHash, lcr->GetRawView());
 	// compile
 	LatteShader_DumpShader(shaderBaseHash, shaderAuxHash, pixelShader);

--- a/src/Cafe/HW/Latte/Core/LatteStreamoutGPU.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteStreamoutGPU.cpp
@@ -101,16 +101,16 @@ void LatteStreamout_PrepareDrawcall(uint32 count, uint32 instanceCount)
 	if (geometryShader)
 	{
 #ifdef CEMU_DEBUG_ASSERT
-		cemu_assert_debug(vertexShader->streamoutBufferWriteMask2.any() == false);
+		cemu_assert_debug(vertexShader->streamoutBufferWriteMask.any() == false);
 #endif
 		for (sint32 i = 0; i < LATTE_NUM_STREAMOUT_BUFFER; i++)
-			if (geometryShader->streamoutBufferWriteMask2[i])
+			if (geometryShader->streamoutBufferWriteMask[i])
 				streamoutWriteMask |= (1 << i);
 	}
 	else
 	{
 		for (sint32 i = 0; i < LATTE_NUM_STREAMOUT_BUFFER; i++)
-			if (vertexShader->streamoutBufferWriteMask2[i])
+			if (vertexShader->streamoutBufferWriteMask[i])
 				streamoutWriteMask |= (1 << i);
 	}
 	activeStreamoutOperation.streamoutWriteMask = streamoutWriteMask;

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.cpp
@@ -1066,35 +1066,34 @@ void _LatteDecompiler_Process(LatteDecompilerShaderContext* shaderContext, uint8
 	_LatteDecompiler_GenerateDataForFastAccess(shaderContext->shader);
 }
 
-void LatteDecompiler_InitContext(LatteDecompilerShaderContext& dCtx, LatteDecompilerOutput_t* output, LatteConst::ShaderType shaderType, uint64 shaderBaseHash, uint32* contextRegisters)
+void LatteDecompiler_InitContext(LatteDecompilerShaderContext& dCtx, const LatteDecompilerOptions& options, LatteDecompilerOutput_t* output, LatteConst::ShaderType shaderType, uint64 shaderBaseHash, uint32* contextRegisters)
 {
 	dCtx.output = output;
 	dCtx.shaderType = shaderType;
+	dCtx.options = &options;
 	output->shaderType = shaderType;
 	dCtx.shaderBaseHash = shaderBaseHash;
 	dCtx.contextRegisters = contextRegisters;
 	dCtx.contextRegistersNew = (LatteContextRegister*)contextRegisters;
+
+	// set context parameters (redundant stuff since options can be accessed directly)
+	dCtx.usesGeometryShader = options.usesGeometryShader;
+	dCtx.useTFViaSSBO = options.useTFViaSSBO;
 }
 
-void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, LatteFetchShader** fetchShaderList, sint32 fetchShaderCount, uint32* hleSpecialState, bool usesGeometryShader, LatteDecompilerOutput_t* output, bool useTFViaSSBO)
+void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, struct LatteFetchShader** fetchShaderList, sint32 fetchShaderCount, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output)
 {
 	cemu_assert_debug((programSize & 3) == 0);
 	performanceMonitor.gpuTime_shaderCreate.beginMeasuring();
 	// prepare decompiler context
 	LatteDecompilerShaderContext shaderContext = { 0 };
-	LatteDecompiler_InitContext(shaderContext, output, LatteConst::ShaderType::Vertex, shaderBaseHash, contextRegisters);
+	LatteDecompiler_InitContext(shaderContext, options, output, LatteConst::ShaderType::Vertex, shaderBaseHash, contextRegisters);
 	cemu_assert_debug(fetchShaderCount == 1);
 	for (sint32 i = 0; i < fetchShaderCount; i++)
 	{
 		shaderContext.fetchShaderList[i] = fetchShaderList[i];
 	}
 	shaderContext.fetchShaderCount = fetchShaderCount;
-	// ugly hack to get tf mode from Vulkan renderer
-	shaderContext.useTFViaSSBO = useTFViaSSBO;
-	if (g_renderer->GetType() == RendererAPI::Vulkan)
-	{
-		shaderContext.useTFViaSSBO = VulkanRenderer::GetInstance()->useTFViaSSBO();
-	}
 	// prepare shader (deprecated)
 	LatteDecompilerShader* shader = new LatteDecompilerShader();
 	shader->shaderType = LatteConst::ShaderType::Vertex;
@@ -1103,7 +1102,6 @@ void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contex
 	output->shaderType = LatteConst::ShaderType::Vertex;
 	shaderContext.shader = shader;
 	output->shader = shader;
-	shaderContext.usesGeometryShader = usesGeometryShader;
 	for (sint32 i = 0; i < LATTE_NUM_MAX_TEX_UNITS; i++)
 	{
 		shader->textureUnitSamplerAssignment[i] = LATTE_DECOMPILER_SAMPLER_NONE;
@@ -1114,14 +1112,14 @@ void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contex
 	performanceMonitor.gpuTime_shaderCreate.endMeasuring();
 }
 
-void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32* hleSpecialState, uint32 vsRingParameterCount, LatteDecompilerOutput_t* output, bool useTFViaSSBO)
+void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32* hleSpecialState, uint32 vsRingParameterCount, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output)
 {
 	cemu_assert_debug((programSize & 3) == 0);
 	performanceMonitor.gpuTime_shaderCreate.beginMeasuring();
 	// prepare decompiler context
 	LatteDecompilerShaderContext shaderContext = { 0 };
 	shaderContext.fetchShaderCount = 0;
-	LatteDecompiler_InitContext(shaderContext, output, LatteConst::ShaderType::Geometry, shaderBaseHash, contextRegisters);
+	LatteDecompiler_InitContext(shaderContext, options, output, LatteConst::ShaderType::Geometry, shaderBaseHash, contextRegisters);
 	// prepare shader
 	LatteDecompilerShader* shader = new LatteDecompilerShader();
 	shaderContext.output = output;
@@ -1131,7 +1129,6 @@ void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* cont
 	output->shaderType = LatteConst::ShaderType::Geometry;
 	shaderContext.shader = shader;
 	output->shader = shader;
-	shaderContext.usesGeometryShader = true;
 	if (gsCopyProgramData == NULL)
 	{
 		shader->hasError = true;
@@ -1145,24 +1142,18 @@ void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* cont
 		shader->textureUnitSamplerAssignment[i] = LATTE_DECOMPILER_SAMPLER_NONE;
 		shader->textureUsesDepthCompare[i] = false;
 	}
-	// ugly hack to get tf mode from Vulkan renderer
-	shaderContext.useTFViaSSBO = useTFViaSSBO;
-	if (g_renderer->GetType() == RendererAPI::Vulkan)
-	{
-		shaderContext.useTFViaSSBO = VulkanRenderer::GetInstance()->useTFViaSSBO();
-	}
 	// parse & compile
 	_LatteDecompiler_Process(&shaderContext, programData, programSize);
 	performanceMonitor.gpuTime_shaderCreate.endMeasuring();
 }
 
-void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint32* hleSpecialState, bool usesGeometryShader, LatteDecompilerOutput_t* output)
+void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output)
 {
 	cemu_assert_debug((programSize & 3) == 0);
 	performanceMonitor.gpuTime_shaderCreate.beginMeasuring();
 	// prepare decompiler context
 	LatteDecompilerShaderContext shaderContext = { 0 };
-	LatteDecompiler_InitContext(shaderContext, output, LatteConst::ShaderType::Pixel, shaderBaseHash, contextRegisters);
+	LatteDecompiler_InitContext(shaderContext, options, output, LatteConst::ShaderType::Pixel, shaderBaseHash, contextRegisters);
 	shaderContext.contextRegisters = contextRegisters;
 	// prepare shader
 	LatteDecompilerShader* shader = new LatteDecompilerShader();
@@ -1172,7 +1163,6 @@ void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* context
 	output->shaderType = LatteConst::ShaderType::Pixel;
 	shaderContext.shader = shader;
 	output->shader = shader;
-	shaderContext.usesGeometryShader = usesGeometryShader;
 	for (sint32 i = 0; i < LATTE_NUM_MAX_TEX_UNITS; i++)
 	{
 		shader->textureUnitSamplerAssignment[i] = LATTE_DECOMPILER_SAMPLER_NONE;

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -218,7 +218,7 @@ struct LatteDecompilerShader
 		std::vector<LatteFastAccessRemappedUniformEntry_buffer_t> entries;
 	};
 	std::vector<LatteFastAccessRemappedUniformEntry_register_t>	list_remappedUniformEntries_register;
-	std::vector<_RemappedUniformBufferGroup>	list_remappedUniformEntries_bufferGroups;
+	std::vector<_RemappedUniformBufferGroup> list_remappedUniformEntries_bufferGroups;
 };
 
 struct LatteDecompilerOutputUniformOffsets
@@ -250,6 +250,17 @@ struct LatteDecompilerOutputUniformOffsets
 	}
 };
 
+struct LatteDecompilerOptions 
+{
+	bool usesGeometryShader{ false };
+	// Vulkan-specific
+	bool useTFViaSSBO{ false };
+	struct  
+	{
+		bool hasRoundingModeRTEFloat32{ false };
+	}spirvInstrinsics;
+};
+
 struct LatteDecompilerOutput_t
 {
 	LatteDecompilerShader* shader;
@@ -272,9 +283,9 @@ struct LatteDecompilerOutput_t
 
 struct LatteDecompilerSubroutineInfo;
 
-void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, struct LatteFetchShader** fetchShaderList, sint32 fetchShaderCount, uint32* hleSpecialState, bool usesGeometryShader, LatteDecompilerOutput_t* output, bool useTFViaSSBO = false);
-void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32* hleSpecialState, uint32 vsRingParameterCount, LatteDecompilerOutput_t* output, bool useTFViaSSBO = false);
-void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint32* hleSpecialState, bool usesGeometryShader, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, struct LatteFetchShader** fetchShaderList, sint32 fetchShaderCount, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32* hleSpecialState, uint32 vsRingParameterCount, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
 
 // specialized shader parsers
 

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -148,6 +148,8 @@ struct LatteDecompilerShaderResourceMapping
 
 struct LatteDecompilerShader
 {
+	LatteDecompilerShader(LatteConst::ShaderType shaderType) : shaderType(shaderType) {}
+
 	LatteDecompilerShader* next;
 	LatteConst::ShaderType shaderType;
 	uint64 baseHash;
@@ -167,21 +169,21 @@ struct LatteDecompilerShader
 	Latte::E_DIM textureUnitDim[LATTE_NUM_MAX_TEX_UNITS]; // dimension of texture unit, from the currently set texture
 	bool textureIsIntegerFormat[LATTE_NUM_MAX_TEX_UNITS]{};
 	// analyzer stage (uniforms)
-	uint8 uniformMode; // determines how uniforms are managed within the shader (see GPU7_DECOMPILER_UNIFORM_MODE_* constants)
+	uint8 uniformMode; // determines how uniforms are managed within the shader (see LATTE_DECOMPILER_UNIFORM_MODE_* constants)
 	uint64 uniformDataHash64[2]; // used to avoid redundant calls to glUniform*
 	std::vector<LatteDecompilerRemappedUniformEntry_t> list_remappedUniformEntries;
 	// analyzer stage (textures)
 	std::bitset<LATTE_NUM_MAX_TEX_UNITS> textureUnitMask2;
-	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]; // GPU7_SAMPLER_NONE means undefined
+	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]; // LATTE_DECOMPILER_SAMPLER_NONE means undefined
 	bool textureUsesDepthCompare[LATTE_NUM_MAX_TEX_UNITS];
 
 	// analyzer stage (pixel outputs)
-	uint32 pixelColorOutputMask; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments, may differ from export index inside the pixel shader)
+	uint32 pixelColorOutputMask; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments)
 	// analyzer stage (geometry shader parameters/inputs)
 	uint32 ringParameterCount;
 	uint32 ringParameterCountFromPrevStage; // used in geometry shader to hold VS ringParameterCount
 	// analyzer stage (misc)
-	std::bitset<LATTE_NUM_STREAMOUT_BUFFER> streamoutBufferWriteMask2;
+	std::bitset<LATTE_NUM_STREAMOUT_BUFFER> streamoutBufferWriteMask;
 	bool hasStreamoutBufferWrite;
 	// output code
 	class StringBuf* strBuf_shaderSource{nullptr};
@@ -283,9 +285,9 @@ struct LatteDecompilerOutput_t
 
 struct LatteDecompilerSubroutineInfo;
 
-void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, struct LatteFetchShader** fetchShaderList, sint32 fetchShaderCount, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
-void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32* hleSpecialState, uint32 vsRingParameterCount, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
-void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint32* hleSpecialState, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompileVertexShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, struct LatteFetchShader* fetchShader, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompileGeometryShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, uint8* gsCopyProgramData, uint32 gsCopyProgramSize, uint32 vsRingParameterCount, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
+void LatteDecompiler_DecompilePixelShader(uint64 shaderBaseHash, uint32* contextRegisters, uint8* programData, uint32 programSize, LatteDecompilerOptions& options, LatteDecompilerOutput_t* output);
 
 // specialized shader parsers
 

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -150,50 +150,50 @@ struct LatteDecompilerShader
 {
 	LatteDecompilerShader(LatteConst::ShaderType shaderType) : shaderType(shaderType) {}
 
-	LatteDecompilerShader* next;
+	LatteDecompilerShader* next{nullptr};
 	LatteConst::ShaderType shaderType;
-	uint64 baseHash;
-	uint64 auxHash;
+	uint64 baseHash{0};
+	uint64 auxHash{0};
 	// vertex shader
 	struct LatteFetchShader* compatibleFetchShader{};
 	// error tracking
-	bool hasError; // if set, the shader cannot be used
+	bool hasError{false}; // if set, the shader cannot be used
 	// optimized access / iteration
 	// list of uniform buffers used
 	uint8 uniformBufferList[LATTE_NUM_MAX_UNIFORM_BUFFERS];
-	uint8 uniformBufferListCount;
+	uint8 uniformBufferListCount{ 0 };
 	// list of used texture units (faster access than iterating textureUnitMask)
 	uint8 textureUnitList[LATTE_NUM_MAX_TEX_UNITS];
-	uint8 textureUnitListCount;
+	uint8 textureUnitListCount{ 0 };
 	// input
-	Latte::E_DIM textureUnitDim[LATTE_NUM_MAX_TEX_UNITS]; // dimension of texture unit, from the currently set texture
+	Latte::E_DIM textureUnitDim[LATTE_NUM_MAX_TEX_UNITS]{}; // dimension of texture unit, from the currently set texture
 	bool textureIsIntegerFormat[LATTE_NUM_MAX_TEX_UNITS]{};
 	// analyzer stage (uniforms)
-	uint8 uniformMode; // determines how uniforms are managed within the shader (see LATTE_DECOMPILER_UNIFORM_MODE_* constants)
-	uint64 uniformDataHash64[2]; // used to avoid redundant calls to glUniform*
+	uint8 uniformMode{0}; // determines how uniforms are managed within the shader (see LATTE_DECOMPILER_UNIFORM_MODE_* constants)
+	uint64 uniformDataHash64[2]{0}; // used to avoid redundant calls to glUniform*
 	std::vector<LatteDecompilerRemappedUniformEntry_t> list_remappedUniformEntries;
 	// analyzer stage (textures)
 	std::bitset<LATTE_NUM_MAX_TEX_UNITS> textureUnitMask2;
-	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]; // LATTE_DECOMPILER_SAMPLER_NONE means undefined
-	bool textureUsesDepthCompare[LATTE_NUM_MAX_TEX_UNITS];
+	uint16 textureUnitSamplerAssignment[LATTE_NUM_MAX_TEX_UNITS]{ 0 }; // LATTE_DECOMPILER_SAMPLER_NONE means undefined
+	bool textureUsesDepthCompare[LATTE_NUM_MAX_TEX_UNITS]{};
 
 	// analyzer stage (pixel outputs)
-	uint32 pixelColorOutputMask; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments)
+	uint32 pixelColorOutputMask{ 0 }; // from LSB to MSB, 1 bit per written output. 1 if written (indices of color attachments)
 	// analyzer stage (geometry shader parameters/inputs)
-	uint32 ringParameterCount;
-	uint32 ringParameterCountFromPrevStage; // used in geometry shader to hold VS ringParameterCount
+	uint32 ringParameterCount{ 0 };
+	uint32 ringParameterCountFromPrevStage{ 0 }; // used in geometry shader to hold VS ringParameterCount
 	// analyzer stage (misc)
 	std::bitset<LATTE_NUM_STREAMOUT_BUFFER> streamoutBufferWriteMask;
-	bool hasStreamoutBufferWrite;
+	bool hasStreamoutBufferWrite{ false };
 	// output code
-	class StringBuf* strBuf_shaderSource{nullptr};
+	class StringBuf* strBuf_shaderSource{ nullptr };
 	// separable shaders
-	RendererShader* shader;
-	bool isCustomShader;
+	RendererShader* shader{ nullptr };
+	bool isCustomShader{ false };
 
-	uint32 outputParameterMask;
+	uint32 outputParameterMask{ 0 };
 	// resource mapping (binding points)
-	LatteDecompilerShaderResourceMapping resourceMapping;
+	LatteDecompilerShaderResourceMapping resourceMapping{};
 	// uniforms
 	struct  
 	{
@@ -210,7 +210,7 @@ struct LatteDecompilerShader
 		sint32 loc_verticesPerInstance;
 		sint32 loc_streamoutBufferBase[LATTE_NUM_STREAMOUT_BUFFER];
 		sint32 uniformRangeSize; // entire size of uniform variable block
-	}uniform;
+	}uniform{ 0 };
 	// fast access
 	struct _RemappedUniformBufferGroup 
 	{

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
@@ -306,6 +306,11 @@ namespace LatteDecompiler
 		{
 			src->add("#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.z, 1.0/gl_FragCoord.w)" _CRLF);
 		}
+		if (decompilerContext->options->spirvInstrinsics.hasRoundingModeRTEFloat32)
+		{
+			src->add("#extension GL_EXT_spirv_intrinsics: enable" _CRLF);
+			src->add("spirv_execution_mode(4462, 32);" _CRLF); // RoundingModeRTE 32
+		}
 		src->add("#else" _CRLF);
 		// OpenGL defines
 		src->add("#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)" _CRLF);

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
@@ -309,7 +309,10 @@ namespace LatteDecompiler
 		if (decompilerContext->options->spirvInstrinsics.hasRoundingModeRTEFloat32)
 		{
 			src->add("#extension GL_EXT_spirv_intrinsics: enable" _CRLF);
-			src->add("spirv_execution_mode(4462, 32);" _CRLF); // RoundingModeRTE 32
+			// set RoundingModeRTE
+			src->add("spirv_execution_mode(4462, 16);" _CRLF);
+			src->add("spirv_execution_mode(4462, 32);" _CRLF);
+			src->add("spirv_execution_mode(4462, 64);" _CRLF);
 		}
 		src->add("#else" _CRLF);
 		// OpenGL defines

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
@@ -95,7 +95,7 @@ namespace LatteDecompiler
 		}
 		if (decompilerContext->analyzer.outputPointSize && decompilerContext->analyzer.writesPointSize == false)
 		{
-			if ((decompilerContext->shaderType == LatteConst::ShaderType::Vertex && !decompilerContext->usesGeometryShader) ||
+			if ((decompilerContext->shaderType == LatteConst::ShaderType::Vertex && !decompilerContext->options->usesGeometryShader) ||
 				decompilerContext->shaderType == LatteConst::ShaderType::Geometry)
 			{
 				uniformCurrentOffset = (uniformCurrentOffset + 3)&~3;
@@ -135,7 +135,7 @@ namespace LatteDecompiler
 		}
 		// define uf_verticesPerInstance + uf_streamoutBufferBaseX
 		if (decompilerContext->analyzer.useSSBOForStreamout &&
-			(shader->shaderType == LatteConst::ShaderType::Vertex && decompilerContext->usesGeometryShader == false) ||
+			(shader->shaderType == LatteConst::ShaderType::Vertex && decompilerContext->options->usesGeometryShader == false) ||
 			(shader->shaderType == LatteConst::ShaderType::Geometry) )
 		{
 			shaderSrc->add("uniform int uf_verticesPerInstance;" _CRLF);
@@ -298,7 +298,7 @@ namespace LatteDecompiler
 
 			if (decompilerContext->shaderType == LatteConst::ShaderType::Vertex || decompilerContext->shaderType == LatteConst::ShaderType::Geometry)
 			{
-				if (decompilerContext->usesGeometryShader)
+				if (decompilerContext->options->usesGeometryShader)
 					src->add("#define V2G_LAYOUT layout(location = 0)" _CRLF);
 			}
 		}
@@ -322,7 +322,7 @@ namespace LatteDecompiler
 				src->add("#define XFB_BLOCK_LAYOUT(__bufferIndex, __stride, __location) layout(xfb_buffer = __bufferIndex, xfb_stride = __stride)" _CRLF);
 
 			src->add("#define SET_POSITION(_v) gl_Position = _v\r\n");
-			if (decompilerContext->usesGeometryShader)
+			if (decompilerContext->options->usesGeometryShader)
 				src->add("#define V2G_LAYOUT" _CRLF);
 		}
 		else if (decompilerContext->shaderType == LatteConst::ShaderType::Pixel)
@@ -430,7 +430,7 @@ namespace LatteDecompiler
 	{
 		auto src = decompilerContext->shaderSource;
 		// per-vertex output (VS or GS)
-		if ((decompilerContext->shaderType == LatteConst::ShaderType::Vertex && decompilerContext->usesGeometryShader == false) ||
+		if ((decompilerContext->shaderType == LatteConst::ShaderType::Vertex && !decompilerContext->options->usesGeometryShader) ||
 			(decompilerContext->shaderType == LatteConst::ShaderType::Geometry))
 		{
 			src->add("out gl_PerVertex" _CRLF);
@@ -441,7 +441,7 @@ namespace LatteDecompiler
 			src->add("};" _CRLF);
 		}
 		// varyings (variables passed from vertex to pixel shader, only if geometry stage is disabled
-		if (decompilerContext->usesGeometryShader == false)
+		if (decompilerContext->options->usesGeometryShader == false)
 		{
 			if (decompilerContext->shaderType == LatteConst::ShaderType::Vertex)
 			{
@@ -537,7 +537,7 @@ namespace LatteDecompiler
 		// streamout buffer (transform feedback)
 		if ((decompilerContext->shaderType == LatteConst::ShaderType::Vertex || decompilerContext->shaderType == LatteConst::ShaderType::Geometry) && decompilerContext->analyzer.hasStreamoutEnable)
 		{
-			if (decompilerContext->useTFViaSSBO)
+			if (decompilerContext->options->useTFViaSSBO)
 			{
 				if (decompilerContext->analyzer.useSSBOForStreamout && decompilerContext->analyzer.hasStreamoutWrite)
 				{

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInternal.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInternal.h
@@ -70,8 +70,6 @@ struct LatteDecompilerTEXInstruction
 		uint8 nfa{};
 		uint8 isSigned{};
 	}memRead;
-	// custom shadow function
-	sint32 shadowFunctionIndex{};
 };
 
 struct LatteDecompilerCFInstruction
@@ -116,7 +114,7 @@ struct LatteDecompilerCFInstruction
 
 	~LatteDecompilerCFInstruction()
 	{
-		cemu_assert_debug(!(instructionsALU.size() != 0 && instructionsTEX.size() != 0)); // make sure we dont accidentally added the wrong instruction type
+		cemu_assert_debug(!(instructionsALU.size() != 0 && instructionsTEX.size() != 0)); // make sure we haven't accidentally added the wrong instruction type
 	}
 
 #if BOOST_OS_WINDOWS
@@ -148,6 +146,7 @@ struct LatteDecompilerShaderContext
 	LatteDecompilerOutput_t* output;
 	LatteDecompilerShader* shader;
 	LatteConst::ShaderType shaderType;
+	const class LatteDecompilerOptions* options;
 	uint32* contextRegisters; // deprecated
 	struct LatteContextRegister* contextRegistersNew;
 	uint64 shaderBaseHash;
@@ -217,10 +216,9 @@ struct LatteDecompilerShaderContext
 	bool hasUniformVarBlock;
 	sint32 currentBindingPointVK{};
 
-	// unsorted
+	// misc
 	bool usesGeometryShader; // for VS
 	bool useTFViaSSBO;
-	sint32 currentShadowFunctionIndex;
 	std::vector<LatteDecompilerSubroutineInfo> list_subroutines;
 };
 

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInternal.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInternal.h
@@ -150,11 +150,10 @@ struct LatteDecompilerShaderContext
 	uint32* contextRegisters; // deprecated
 	struct LatteContextRegister* contextRegistersNew;
 	uint64 shaderBaseHash;
-	StringBuf* shaderSource; // move to output struct
+	StringBuf* shaderSource;
 	std::vector<LatteDecompilerCFInstruction> cfInstructions;
 	// fetch shader (required for vertex shader)
-	LatteFetchShader* fetchShaderList[32];
-	sint32 fetchShaderCount;
+	LatteFetchShader* fetchShader{};
 	// geometry copy shader (only present when geometry shader is active)
 	LatteParsedGSCopyShader* parsedGSCopyShader;
 	// state
@@ -217,8 +216,6 @@ struct LatteDecompilerShaderContext
 	sint32 currentBindingPointVK{};
 
 	// misc
-	bool usesGeometryShader; // for VS
-	bool useTFViaSSBO;
 	std::vector<LatteDecompilerSubroutineInfo> list_subroutines;
 };
 

--- a/src/Cafe/HW/Latte/Renderer/RendererShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererShader.cpp
@@ -17,7 +17,7 @@ uint32 RendererShader::GeneratePrecompiledCacheId()
 	v += (EMULATOR_VERSION_MINOR * 100u);
 
 	// settings that can influence shaders
-	v += (uint32)g_current_game_profile->GetAccurateShaderMul() * 133; // this option modifies shaders
+	v += (uint32)g_current_game_profile->GetAccurateShaderMul() * 133;
 
 	return v;
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -9,11 +9,6 @@
 #include <glslang/Public/ShaderLang.h>
 #include <glslang/SPIRV/GlslangToSpv.h>
 
-// required for modifying SPIR-V
-#include <glslang/SPIRV/SpvBuilder.h>
-
-
-
 bool s_isLoadingShadersVk{ false };
 class FileCache* s_spirvCache{nullptr};
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -1,16 +1,18 @@
 #include "Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.h"
+#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
+#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h"
+#include "config/ActiveSettings.h"
+#include "config/CemuConfig.h"
+#include "util/helpers/ConcurrentQueue.h"
+#include "Cemu/FileCache/FileCache.h"
 
 #include <glslang/Public/ShaderLang.h>
 #include <glslang/SPIRV/GlslangToSpv.h>
 
-#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
-#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h"
+// required for modifying SPIR-V
+#include <glslang/SPIRV/SpvBuilder.h>
 
-#include "config/ActiveSettings.h"
-#include "config/CemuConfig.h"
-#include "util/helpers/ConcurrentQueue.h"
 
-#include "Cemu/FileCache/FileCache.h"
 
 bool s_isLoadingShadersVk{ false };
 class FileCache* s_spirvCache{nullptr};

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -463,7 +463,13 @@ private:
 			bool external_memory_host = false; // VK_EXT_external_memory_host
 			bool synchronization2 = false; // VK_KHR_synchronization2
 			bool dynamic_rendering = false; // VK_KHR_dynamic_rendering
+			bool shader_float_controls = false; // VK_KHR_shader_float_controls
 		}deviceExtensions;
+
+		struct
+		{
+			bool shaderRoundingModeRTEFloat32{ false };
+		}shaderFloatControls; // from VK_KHR_shader_float_controls
 
 		struct  
 		{
@@ -482,8 +488,8 @@ private:
 			uint32 nonCoherentAtomSize = 256;
 		}limits;
 
-		bool debugMarkersSupported = false; // frame debugger is attached
-		bool disableMultithreadedCompilation = false; // for old nvidia drivers
+		bool debugMarkersSupported{ false }; // frame debugger is attached
+		bool disableMultithreadedCompilation{ false }; // for old nvidia drivers
 
 	}m_featureControl{};
 	static bool CheckDeviceExtensionSupport(const VkPhysicalDevice device, FeatureControl& info);
@@ -936,12 +942,10 @@ private:
 
 
 public:
-	bool GetDisableMultithreadedCompilation() { return m_featureControl.disableMultithreadedCompilation; }
-	bool useTFViaSSBO() { return m_featureControl.mode.useTFEmulationViaSSBO; }
-	bool IsDebugUtilsEnabled() const
-	{
-		return m_featureControl.debugMarkersSupported && m_featureControl.instanceExtensions.debug_utils;
-	}
+	bool GetDisableMultithreadedCompilation() const { return m_featureControl.disableMultithreadedCompilation; }
+	bool UseTFViaSSBO() const { return m_featureControl.mode.useTFEmulationViaSSBO; }
+	bool HasSPRIVRoundingModeRTE32() const { return m_featureControl.shaderFloatControls.shaderRoundingModeRTEFloat32; }
+	bool IsDebugUtilsEnabled() const { return m_featureControl.debugMarkersSupported && m_featureControl.instanceExtensions.debug_utils; }
 
 private:
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -1579,7 +1579,7 @@ void VulkanRenderer::draw_updateVertexBuffersDirectAccess()
 
 		if (bufferAddress == MPTR_NULL)
 		{
-			cemu_assert_unimplemented();
+			bufferAddress = 0x10000000;
 		}
 		if (m_state.currentVertexBinding[bufferIndex].offset == bufferAddress)
 			continue;

--- a/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp
+++ b/src/gui/windows/TextureRelationViewer/TextureRelationWindow.cpp
@@ -228,7 +228,7 @@ void TextureRelationViewerWindow::_setTextureRelationListItemTexture(wxListCtrl*
 	uiList->SetItem(rowIndex, columnIndex, tempStr);
 	columnIndex++;
 	// tilemode
-	sprintf(tempStr, "%d", texInfo->tileMode);
+	sprintf(tempStr, "%d", (int)texInfo->tileMode);
 	uiList->SetItem(rowIndex, columnIndex, tempStr);
 	columnIndex++;
 	// sliceRange


### PR DESCRIPTION
`VK_KHR_SHADER_FLOAT_CONTROLS` lets us set rounding behavior for floating point math in shaders to `round-to-even` instead of truncate rounding, which more closely matches console behavior. If the extension is not supported then Cemu will fall back to default rounding.

This is a bit of a risky change since it subtly affects *all* shaders and may break things in unexpected places. For this reason I'll leave this up for a bit before merging. Testing is appreciated! But make sure to clear the shader cache first.

I'm still doing some testing myself but so far one known effect is that it fixes mobs in Minecraft having misplaced body parts:
![image](https://user-images.githubusercontent.com/13877693/222475961-f8a4e50d-91bf-48b7-97a5-3f02af7c600e.png)
