### PR TITLE
Wayland: Set app_id for icon in kde

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -69,6 +69,8 @@ add_library(CemuGui
   helpers/wxHelpers.cpp
   helpers/wxHelpers.h
   helpers/wxLogEvent.h
+  helpers/wxWayland.cpp
+  helpers/wxWayland.h
   input/InputAPIAddWindow.cpp
   input/InputAPIAddWindow.h
   input/InputSettings2.cpp

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -12,6 +12,10 @@
 #include "gui/helpers/wxHelpers.h"
 #include "Cemu/ncrypto/ncrypto.h"
 
+#if BOOST_OS_LINUX && HAS_WAYLAND
+#include "gui/helpers/wxWayland.h"
+#endif
+
 #include <wx/image.h>
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
@@ -175,6 +179,11 @@ bool CemuApp::OnInit()
 
 	SetTopWindow(m_mainFrame);
 	m_mainFrame->Show();
+
+#if BOOST_OS_LINUX && HAS_WAYLAND
+	if (wxWlIsWaylandWindow(m_mainFrame))
+		wxWlSetAppId(m_mainFrame, "info.cemu.Cemu");
+#endif
 
 	// show warning on macOS about state of builds
 #if BOOST_OS_MACOS

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -57,6 +57,10 @@
 #include "resource/embedded/resources.h"
 #endif
 
+#if BOOST_OS_LINUX && HAS_WAYLAND
+#include "gui/helpers/wxWayland.h"
+#endif
+
 #include "Cafe/TitleList/TitleInfo.h"
 #include "Cafe/TitleList/TitleList.h"
 #include "wxHelper.h"
@@ -753,6 +757,12 @@ void MainWindow::TogglePadView()
 		m_padView->Bind(wxEVT_CLOSE_WINDOW, &MainWindow::OnPadClose, this);
 
 		m_padView->Show(true);
+
+#if BOOST_OS_LINUX && HAS_WAYLAND
+		if (wxWlIsWaylandWindow(m_padView))
+			wxWlSetAppId(m_padView, "info.cemu.Cemu");
+#endif
+
 		m_padView->Initialize();
 		if (m_game_launched)
 			m_padView->InitializeRenderCanvas();

--- a/src/gui/helpers/wxWayland.cpp
+++ b/src/gui/helpers/wxWayland.cpp
@@ -1,0 +1,24 @@
+#include "gui/helpers/wxWayland.h"
+
+#if BOOST_OS_LINUX && HAS_WAYLAND
+
+#include <dlfcn.h>
+
+bool wxWlIsWaylandWindow(wxWindow* window)
+{
+	GtkWidget* gtkWindow = static_cast<GtkWidget*>(window->GetHandle());
+	GdkWindow* gdkWindow = gtk_widget_get_window(gtkWindow);
+	return GDK_IS_WAYLAND_WINDOW(gdkWindow);
+}
+
+void wxWlSetAppId(wxFrame* frame, const char* applicationId)
+{
+	GtkWidget* gtkWindow = static_cast<GtkWidget*>(frame->GetHandle());
+	gtk_widget_realize(gtkWindow);
+	GdkWindow* gdkWindow = gtk_widget_get_window(gtkWindow);
+	static auto gdk_wl_set_app_id = reinterpret_cast<void (*) (GdkWindow*, const char*)>(dlsym(nullptr, "gdk_wayland_window_set_application_id"));
+	if (gdk_wl_set_app_id)
+		gdk_wl_set_app_id(gdkWindow, application_id);
+}
+
+#endif	// BOOST_OS_LINUX && HAS_WAYLAND

--- a/src/gui/helpers/wxWayland.cpp
+++ b/src/gui/helpers/wxWayland.cpp
@@ -18,7 +18,7 @@ void wxWlSetAppId(wxFrame* frame, const char* applicationId)
 	GdkWindow* gdkWindow = gtk_widget_get_window(gtkWindow);
 	static auto gdk_wl_set_app_id = reinterpret_cast<void (*) (GdkWindow*, const char*)>(dlsym(nullptr, "gdk_wayland_window_set_application_id"));
 	if (gdk_wl_set_app_id)
-		gdk_wl_set_app_id(gdkWindow, application_id);
+		gdk_wl_set_app_id(gdkWindow, applicationId);
 }
 
 #endif	// BOOST_OS_LINUX && HAS_WAYLAND

--- a/src/gui/helpers/wxWayland.h
+++ b/src/gui/helpers/wxWayland.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if BOOST_OS_LINUX
+#if BOOST_OS_LINUX && HAS_WAYLAND
 
 #include <gdk/gdk.h>
 #include <gdk/gdkwayland.h>
@@ -27,7 +27,7 @@ class wxWlSubsurface
 	int32_t m_xPos = 0;
 	int32_t m_yPos = 0;
 
-   public:
+public:
 	wxWlSubsurface(wxWindow* window)
 	{
 		GtkWidget* widget = static_cast<GtkWidget*>(window->GetHandle());
@@ -72,4 +72,7 @@ class wxWlSubsurface
 	}
 };
 
-#endif	// BOOST_OS_LINUX
+bool wxWlIsWaylandWindow(wxWindow* window);
+void wxWlSetAppId(wxFrame* frame, const char* application_id);
+
+#endif	// BOOST_OS_LINUX && HAS_WAYLAND


### PR DESCRIPTION
KDE requires [set_app_id](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id) to be called to display the app icon.
I don't know if there's a way to set this value in wxWidgets, in Gtk it's for each window by the [GtkApplication](https://docs.gtk.org/gio/property.Application.application-id.html)
This hack set's it directly for a Gtk window.


![cemu_kde](https://user-images.githubusercontent.com/334272/228243011-09b98abd-0a4b-4c8c-ae5d-f884f40fab8d.png)
![Screenshot from 2023-03-28 16-28-27](https://user-images.githubusercontent.com/334272/228288925-33865a83-88ca-4ff3-8a5c-bceca6316388.png)

Currently it's only applied to the main window and the GamePad window but ideally it would run after `Show` for each toplevel window (`wxFrame`).

The `gdk_wayland_window_set_application_id` function was added in gtk `3.24.22`. Ubuntu 20.04 LTS supports `3.24.18` and with updates `3.24.20`. Therefore the function call will be dynamic.