### PR TITLE
metainfo.xml: respect AppStream version format

### DIFF
--- a/dist/linux/info.cemu.Cemu.metainfo.xml
+++ b/dist/linux/info.cemu.Cemu.metainfo.xml
@@ -52,7 +52,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="v2.0" date="2022-08-22" type="stable">
+    <release version="2.0" date="2022-08-22" type="stable">
       <url>https://github.com/cemu-project/Cemu/releases/tag/v2.0</url>
     </release>
   </releases>


### PR DESCRIPTION
Since metainfo.xml is meant to be an AppStream file, we should follow its format recommendations. Specifically:

> A version number should always start with a number. Do not start version numbers with a letter or make them consist entirely of letters, e.g. BETA is not a version number. 

https://www.freedesktop.org/software/appstream/docs/chap-AppStream-Misc.html#spec-vercmp-recommendations