### PR TITLE
use "if" macro instead of "ifdef"

### DIFF
--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -178,7 +178,7 @@ wxPanel* GeneralSettings2::AddGeneralPage(wxNotebook* notebook)
 			m_disable_screensaver = new wxCheckBox(box, wxID_ANY, _("Disable screen saver"));
 			m_disable_screensaver->SetToolTip(_("Prevents the system from activating the screen saver or going to sleep while running a game."));
 			second_row->Add(m_disable_screensaver, 0, botflag, 5);
-#ifdef BOOST_OS_MACOS
+#if BOOST_OS_MACOS
 			m_disable_screensaver->SetValue(false);
 			m_disable_screensaver->Enable(false);
 #endif

--- a/src/util/ScreenSaver/ScreenSaver.h
+++ b/src/util/ScreenSaver/ScreenSaver.h
@@ -6,7 +6,7 @@ class ScreenSaver
 public:
   static void SetInhibit(bool inhibit)
   {
-#ifdef BOOST_OS_MACOS
+#if BOOST_OS_MACOS
 	  return;
 #endif
     // Initialize video subsystem if necessary


### PR DESCRIPTION
Fixes https://github.com/cemu-project/Cemu/issues/726

BOOST_OS_MACOS is defined on other platforms, but is only true when on building MacOS.

The workaround ended up affecting all platforms