### PR TITLE
Revert "Force async compile off for macos (#532)"

### DIFF
--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1447,12 +1447,7 @@ void GeneralSettings2::HandleGraphicsApiSelection()
 	{
 		// Vulkan
 		m_gx2drawdone_sync->Disable();
-#if BOOST_OS_MACOS
-		m_async_compile->Disable();
-		m_async_compile->SetValue(false);
-#else
 		m_async_compile->Enable();
-#endif
 
 		m_vsync->AppendString(_("Off"));
 		m_vsync->AppendString(_("Double buffering"));


### PR DESCRIPTION
VK_EXT_pipeline_creation_cache_control was [added](https://github.com/KhronosGroup/MoltenVK/pull/1847) into MoltenVK, which allows us to enable async shader compile in macOS.

Now only waiting on a new release of MoltenVK.