### PR TITLE
Use system libpng for vcpkg on linux

### DIFF
--- a/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/vcpkg.json
@@ -27,7 +27,10 @@
       "platform": "!windows"
     },
     "libjpeg-turbo",
-    "libpng",
+    {
+      "name": "libpng",
+      "platform": "!linux"
+    },
     "nanosvg",
     "opengl",
     "pcre2",


### PR DESCRIPTION
Replicate #382 for the new wxWidgets version