### PR TITLE
Disable the "Disable screen saver" option in MacOS

### DIFF
--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -178,6 +178,10 @@ wxPanel* GeneralSettings2::AddGeneralPage(wxNotebook* notebook)
 			m_disable_screensaver = new wxCheckBox(box, wxID_ANY, _("Disable screen saver"));
 			m_disable_screensaver->SetToolTip(_("Prevents the system from activating the screen saver or going to sleep while running a game."));
 			second_row->Add(m_disable_screensaver, 0, botflag, 5);
+#ifdef BOOST_OS_MACOS
+			m_disable_screensaver->SetValue(false);
+			m_disable_screensaver->Enable(false);
+#endif
 
 			box_sizer->Add(second_row, 0, wxEXPAND, 5);
 		}

--- a/src/util/ScreenSaver/ScreenSaver.h
+++ b/src/util/ScreenSaver/ScreenSaver.h
@@ -6,6 +6,9 @@ class ScreenSaver
 public:
   static void SetInhibit(bool inhibit)
   {
+#ifdef BOOST_OS_MACOS
+	  return;
+#endif
     // Initialize video subsystem if necessary
     if (SDL_WasInit(SDL_INIT_VIDEO) == 0)
     {


### PR DESCRIPTION
This option, when enabled, causes a crash in MacOS. SDL_DisableScreenSaver() requires the SDL_Video subsystem to be initialized to function properly. This causes the SDL_Events subsystem to also initialize and cause a crash elsewhere.

This PR simply disables the option box and causes the SetInhibit() function to return early.