### PR TITLE
Fix GamePad window when using vulkan with wayland

### DIFF
--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -14,20 +14,15 @@ VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_wi
 	Bind(wxEVT_PAINT, &VulkanCanvas::OnPaint, this);
 	Bind(wxEVT_SIZE, &VulkanCanvas::OnResize, this);
 
-	if(is_main_window)
+	WindowHandleInfo& canvas = is_main_window ? gui_getWindowInfo().canvas_main : gui_getWindowInfo().canvas_pad;
+	gui_initHandleContextFromWxWidgetsWindow(canvas, this);
+	#if BOOST_OS_LINUX && HAS_WAYLAND
+	if (canvas.backend == WindowHandleInfo::Backend::WAYLAND)
 	{
-		WindowHandleInfo& canvasMain = gui_getWindowInfo().canvas_main;
-		gui_initHandleContextFromWxWidgetsWindow(canvasMain, this);
-		#if BOOST_OS_LINUX && HAS_WAYLAND
-		if(canvasMain.backend == WindowHandleInfo::Backend::WAYLAND)
-		{	
-			m_subsurface = std::make_unique<wxWlSubsurface>(this);
-			canvasMain.surface = m_subsurface->getSurface();
-		}
-		#endif
+		m_subsurface = std::make_unique<wxWlSubsurface>(this);
+		canvas.surface = m_subsurface->getSurface();
 	}
-	else
-		gui_initHandleContextFromWxWidgetsWindow(gui_getWindowInfo().canvas_pad, this);
+	#endif
 
 	cemu_assert(g_vulkan_available);
 


### PR DESCRIPTION
Use the same wayland subsurface mechanism for the GamePad window as the main window. 
Fixes this bug:

| before | after |
| - | - |
| ![Screencast from 2023-03-22 00-54-04.webm](https://user-images.githubusercontent.com/334272/226774659-075da073-f69b-44cc-b7a6-5af5b0427f21.webm) ![cemu_gamepad_before_b](https://user-images.githubusercontent.com/334272/228325688-f4481422-2e32-4a1b-b017-cdcb952a5f9a.png) ![cemu_gamepad_before_a](https://user-images.githubusercontent.com/334272/228325705-9334047c-7cd7-4b47-ab1a-ccd6ad889202.png) | ![cemu_gamepad_after](https://user-images.githubusercontent.com/334272/228325729-d4734b77-fc18-4169-a31a-2cc8ffc78238.png) |

The window decoration is shown for a single frame whenever the FPS counter is updated
