### PR TITLE
Latte optimizations and tweaks

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteOverlay.cpp
@@ -26,6 +26,7 @@ struct OverlayStats
 
 	double fps{};
 	uint32 draw_calls_per_frame{};
+	uint32 fast_draw_calls_per_frame{};
 	float cpu_usage{}; // cemu cpu usage in %
 	std::vector<float> cpu_per_core; // global cpu usage in % per core
 	uint32 ram_usage{}; // ram usage in MB
@@ -86,7 +87,7 @@ void LatteOverlay_renderOverlay(ImVec2& position, ImVec2& pivot, sint32 directio
 				ImGui::Text("FPS: %.2lf", g_state.fps);
 
 			if (config.overlay.drawcalls)
-				ImGui::Text("Draws/f: %d", g_state.draw_calls_per_frame);
+				ImGui::Text("Draws/f: %d (fast: %d)", g_state.draw_calls_per_frame, g_state.fast_draw_calls_per_frame);
 
 			if (config.overlay.cpu_usage)
 				ImGui::Text("CPU: %.2lf%%", g_state.cpu_usage);
@@ -588,13 +589,14 @@ static void UpdateStats_CpuPerCore()
 	}
 }
 
-void LatteOverlay_updateStats(double fps, sint32 drawcalls)
+void LatteOverlay_updateStats(double fps, sint32 drawcalls, sint32 fastDrawcalls)
 {
 	if (GetConfig().overlay.position == ScreenPosition::kDisabled)
 		return;
 
 	g_state.fps = fps;
 	g_state.draw_calls_per_frame = drawcalls;
+	g_state.fast_draw_calls_per_frame = fastDrawcalls;
 	UpdateStats_CemuCpu();
 	UpdateStats_CpuPerCore();
 

--- a/src/Cafe/HW/Latte/Core/LatteOverlay.h
+++ b/src/Cafe/HW/Latte/Core/LatteOverlay.h
@@ -2,6 +2,6 @@
 
 void LatteOverlay_init();
 void LatteOverlay_render(bool pad_view);
-void LatteOverlay_updateStats(double fps, sint32 drawcalls);
+void LatteOverlay_updateStats(double fps, sint32 drawcalls, sint32 fastDrawcalls);
 
 void LatteOverlay_pushNotification(const std::string& text, sint32 duration);

--- a/src/Cafe/HW/Latte/Core/LattePerformanceMonitor.cpp
+++ b/src/Cafe/HW/Latte/Core/LattePerformanceMonitor.cpp
@@ -38,6 +38,7 @@ void LattePerformanceMonitor_frameEnd()
 		uint64 indexDataCached = 0;
 		uint32 frameCounter = 0;
 		uint32 drawCallCounter = 0;
+		uint32 fastDrawCallCounter = 0;
 		uint32 shaderBindCounter = 0;
 		uint32 recompilerLeaveCount = 0;
 		uint32 threadLeaveCount = 0;
@@ -53,6 +54,7 @@ void LattePerformanceMonitor_frameEnd()
 			indexDataCached += performanceMonitor.cycle[i].indexDataCached;
 			frameCounter += performanceMonitor.cycle[i].frameCounter;
 			drawCallCounter += performanceMonitor.cycle[i].drawCallCounter;
+			fastDrawCallCounter += performanceMonitor.cycle[i].fastDrawCallCounter;
 			shaderBindCounter += performanceMonitor.cycle[i].shaderBindCount;
 			recompilerLeaveCount += performanceMonitor.cycle[i].recompilerLeaveCount;
 			threadLeaveCount += performanceMonitor.cycle[i].threadLeaveCount;
@@ -75,7 +77,6 @@ void LattePerformanceMonitor_frameEnd()
 		indexDataUploadPerFrame /= 1024ULL;
 
 		double fps = (double)elapsedFrames2S * 1000.0 / (double)totalElapsedTimeFPS;
-		uint32 drawCallsPerFrame = drawCallCounter / elapsedFrames;
 		uint32 shaderBindsPerFrame = shaderBindCounter / elapsedFrames;
 		passedCycles = passedCycles * 1000ULL / totalElapsedTime;
 		uint32 rlps = (uint32)((uint64)recompilerLeaveCount * 1000ULL / (uint64)totalElapsedTime);
@@ -85,6 +86,7 @@ void LattePerformanceMonitor_frameEnd()
 		// next counter cycle
 		sint32 nextCycleIndex = (performanceMonitor.cycleIndex + 1) % PERFORMANCE_MONITOR_TRACK_CYCLES;
 		performanceMonitor.cycle[nextCycleIndex].drawCallCounter = 0;
+		performanceMonitor.cycle[nextCycleIndex].fastDrawCallCounter = 0;
 		performanceMonitor.cycle[nextCycleIndex].frameCounter = 0;
 		performanceMonitor.cycle[nextCycleIndex].shaderBindCount = 0;
 		performanceMonitor.cycle[nextCycleIndex].lastCycleCount = PPCInterpreter_getMainCoreCycleCounter();
@@ -104,12 +106,12 @@ void LattePerformanceMonitor_frameEnd()
 
 		if (isFirstUpdate)
 		{
-			LatteOverlay_updateStats(0.0, 0);
+			LatteOverlay_updateStats(0.0, 0, 0);
 			gui_updateWindowTitles(false, false, 0.0);
 		}
 		else
 		{
-			LatteOverlay_updateStats(fps, drawCallCounter / elapsedFrames);
+			LatteOverlay_updateStats(fps, drawCallCounter / elapsedFrames, fastDrawCallCounter / elapsedFrames);
 			gui_updateWindowTitles(false, false, fps);
 		}
 	}

--- a/src/Cafe/HW/Latte/Core/LattePerformanceMonitor.h
+++ b/src/Cafe/HW/Latte/Core/LattePerformanceMonitor.h
@@ -84,6 +84,7 @@ typedef struct
 		uint32 lastUpdate;
 		uint32 frameCounter;
 		uint32 drawCallCounter;
+		uint32 fastDrawCallCounter;
 		uint32 shaderBindCount;
 		uint64 vertexDataUploaded; // amount of vertex data uploaded to GPU (bytes)
 		uint64 vertexDataCached; // amount of vertex data reused from GPU cache (bytes)

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -295,6 +295,15 @@ LatteTextureView* LatteMRT::GetColorAttachmentTexture(uint32 index, bool createN
 	uint32 colorBufferHeight = pitchHeight / colorBufferPitch;
 	uint32 colorBufferWidth = colorBufferPitch;
 
+	// colorbuffer width/height has to be padded to 8/32 but the actual resolution might be smaller
+	// use the scissor box as a clue to figure out the original resolution if possible
+	uint32 scissorBoxWidth = LatteGPUState.contextNew.PA_SC_GENERIC_SCISSOR_BR.get_BR_X();
+	uint32 scissorBoxHeight = LatteGPUState.contextNew.PA_SC_GENERIC_SCISSOR_BR.get_BR_Y();
+	if (((scissorBoxWidth + 7) & ~7) == colorBufferWidth)
+		colorBufferWidth = scissorBoxWidth;
+	if (((colorBufferHeight + 31) & ~31) == colorBufferHeight)
+		colorBufferHeight = scissorBoxHeight;
+
 	bool colorBufferWasFound = false;
 	sint32 viewFirstMip = 0; // todo
 

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -295,14 +295,33 @@ LatteTextureView* LatteMRT::GetColorAttachmentTexture(uint32 index, bool createN
 	uint32 colorBufferHeight = pitchHeight / colorBufferPitch;
 	uint32 colorBufferWidth = colorBufferPitch;
 
-	// colorbuffer width/height has to be padded to 8/32 but the actual resolution might be smaller
+	// colorbuffer width/height has to be padded to 8/32 alignment but the actual resolution might be smaller
 	// use the scissor box as a clue to figure out the original resolution if possible
+#if 0
 	uint32 scissorBoxWidth = LatteGPUState.contextNew.PA_SC_GENERIC_SCISSOR_BR.get_BR_X();
 	uint32 scissorBoxHeight = LatteGPUState.contextNew.PA_SC_GENERIC_SCISSOR_BR.get_BR_Y();
 	if (((scissorBoxWidth + 7) & ~7) == colorBufferWidth)
 		colorBufferWidth = scissorBoxWidth;
 	if (((colorBufferHeight + 31) & ~31) == colorBufferHeight)
 		colorBufferHeight = scissorBoxHeight;
+#endif
+
+	// log resolution changes if the above heuristic takes effect
+	// this is useful to find resolutions which need to be updated in gfx pack texture rules
+#if 0
+	uint32 colorBufferHeight2 = pitchHeight / colorBufferPitch;
+	static std::unordered_set<uint64> s_foundColorBufferResMappings;
+	if (colorBufferPitch != colorBufferWidth || colorBufferHeight != colorBufferHeight2)
+	{
+		// only log unique, source and dest resolution. Encode into a key with 16 bits per component
+		uint64 resHash = (uint64)colorBufferWidth | ((uint64)colorBufferHeight << 16) | ((uint64)colorBufferPitch << 32) | ((uint64)colorBufferHeight2 << 48);
+		if( !s_foundColorBufferResMappings.contains(resHash) )
+		{
+			s_foundColorBufferResMappings.insert(resHash);
+			cemuLog_log(LogType::Force, "[COLORBUFFER-DBG] Using res {}x{} instead of {}x{}", colorBufferWidth, colorBufferHeight, colorBufferPitch, colorBufferHeight2);
+		}
+	}
+#endif
 
 	bool colorBufferWasFound = false;
 	sint32 viewFirstMip = 0; // todo

--- a/src/Cafe/HW/Latte/Core/LatteTextureReadbackInfo.h
+++ b/src/Cafe/HW/Latte/Core/LatteTextureReadbackInfo.h
@@ -21,6 +21,7 @@ public:
 
 	HRTick transferStartTime;
 	HRTick waitStartTime;
+	bool forceFinish{ false }; // set to true if not finished in time for dependent operation
 	// texture info
 	LatteTextureDefinition hostTextureCopy{};
 

--- a/src/Cafe/HW/Latte/ISA/LatteReg.h
+++ b/src/Cafe/HW/Latte/ISA/LatteReg.h
@@ -484,7 +484,7 @@ namespace Latte
 		SQ_TEX_RESOURCE_WORD0_N_GS			= 0xE930,
 		SQ_TEX_RESOURCE_WORD_FIRST			= SQ_TEX_RESOURCE_WORD0_N_PS,
 		SQ_TEX_RESOURCE_WORD_LAST			= (SQ_TEX_RESOURCE_WORD0_N_GS + GPU_LIMITS::NUM_TEXTURES_PER_STAGE * 7 - 1),
-		// there are 54 samplers with 3 registers each. 18 per stage. For stage indices see SAMPLER_BASE_INDEX_*
+		// there are 54 samplers with 3 registers each. 18 (actually only 16?) per stage. For stage indices see SAMPLER_BASE_INDEX_*
 		SQ_TEX_SAMPLER_WORD0_0				= 0xF000,
 		SQ_TEX_SAMPLER_WORD1_0				= 0xF001,
 		SQ_TEX_SAMPLER_WORD2_0				= 0xF002,

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2002,7 +2002,7 @@ void VulkanRenderer::SubmitCommandBuffer(VkSemaphore signalSemaphore, VkSemaphor
 	occlusionQuery_notifyBeginCommandBuffer();
 
 	m_recordedDrawcalls = 0;
-	m_submitThreshold = 500; // this used to be 750 before 1.25.5, but more frequent submission is actually better for latency
+	m_submitThreshold = 300;
 	m_submitOnIdle = false;
 }
 


### PR DESCRIPTION
Changes:
- Reworked "fast drawing" logic. Fast draws are a special mode where the renderer can skip some of the more expensive per-drawcall checks if only a subset of states was changed. With this PR more drawcalls now qualify for the fast mode, reducing overall CPU load on the GPU emulation thread.
- Lowered amount of drawcalls that need to accumulate before LatteVk flushes the command buffer. Should decrease latency for texture readbacks.
- Use heuristic to determine the real resolution of colorbuffers. In cases where the aligned colorbuffer resolution mismatches the texture resolution (e.g. 1920x1088 vs 1920x1080) it is necessary to allocate and synchronize two textures. If we can guess the real colorbuffer resolution correctly we can avoid all the overhead of double textures, lowering VRAM requirements and texture synchronization overhead. Fixes #380