### PR TITLE
update homebrew in MacOS build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,9 @@ jobs:
         
     - name: "Install system dependencies"
       run: |
-        brew install llvm ninja nasm molten-vk
+        brew update
+        brew install llvm@15 ninja nasm molten-vk
+
     - name: "Bootstrap vcpkg"
       run: |
         bash ./dependencies/vcpkg/bootstrap-vcpkg.sh
@@ -255,8 +257,8 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
         -DPORTABLE=OFF \
         -DMACOS_BUNDLE=ON \
-        -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
-        -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
+        -DCMAKE_C_COMPILER=/usr/local/opt/llvm@15/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@15/bin/clang++ \
         -G Ninja
         
     - name: "Build Cemu"


### PR DESCRIPTION
Used to get the latest version of packages. Mainly used to get the latest MoltenVK dylib

use llvm@15, llvm@16 has a compatibility issue with boost

Fixes #730 