### PR TITLE
Use system GTK3 instead of vcpkg port

### DIFF
--- a/dependencies/vcpkg_overlay_ports/wxwidgets/example/CMakeLists.txt
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/example/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(wxwidgets-example)
+
+add_executable(main WIN32 popup.cpp)
+
+find_package(wxWidgets REQUIRED)
+target_compile_definitions(main PRIVATE ${wxWidgets_DEFINITIONS} "$<$<CONFIG:DEBUG>:${wxWidgets_DEFINITIONS_DEBUG}>")
+target_include_directories(main PRIVATE ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(main PRIVATE ${wxWidgets_LIBRARIES})
+
+add_executable(main2 WIN32 popup.cpp)
+
+find_package(wxWidgets CONFIG REQUIRED)
+target_link_libraries(main2 PRIVATE wx::core wx::base)
+
+option(USE_WXRC "Use the wxrc resource compiler" ON)
+if(USE_WXRC)
+    execute_process(
+        COMMAND "${wxWidgets_wxrc_EXECUTABLE}" --help
+        RESULTS_VARIABLE error_result
+    )
+    if(error_result)
+        message(FATAL_ERROR "Failed to run wxWidgets_wxrc_EXECUTABLE (${wxWidgets_wxrc_EXECUTABLE})")
+    endif()
+endif()
+
+set(PRINT_VARS "" CACHE STRING "Variables to print at the end of configuration")
+foreach(var IN LISTS PRINT_VARS)
+    message(STATUS "${var}:=${${var}}")
+endforeach()

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/fix-libs-export.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/fix-libs-export.patch
@@ -1,0 +1,21 @@
+diff --git a/build/cmake/config.cmake b/build/cmake/config.cmake
+index b359560..7504458 100644
+--- a/build/cmake/config.cmake
++++ b/build/cmake/config.cmake
+@@ -39,8 +39,14 @@ macro(wx_get_dependencies var lib)
+             else()
+                 # For the value like $<$<CONFIG:DEBUG>:LIB_PATH>
+                 # Or $<$<NOT:$<CONFIG:DEBUG>>:LIB_PATH>
+-                string(REGEX REPLACE "^.+>:(.+)>$" "\\1" dep_name ${dep})
+-                if (NOT dep_name)
++                if(dep MATCHES "^(.+>):(.+)>$")
++                    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_MATCH_1 STREQUAL [[$<$<NOT:$<CONFIG:DEBUG>>]])
++                        continue()
++                    elseif(CMAKE_BUILD_TYPE STREQUAL "Release" AND CMAKE_MATCH_1 STREQUAL [[$<$<CONFIG:DEBUG>]])
++                        continue()
++                    endif()
++                    set(dep_name "${CMAKE_MATCH_2}")
++                else()
+                     set(dep_name ${dep})
+                 endif()
+             endif()

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/fix-pcre2.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/fix-pcre2.patch
@@ -1,0 +1,23 @@
+diff --git a/build/cmake/modules/FindPCRE2.cmake b/build/cmake/modules/FindPCRE2.cmake
+index a27693a..455675a 100644
+--- a/build/cmake/modules/FindPCRE2.cmake
++++ b/build/cmake/modules/FindPCRE2.cmake
+@@ -24,7 +24,10 @@ set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
+ 
+ find_package(PkgConfig QUIET)
+ pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
++set(PCRE2_LIBRARIES ${PC_PCRE2_LINK_LIBRARIES})
++set(PCRE2_INCLUDE_DIRS ${PC_PCRE2_INCLUDE_DIRS})
+ 
++if (0)
+ find_path(PCRE2_INCLUDE_DIRS
+     NAMES pcre2.h
+     HINTS ${PC_PCRE2_INCLUDEDIR}
+@@ -36,6 +39,7 @@ find_library(PCRE2_LIBRARIES
+     HINTS ${PC_PCRE2_LIBDIR}
+           ${PC_PCRE2_LIBRARY_DIRS}
+ )
++endif()
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 REQUIRED_VARS PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS VERSION_VAR PC_PCRE2_VERSION)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/fix_include.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/fix_include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stc/scintilla/include/Scintilla.h b/src/stc/scintilla/include/Scintilla.h
+index 8c57520e1..54ffb27d2 100644
+--- a/src/stc/scintilla/include/Scintilla.h	
++++ b/src/stc/scintilla/include/Scintilla.h
+@@ -27,7 +27,7 @@ int Scintilla_LinkLexers(void);
+ #endif
+ 
+ // Include header that defines basic numeric types.
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) && !defined(__clang__)
+ // Older releases of MSVC did not have stdint.h.
+ #include <stddef.h>
+ #elif defined( __VMS )

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/gtk3-link-libraries.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/gtk3-link-libraries.patch
@@ -1,0 +1,12 @@
+diff --git a/build/cmake/modules/FindGTK3.cmake b/build/cmake/modules/FindGTK3.cmake
+index d2939a1..daf33fe 100644
+--- a/build/cmake/modules/FindGTK3.cmake
++++ b/build/cmake/modules/FindGTK3.cmake
+@@ -47,6 +47,7 @@ include(CheckSymbolExists)
+ set(CMAKE_REQUIRED_INCLUDES ${GTK3_INCLUDE_DIRS})
+ check_symbol_exists(GDK_WINDOWING_WAYLAND "gdk/gdk.h" wxHAVE_GDK_WAYLAND)
+ check_symbol_exists(GDK_WINDOWING_X11 "gdk/gdk.h" wxHAVE_GDK_X11)
++set(GTK3_LIBRARIES "${GTK3_LINK_LIBRARIES}" CACHE INTERNAL "")
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTK3 DEFAULT_MSG GTK3_INCLUDE_DIRS GTK3_LIBRARIES VERSION_OK)
+ 

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/install-layout.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/install-layout.patch
@@ -1,0 +1,52 @@
+diff --git a/build/cmake/functions.cmake b/build/cmake/functions.cmake
+index 7182364..4f90430 100644
+--- a/build/cmake/functions.cmake
++++ b/build/cmake/functions.cmake
+@@ -428,7 +428,7 @@ macro(wx_add_library name)
+         set_target_properties(${name} PROPERTIES PROJECT_LABEL ${name_short})
+ 
+         # Setup install
+-        set(runtime_dir "lib")
++        set(runtime_dir "bin")
+         if(WIN32 AND NOT WIN32_MSVC_NAMING)
+             # configure puts the .dll in the bin directory
+             set(runtime_dir "bin")
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+index ef28c99..928bc0b 100644
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -146,7 +146,7 @@ if(WIN32)
+     endif()
+ endif()
+ 
+-if(WIN32_MSVC_NAMING)
++if(0)
+     if(wxBUILD_SHARED)
+         set(lib_suffix "_dll")
+     else()
+diff --git a/build/cmake/install.cmake b/build/cmake/install.cmake
+index 384c683..a662a48 100644
+--- a/build/cmake/install.cmake
++++ b/build/cmake/install.cmake
+@@ -41,7 +41,7 @@ else()
+ 
+     install(DIRECTORY DESTINATION "bin")
+     install(CODE "execute_process( \
+-        COMMAND ${CMAKE_COMMAND} -E create_symlink \
++        COMMAND ${CMAKE_COMMAND} -E copy \
+         \"${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
+         \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
+         )"
+diff --git a/build/cmake/utils/CMakeLists.txt b/build/cmake/utils/CMakeLists.txt
+index dbed8cc..f1da8e3 100644
+--- a/build/cmake/utils/CMakeLists.txt
++++ b/build/cmake/utils/CMakeLists.txt
+@@ -39,7 +39,7 @@ if(wxUSE_XRC)
+ 
+         # Don't use wx_install() here to preserve escaping.
+         install(CODE "execute_process( \
+-            COMMAND ${CMAKE_COMMAND} -E create_symlink \
++            COMMAND ${CMAKE_COMMAND} -E copy \
+             \"${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
+             \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
+             )"

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/nanosvg-ext-depend.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/nanosvg-ext-depend.patch
@@ -1,0 +1,13 @@
+diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
+index 6ef5a6e..248a701 100644
+--- a/build/cmake/wxWidgetsConfig.cmake.in
++++ b/build/cmake/wxWidgetsConfig.cmake.in
+@@ -1,5 +1,8 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(NanoSVG CONFIG)
++
+ # determine target from compiler, platform and library type
+ if(WIN32 AND NOT CYGWIN AND NOT MSYS)
+     if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/portfile.cmake
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/portfile.cmake
@@ -1,0 +1,193 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wxWidgets/wxWidgets
+    REF "v${VERSION}"
+    SHA512 8ff645fe7ee97bf6358b3619efd737ef8f9eb0235ca481e921a64d451c45eb9671ee4e2807fea285153bc0bb434266234f6f4ab15f396bb8290f262fa879e9b3 
+    HEAD_REF master
+    PATCHES
+        install-layout.patch
+        relocatable-wx-config.patch
+        nanosvg-ext-depend.patch
+        fix-libs-export.patch
+        fix-pcre2.patch
+        gtk3-link-libraries.patch
+        sdl2.patch
+        fix_include.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        fonts   wxUSE_PRIVATE_FONTS
+        media   wxUSE_MEDIACTRL
+        sound   wxUSE_SOUND
+        webview wxUSE_WEBVIEW
+        webview wxUSE_WEBVIEW_EDGE
+)
+
+set(OPTIONS_RELEASE "")
+if(NOT "debug-support" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE "-DwxBUILD_DEBUG_LEVEL=0")
+endif()
+
+set(OPTIONS "")
+if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm"))
+    list(APPEND OPTIONS
+        -DwxUSE_STACKWALKER=OFF
+    )
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX)
+    list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=OFF)
+else()
+    list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=ON)
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+# This may be set to ON by users in a custom triplet.
+# The use of 'wxUSE_STL' and 'WXWIDGETS_USE_STD_CONTAINERS' (ON or OFF) are not API compatible
+# which is why they must be set in a custom triplet rather than a port feature.
+if(NOT DEFINED WXWIDGETS_USE_STL)
+    set(WXWIDGETS_USE_STL OFF)
+endif()
+
+if(NOT DEFINED WXWIDGETS_USE_STD_CONTAINERS)
+    set(WXWIDGETS_USE_STD_CONTAINERS OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DwxUSE_REGEX=sys
+        -DwxUSE_ZLIB=sys
+        -DwxUSE_EXPAT=sys
+        -DwxUSE_LIBJPEG=sys
+        -DwxUSE_LIBPNG=sys
+        -DwxUSE_LIBTIFF=sys
+        -DwxUSE_NANOSVG=sys
+        -DwxUSE_GLCANVAS=ON
+        -DwxUSE_LIBGNOMEVFS=OFF
+        -DwxUSE_LIBNOTIFY=OFF
+        -DwxUSE_SECRETSTORE=OFF
+        -DwxUSE_STL=${WXWIDGETS_USE_STL}
+        -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}
+        -DwxUSE_UIACTIONSIMULATOR=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GSPELL=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_MSPACK=ON
+        ${OPTIONS}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        # The minimum cmake version requirement for Cotire is 2.8.12.
+        # however, we need to declare that the minimum cmake version requirement is at least 3.1 to use CMAKE_PREFIX_PATH as the path to find .pc.
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_GSPELL
+        CMAKE_DISABLE_FIND_PACKAGE_MSPACK
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets)
+
+# The CMake export is not ready for use: It lacks a config file.
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/lib/cmake
+    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+)
+
+set(tools wxrc)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND tools wxrc-3.2)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/wx-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/wx-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+    endif()
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
+
+# do the copy pdbs now after the dlls got moved to the expected /bin folder above
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/msvc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(GLOB_RECURSE INCLUDES "${CURRENT_PACKAGES_DIR}/include/*.h")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h")
+    list(APPEND INCLUDES "${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+    list(APPEND INCLUDES "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+endif()
+foreach(INC IN LISTS INCLUDES)
+    file(READ "${INC}" _contents)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        string(REPLACE "defined(WXUSINGDLL)" "0" _contents "${_contents}")
+    else()
+        string(REPLACE "defined(WXUSINGDLL)" "1" _contents "${_contents}")
+    endif()
+    # Remove install prefix from setup.h to ensure package is relocatable
+    string(REGEX REPLACE "\n#define wxINSTALL_PREFIX [^\n]*" "\n#define wxINSTALL_PREFIX \"\"" _contents "${_contents}")
+    file(WRITE "${INC}" "${_contents}")
+endforeach()
+
+if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/include/wx/setup.h")
+    file(GLOB_RECURSE WX_SETUP_H_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/*.h")
+    file(GLOB_RECURSE WX_SETUP_H_FILES_REL "${CURRENT_PACKAGES_DIR}/lib/*.h")
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${WX_SETUP_H_FILES_REL}" "${CURRENT_PACKAGES_DIR}" "")
+
+        string(REPLACE "${CURRENT_PACKAGES_DIR}/lib/" "" WX_SETUP_H_FILES_REL "${WX_SETUP_H_FILES_REL}")
+        string(REPLACE "/setup.h" "" WX_SETUP_H_REL_RELATIVE "${WX_SETUP_H_FILES_REL}")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${WX_SETUP_H_FILES_DBG}" "${CURRENT_PACKAGES_DIR}" "")
+
+        string(REPLACE "${CURRENT_PACKAGES_DIR}/debug/lib/" "" WX_SETUP_H_FILES_DBG "${WX_SETUP_H_FILES_DBG}")
+        string(REPLACE "/setup.h" "" WX_SETUP_H_DBG_RELATIVE "${WX_SETUP_H_FILES_DBG}")
+    endif()
+
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/setup.h.in" "${CURRENT_PACKAGES_DIR}/include/wx/setup.h" @ONLY)
+endif()
+
+file(GLOB configs LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/lib/wx/config/*" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config")
+foreach(config IN LISTS configs)
+    vcpkg_replace_string("${config}" "${CURRENT_INSTALLED_DIR}" [[${prefix}]])
+endforeach()
+file(GLOB configs LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/debug/lib/wx/config/*" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+foreach(config IN LISTS configs)
+    vcpkg_replace_string("${config}" "${CURRENT_INSTALLED_DIR}/debug" [[${prefix}]])
+endforeach()
+
+# For CMake multi-config in connection with wrapper
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib/mswud/wx"
+    )
+endif()
+
+if(NOT "debug-support" IN_LIST FEATURES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wx/debug.h" "#define wxDEBUG_LEVEL 1" "#define wxDEBUG_LEVEL 0")
+    else()
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wx-3.2/wx/debug.h" "#define wxDEBUG_LEVEL 1" "#define wxDEBUG_LEVEL 0")
+    endif()
+endif()
+
+if("example" IN_LIST FEATURES)
+    file(INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/example/CMakeLists.txt"
+        "${SOURCE_PATH}/samples/popup/popup.cpp"
+        "${SOURCE_PATH}/samples/sample.xpm"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/example"
+    )
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/example/popup.cpp" "../sample.xpm" "sample.xpm")
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/docs/licence.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/relocatable-wx-config.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/relocatable-wx-config.patch
@@ -1,0 +1,49 @@
+diff --git a/wx-config.in b/wx-config.in
+index 441f88c..b326867 100755
+--- a/wx-config.in
++++ b/wx-config.in
+@@ -91,7 +91,7 @@ EOF
+ 
+ 
+ # Contentious tools determined by configure.
+-EGREP="@EGREP@"
++EGREP="grep -E" # no absolute path from host
+ 
+ 
+ # For the people who know what they want, or think they do:
+@@ -402,8 +402,23 @@ is_cross()  { [ "x@cross_compiling@" = "xyes" ]; }
+ 
+ 
+ # Determine the base directories we require.
+-prefix=${input_option_prefix-${this_prefix:-@prefix@}}
+-exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-@exec_prefix@}}}
++vcpkg_prefix=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
++case "$vcpkg_prefix" in
++    */lib/wx/config)
++        vcpkg_prefix=${vcpkg_prefix%/*/*/*}
++        ;;
++    */tools/wxwidgets/debug)
++        vcpkg_prefix=${vcpkg_prefix%/*/*/*}/debug
++        ;;
++    */tools/wxwidgets)
++        vcpkg_prefix=${vcpkg_prefix%/*/*}
++        ;;
++esac
++if [ -n "@MINGW@" -a -n "@CMAKE_HOST_WIN32@" ]; then
++    vcpkg_prefix=$(cygpath -m "$vcpkg_prefix")
++fi
++prefix=${input_option_prefix-${this_prefix:-$vcpkg_prefix}}
++exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-$prefix}}}
+ wxconfdir="@libdir@/wx/config"
+ 
+ installed_configs=`cd "$wxconfdir" 2> /dev/null && ls | grep -v "^inplace-"`
+@@ -940,6 +949,9 @@ prefix=${this_prefix-$prefix}
+ exec_prefix=${this_exec_prefix-$exec_prefix}
+ 
+ includedir="@includedir@"
++if [ "@CMAKE_BUILD_TYPE@" = "Debug" ] ; then
++    includedir="${includedir%/debug/include}/include"
++fi
+ libdir="@libdir@"
+ bindir="@bindir@"
+ 

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/sdl2.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/sdl2.patch
@@ -1,0 +1,29 @@
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+index 7bd00d3..d903584 100644
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -493,7 +493,9 @@ if(wxUSE_GUI)
+     endif()
+ 
+     if(wxUSE_SOUND AND wxUSE_LIBSDL AND UNIX AND NOT APPLE)
+-        find_package(SDL2)
++        find_package(SDL2 CONFIG REQUIRED)
++        set(SDL2_INCLUDE_DIR "" CACHE INTERNAL "")
++        set(SDL2_LIBRARY SDL2::SDL2 CACHE INTERNAL "")
+         if(NOT SDL2_FOUND)
+             find_package(SDL)
+         endif()
+diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
+index 248a701..f617dc4 100644
+--- a/build/cmake/wxWidgetsConfig.cmake.in
++++ b/build/cmake/wxWidgetsConfig.cmake.in
+@@ -2,6 +2,9 @@
+ 
+ include(CMakeFindDependencyMacro)
+ find_dependency(NanoSVG CONFIG)
++if("@wxUSE_LIBSDL@")
++    find_dependency(SDL2 CONFIG)
++endif()
+ 
+ # determine target from compiler, platform and library type
+ if(WIN32 AND NOT CYGWIN AND NOT MSYS)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/setup.h.in
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/setup.h.in
@@ -1,0 +1,5 @@
+#ifdef _DEBUG
+#include "../../debug/lib/@WX_SETUP_H_DBG_RELATIVE@/setup.h"
+#else
+#include "../../lib/@WX_SETUP_H_REL_RELATIVE@/setup.h"
+#endif

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/usage
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/usage
@@ -1,0 +1,4 @@
+The package wxwidgets provides CMake targets:
+
+    find_package(wxWidgets CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE wx::core wx::base)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg-cmake-wrapper.cmake
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,81 @@
+cmake_policy(PUSH)
+cmake_policy(SET CMP0012 NEW)
+cmake_policy(SET CMP0054 NEW)
+cmake_policy(SET CMP0057 NEW)
+
+get_filename_component(_vcpkg_wx_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(wxWidgets_ROOT_DIR "${_vcpkg_wx_root}" CACHE INTERNAL "")
+set(WX_ROOT_DIR "${_vcpkg_wx_root}" CACHE INTERNAL "")
+unset(_vcpkg_wx_root)
+
+if(WIN32)
+    # Find all libs with "32" infix which is unknown to FindwxWidgets.cmake
+    function(z_vcpkg_wxwidgets_find_base_library BASENAME)
+        find_library(WX_${BASENAME}d wx${BASENAME}32ud NAMES wx${BASENAME}d PATHS "${wxWidgets_ROOT_DIR}/debug/lib" NO_DEFAULT_PATH)
+        find_library(WX_${BASENAME}  wx${BASENAME}32u  NAMES wx${BASENAME}  PATHS "${wxWidgets_ROOT_DIR}/lib" NO_DEFAULT_PATH REQUIRED)
+    endfunction()
+    function(z_vcpkg_wxwidgets_find_suffix_library BASENAME)
+        foreach(lib IN LISTS ARGN)
+            find_library(WX_${lib}d NAMES wx${BASENAME}32ud_${lib} PATHS "${wxWidgets_ROOT_DIR}/debug/lib" NO_DEFAULT_PATH)
+            find_library(WX_${lib}  NAMES wx${BASENAME}32u_${lib}  PATHS "${wxWidgets_ROOT_DIR}/lib" NO_DEFAULT_PATH)
+        endforeach()
+    endfunction()
+    z_vcpkg_wxwidgets_find_base_library(base)
+    z_vcpkg_wxwidgets_find_suffix_library(base net odbc xml)
+    z_vcpkg_wxwidgets_find_suffix_library(msw core adv aui html media xrc dbgrid gl qa richtext stc ribbon propgrid webview)
+    if(WX_stc AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+        z_vcpkg_wxwidgets_find_base_library(scintilla)
+    endif()
+    # Force FindwxWidgets.cmake win32 mode for all windows targets built on windows
+    set(_vcpkg_wxwidgets_backup_crosscompiling "${CMAKE_CROSSCOMPILING}")
+    set(CMAKE_CROSSCOMPILING 0)
+    set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/lib" CACHE INTERNAL "")
+else()
+    # FindwxWidgets.cmake unix mode, single-config
+    set(_vcpkg_wxconfig "")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "Debug" IN_LIST MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE})
+        # Debug
+        set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/debug/lib" CACHE INTERNAL "")
+        file(GLOB _vcpkg_wxconfig LIST_DIRECTORIES false "${wxWidgets_LIB_DIR}/wx/config/*")
+    endif()
+    if(NOT _vcpkg_wxconfig)
+        # Release or fallback
+        set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/lib" CACHE INTERNAL "")
+        file(GLOB _vcpkg_wxconfig LIST_DIRECTORIES false "${wxWidgets_LIB_DIR}/wx/config/*")
+    endif()
+    set(wxWidgets_CONFIG_EXECUTABLE "${_vcpkg_wxconfig}" CACHE INTERNAL "")
+    unset(_vcpkg_wxconfig)
+endif()
+set(WX_LIB_DIR "${wxWidgets_LIB_DIR}" CACHE INTERNAL "")
+
+_find_package(${ARGS})
+
+if(DEFINED _vcpkg_wxwidgets_backup_crosscompiling)
+    set(CMAKE_CROSSCOMPILING "${_vcpkg_wxwidgets_backup_crosscompiling}")
+    unset(_vcpkg_wxwidgets_backup_crosscompiling)
+endif()
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT "wx::core" IN_LIST wxWidgets_LIBRARIES)
+    find_package(NanoSVG CONFIG QUIET)
+    list(APPEND wxWidgets_LIBRARIES
+        NanoSVG::nanosvg NanoSVG::nanosvgrast
+        )
+endif()
+
+
+if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT "wx::core" IN_LIST wxWidgets_LIBRARIES)
+    find_package(EXPAT QUIET)
+    find_package(JPEG QUIET)
+    find_package(PNG QUIET)
+    find_package(TIFF QUIET)
+    find_package(ZLIB QUIET)
+    list(APPEND wxWidgets_LIBRARIES
+        ${EXPAT_LIBRARIES}
+        ${JPEG_LIBRARIES}
+        ${PNG_LIBRARIES}
+        ${TIFF_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+    )
+endif()
+
+cmake_policy(POP)

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
@@ -1,0 +1,96 @@
+{
+  "name": "wxwidgets",
+  "version": "3.2.2.1",
+  "port-version": 1,
+  "description": [
+    "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
+    "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",
+    "Set WXWIDGETS_USE_STD_CONTAINERS in a custom triplet to build with the wxUSE_STD_CONTAINERS build option."
+  ],
+  "homepage": "https://github.com/wxWidgets/wxWidgets",
+  "license": "LGPL-2.0-or-later WITH WxWindows-exception-3.1",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "cairo",
+      "default-features": false,
+      "platform": "!windows & !osx & !ios"
+    },
+    {
+      "name": "curl",
+      "default-features": false,
+      "platform": "!windows & !osx"
+    },
+    "expat",
+    {
+      "name": "libiconv",
+      "platform": "!windows"
+    },
+    "libjpeg-turbo",
+    "libpng",
+    "nanosvg",
+    "opengl",
+    "pcre2",
+    "tiff",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "debug-support",
+    "sound"
+  ],
+  "features": {
+    "debug-support": {
+      "description": "Enable wxWidgets debugging support hooks even for release builds (wxDEBUG_LEVEL 1)"
+    },
+    "example": {
+      "description": "Example source code and CMake project"
+    },
+    "fonts": {
+      "description": "Enable to use the font functionality of wxWidgets",
+      "dependencies": [
+        {
+          "name": "fontconfig",
+          "platform": "!windows & !osx"
+        },
+        {
+          "name": "pango",
+          "platform": "!windows & !osx"
+        }
+      ]
+    },
+    "media": {
+      "description": "Build wxMediaCtrl support",
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
+    },
+    "sound": {
+      "description": "Build wxSound support",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
+    },
+    "webview": {
+      "description": "The Edge backend uses Microsoft's Edge WebView2",
+      "dependencies": [
+        "webview2"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This changes the wxWidgets vcpkg port to no longer pull GTK from vcpkg, but instead use the system package. Basically restoring the behavior from before 3ff3b732c814abd90e40fdd95b907d183bed9ea5

This should fix #722 and also helps to avoid a new issue with GTK include files missing.