### PR TITLE
Logging migration (gx2Log_printf)

### DIFF
--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -345,7 +345,7 @@ void _GX2SubmitToTCL()
 	// update last submitted CB timestamp
 	uint64 commandBufferTimestamp = Latte_GetTime();
 	LatteGPUState.lastSubmittedCommandBufferTimestamp.store(commandBufferTimestamp);
-	gx2Log_printf("Submitting GX2 command buffer with timestamp %016" PRIx64, commandBufferTimestamp);
+	cemuLog_log(LogType::GX2, "Submitting GX2 command buffer with timestamp {:016x}", commandBufferTimestamp);
 	// submit HLE packet to write retirement timestamp
 	gx2WriteGather_submitU32AsBE(pm4HeaderType3(IT_HLE_SET_CB_RETIREMENT_TIMESTAMP, 2));
 	gx2WriteGather_submitU32AsBE((uint32)(commandBufferTimestamp>>32ULL));

--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -48,7 +48,7 @@ uint64 lastSwapTime = 0;
 
 void gx2Export_GX2SwapScanBuffers(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SwapScanBuffers()");
+	cemuLog_log(LogType::GX2, "GX2SwapScanBuffers()");
 
 	bool isPokken = false;
 
@@ -262,7 +262,7 @@ void gx2Export_GX2CalcDRCSize(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetDRCScale(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetDRCScale(%d,%d)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2SetDRCScale({},{})", hCPU->gpr[3], hCPU->gpr[4]);
 	osLib_returnFromFunction(hCPU, 0);
 }
 
@@ -311,7 +311,7 @@ void gx2Export_GX2SetSemaphore(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2Flush(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2Flush()");
+	cemuLog_log(LogType::GX2, "GX2Flush()");
 	_GX2SubmitToTCL();
 	osLib_returnFromFunction(hCPU, 0);
 }

--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -92,7 +92,7 @@ void gx2Export_GX2SwapScanBuffers(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2CopyColorBufferToScanBuffer(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2CopyColorBufferToScanBuffer(0x%08x,%d)\n", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2CopyColorBufferToScanBuffer(0x{:08x},{})", hCPU->gpr[3], hCPU->gpr[4]);
 	GX2ReserveCmdSpace(5);
 
 	// todo: proper implementation
@@ -270,7 +270,7 @@ void gx2Export_GX2SetDRCConnectCallback(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamS32(channel, 0);
 	ppcDefineParamMEMPTR(callback, void, 1);
-	gx2Log_printf("GX2SetDRCConnectCallback(%d, 0x%08x)", channel, callback.GetMPTR());
+	cemuLog_log(LogType::GX2, "GX2SetDRCConnectCallback({}, 0x{:08x})", channel, callback.GetMPTR());
 	if(callback.GetPtr())
 		PPCCoreCallback(callback, channel, TRUE);
 	osLib_returnFromFunction(hCPU, 0);
@@ -278,7 +278,7 @@ void gx2Export_GX2SetDRCConnectCallback(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetSemaphore(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetSemaphore(0x%08x,%d)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2SetSemaphore(0x{:08x},{})", hCPU->gpr[3], hCPU->gpr[4]);
 	ppcDefineParamMPTR(semaphoreMPTR, 0);
 	ppcDefineParamS32(mode, 1);
 

--- a/src/Cafe/OS/libs/gx2/GX2_ContextState.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_ContextState.cpp
@@ -301,7 +301,7 @@ void _GX2ContextCreateRestoreStateDL(GX2ContextState_t* gx2ContextState)
 
 void gx2Export_GX2SetupContextStateEx(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetupContextStateEx(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetupContextStateEx(0x{:08x})", hCPU->gpr[3]);
 	cemu_assert_debug(hCPU->gpr[4] == 0 || hCPU->gpr[4] == 1);
 
 	GX2ContextState_t* gx2ContextState = (GX2ContextState_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
@@ -329,7 +329,7 @@ void gx2Export_GX2SetupContextStateEx(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetContextState(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetContextState(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetContextState(0x{:08x})", hCPU->gpr[3]);
 	// parameters:
 	if( hCPU->gpr[3] == MPTR_NULL )
 	{
@@ -380,7 +380,7 @@ void gx2Export_GX2SetContextState(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetContextStateDisplayList(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetContextStateDisplayList(0x%08x, 0x%08x, 0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2GetContextStateDisplayList(0x{:08x}, 0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	ppcDefineParamStructPtr(gx2ContextState, GX2ContextState_t, 0);
 	ppcDefineParamU32BEPtr(displayListPtrOut, 1);
 	ppcDefineParamU32BEPtr(displayListSizeOut, 2);

--- a/src/Cafe/OS/libs/gx2/GX2_ContextState.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_ContextState.cpp
@@ -283,7 +283,7 @@ void GX2SetDefaultState()
 
 void gx2Export_GX2SetDefaultState(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetDefaultState()");
+	cemuLog_log(LogType::GX2, "GX2SetDefaultState()");
 	GX2SetDefaultState();
 	osLib_returnFromFunction(hCPU, 0);
 }

--- a/src/Cafe/OS/libs/gx2/GX2_Memory.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Memory.cpp
@@ -34,7 +34,7 @@ void _GX2DefaultAlloc_Free(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetDefaultAllocator(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetDefaultAllocator(0x%08x, 0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2SetDefaultAllocator(0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 	gx2Mem_defaultAlloc = hCPU->gpr[3];
 	gx2Mem_defaultFree = hCPU->gpr[4];
 	osLib_returnFromFunction(hCPU, 0);
@@ -42,7 +42,7 @@ void gx2Export_GX2SetDefaultAllocator(PPCInterpreter_t* hCPU)
 
 void _GX2DefaultAllocR_Alloc(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2DefaultAllocate(0x%08x, 0x%08x, 0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2DefaultAllocate(0x{:08x}, 0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	// parameters:
 	// r3	uint32	userParam
 	// r4	uint32  size
@@ -52,7 +52,7 @@ void _GX2DefaultAllocR_Alloc(PPCInterpreter_t* hCPU)
 
 void _GX2DefaultAllocR_Free(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2DefaultFree(0x%08x, 0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2DefaultFree(0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 	// parameters:
 	// r3	uint32	userParam
 	// r4	void*	mem

--- a/src/Cafe/OS/libs/gx2/GX2_Misc.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Misc.cpp
@@ -15,7 +15,7 @@
 
 void gx2Export_GX2SetSwapInterval(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetSwapInterval(%d)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetSwapInterval({})", hCPU->gpr[3]);
 	if( hCPU->gpr[3] >= 20 )
 	{
 		cemuLog_log(LogType::Force, "GX2SetSwapInterval() called with out of range value ({})", hCPU->gpr[3]);
@@ -27,7 +27,7 @@ void gx2Export_GX2SetSwapInterval(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetSwapInterval(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetSwapInterval()\n");
+	cemuLog_log(LogType::GX2, "GX2GetSwapInterval()");
 	osLib_returnFromFunction(hCPU, LatteGPUState.sharedArea->swapInterval);
 }
 
@@ -45,7 +45,7 @@ void gx2Export_GX2GetSwapStatus(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetGPUTimeout(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetGPUTimeout()\n");
+	cemuLog_log(LogType::GX2, "GX2GetGPUTimeout()");
 	osLib_returnFromFunction(hCPU, 0x3E8);
 }
 

--- a/src/Cafe/OS/libs/gx2/GX2_Misc.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Misc.cpp
@@ -53,14 +53,14 @@ void gx2Export_GX2GetGPUTimeout(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SampleTopGPUCycle(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SampleTopGPUCycle(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SampleTopGPUCycle(0x{:08x})", hCPU->gpr[3]);
 	memory_writeU64(hCPU->gpr[3], coreinit::coreinit_getTimerTick());
 	osLib_returnFromFunction(hCPU, 0);
 }
 
 void gx2Export_GX2SampleBottomGPUCycle(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SampleBottomGPUCycle(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SampleBottomGPUCycle(0x{:08x})", hCPU->gpr[3]);
 	memory_writeU64(hCPU->gpr[3], GX2_INVALID_COUNTER_VALUE_U64);
 
 	osLib_returnFromFunction(hCPU, 0);

--- a/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
@@ -13,7 +13,7 @@
 
 void gx2Export_GX2InitColorBufferRegs(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2InitColorBufferRegs(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2InitColorBufferRegs(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(colorBuffer, GX2ColorBuffer, 0);
 
 	LatteAddrLib::AddrSurfaceInfo_OUT surfaceInfo;
@@ -114,7 +114,7 @@ void gx2Export_GX2InitColorBufferRegs(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2InitDepthBufferRegs(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2InitDepthBufferRegs(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2InitDepthBufferRegs(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(depthBuffer, GX2DepthBuffer, 0);
 
 	LatteAddrLib::AddrSurfaceInfo_OUT surfaceInfo;
@@ -134,13 +134,13 @@ void gx2Export_GX2InitDepthBufferRegs(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetColorBuffer(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetColorBuffer(0x%08x, %d)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::GX2, "GX2SetColorBuffer(0x{:08x}, {})", hCPU->gpr[3], hCPU->gpr[4]);
 	GX2ReserveCmdSpace(20);
 
 	GX2ColorBuffer* colorBufferBE = (GX2ColorBuffer*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 
 #ifdef CEMU_DEBUG_ASSERT
-	gx2Log_printf("ColorBuffer tileMode %01x PhysAddr %08x fmt %04x res %dx%d Mip %d Slice %d", (uint32)colorBufferBE->surface.tileMode.value(), (uint32)colorBufferBE->surface.imagePtr, (uint32)colorBufferBE->surface.format.value(), (uint32)colorBufferBE->surface.width, (uint32)colorBufferBE->surface.height, _swapEndianU32(colorBufferBE->viewMip), _swapEndianU32(colorBufferBE->viewFirstSlice));
+	cemuLog_log(LogType::GX2, "ColorBuffer tileMode {:01x} PhysAddr {:08x} fmt {:04x} res {}x{} Mip {} Slice {}", (uint32)colorBufferBE->surface.tileMode.value(), (uint32)colorBufferBE->surface.imagePtr, (uint32)colorBufferBE->surface.format.value(), (uint32)colorBufferBE->surface.width, (uint32)colorBufferBE->surface.height, _swapEndianU32(colorBufferBE->viewMip), _swapEndianU32(colorBufferBE->viewFirstSlice));
 #endif
 
 	// regs[0] = mmCB_COLOR0_SIZE
@@ -205,12 +205,12 @@ void gx2Export_GX2SetColorBuffer(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetDepthBuffer(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetDepthBuffer(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetDepthBuffer(0x{:08x})", hCPU->gpr[3]);
 	GX2ReserveCmdSpace(20);
 
 	GX2DepthBuffer* depthBufferBE = (GX2DepthBuffer*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 
-	gx2Log_printf("DepthBuffer tileMode %01x PhysAddr %08x fmt %04x res %dx%d", (uint32)depthBufferBE->surface.tileMode.value(), (uint32)depthBufferBE->surface.imagePtr, (uint32)depthBufferBE->surface.format.value(), (uint32)depthBufferBE->surface.width, (uint32)depthBufferBE->surface.height);
+	cemuLog_log(LogType::GX2, "DepthBuffer tileMode {:01x} PhysAddr {:08x} fmt {:04x} res {}x{}", (uint32)depthBufferBE->surface.tileMode.value(), (uint32)depthBufferBE->surface.imagePtr, (uint32)depthBufferBE->surface.format.value(), (uint32)depthBufferBE->surface.width, (uint32)depthBufferBE->surface.height);
 
 	uint32 viewMip = _swapEndianU32(depthBufferBE->viewMip);
 

--- a/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
@@ -576,7 +576,7 @@ void gx2Export_GX2ResolveAAColorBuffer(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2ConvertDepthBufferToTextureSurface(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2ConvertDepthBufferToTextureSurface(0x%x, 0x%x, %d, %d)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
+	cemuLog_log(LogType::GX2, "GX2ConvertDepthBufferToTextureSurface(0x{:x}, 0x{:x}, {}, {})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 	GX2DepthBuffer* depthBuffer = (GX2DepthBuffer*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	GX2Surface* dstSurface = (GX2Surface*)memory_getPointerFromVirtualOffset(hCPU->gpr[4]);
 	uint32 dstMip = hCPU->gpr[5];

--- a/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
@@ -378,7 +378,7 @@ void gx2Export_GX2AllocateTilingApertureEx(PPCInterpreter_t* hCPU)
 {
 	cemuLog_log(LogType::GX2, "GX2AllocateTilingApertureEx(0x{:08x}, {}, {}, {}, 0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->gpr[8]);
 	GX2Surface* surface = (GX2Surface*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
-	gx2Log_printf("Tiling Tex: %08X %dx%d Swizzle: %08x tm: %d fmt: %04x use: %02x", (uint32)surface->imagePtr, (uint32)surface->width, (uint32)surface->height, (uint32)surface->swizzle, (uint32)surface->tileMode.value(), (uint32)surface->format.value(), (uint32)surface->resFlag);
+	cemuLog_log(LogType::GX2, "Tiling Tex: {:08x} {}x{} Swizzle: {:08x} tm: {} fmt: {:04x} use: {:02x}", (uint32)surface->imagePtr, (uint32)surface->width, (uint32)surface->height, (uint32)surface->swizzle, (uint32)surface->tileMode.value(), (uint32)surface->format.value(), (uint32)surface->resFlag);
 
 	if( activeTilingAperatureCount >= GX2_MAX_ACTIVE_TILING_APERATURES )
 	{

--- a/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
@@ -376,7 +376,7 @@ void GX2TilingAperature_RetileTexture(ActiveTilingAperature* tilingAperture, boo
 
 void gx2Export_GX2AllocateTilingApertureEx(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2AllocateTilingApertureEx(0x%08x, %d, %d, %d, 0x%08x, 0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->gpr[8]);
+	cemuLog_log(LogType::GX2, "GX2AllocateTilingApertureEx(0x{:08x}, {}, {}, {}, 0x{:08x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->gpr[8]);
 	GX2Surface* surface = (GX2Surface*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	gx2Log_printf("Tiling Tex: %08X %dx%d Swizzle: %08x tm: %d fmt: %04x use: %02x", (uint32)surface->imagePtr, (uint32)surface->width, (uint32)surface->height, (uint32)surface->swizzle, (uint32)surface->tileMode.value(), (uint32)surface->format.value(), (uint32)surface->resFlag);
 
@@ -437,7 +437,7 @@ void gx2Export_GX2AllocateTilingApertureEx(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2FreeTilingAperture(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2FreeTilingAperture(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2FreeTilingAperture(0x{:08x})", hCPU->gpr[3]);
 	uint32 handle = hCPU->gpr[3];
 	for(sint32 i=0; i<activeTilingAperatureCount; i++)
 	{

--- a/src/Cafe/OS/libs/gx2/GX2_shader_legacy.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_shader_legacy.cpp
@@ -10,7 +10,7 @@
 
 void gx2Export_GX2SetFetchShader(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetFetchShader(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetFetchShader(0x{:08x})", hCPU->gpr[3]);
 	GX2ReserveCmdSpace(11);
 	GX2FetchShader_t* fetchShaderPtr = (GX2FetchShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	cemu_assert_debug((_swapEndianU32(fetchShaderPtr->shaderPtr) & 0xFF) == 0);
@@ -36,7 +36,7 @@ void gx2Export_GX2SetFetchShader(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetVertexShaderGPRs(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetVertexShaderGPRs(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2GetVertexShaderGPRs(0x{:08x})", hCPU->gpr[3]);
 	GX2VertexShader_t* vertexShader = (GX2VertexShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	uint8 numGPRs = _swapEndianU32(vertexShader->regs[0])&0xFF;
 	osLib_returnFromFunction(hCPU, numGPRs);
@@ -44,7 +44,7 @@ void gx2Export_GX2GetVertexShaderGPRs(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetVertexShaderStackEntries(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetVertexShaderStackEntries(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2GetVertexShaderStackEntries(0x{:08x})", hCPU->gpr[3]);
 	GX2VertexShader_t* vertexShader = (GX2VertexShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	uint8 stackEntries = (_swapEndianU32(vertexShader->regs[0])>>8)&0xFF;
 	osLib_returnFromFunction(hCPU, stackEntries);
@@ -52,7 +52,7 @@ void gx2Export_GX2GetVertexShaderStackEntries(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetPixelShaderGPRs(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetPixelShaderGPRs(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2GetPixelShaderGPRs(0x{:08x})", hCPU->gpr[3]);
 	GX2PixelShader_t* pixelShader = (GX2PixelShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	uint8 stackEntries = (_swapEndianU32(pixelShader->regs[0]))&0xFF;
 	osLib_returnFromFunction(hCPU, stackEntries);
@@ -60,7 +60,7 @@ void gx2Export_GX2GetPixelShaderGPRs(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2GetPixelShaderStackEntries(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2GetPixelShaderStackEntries(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2GetPixelShaderStackEntries(0x{:08x})", hCPU->gpr[3]);
 	GX2PixelShader_t* pixelShader = (GX2PixelShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	uint8 numGPRs = (_swapEndianU32(pixelShader->regs[0]>>8))&0xFF;
 	osLib_returnFromFunction(hCPU, numGPRs);
@@ -68,7 +68,7 @@ void gx2Export_GX2GetPixelShaderStackEntries(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetVertexShader(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetVertexShader(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetVertexShader(0x{:08x})", hCPU->gpr[3]);
 	GX2ReserveCmdSpace(100);
 
 	GX2VertexShader_t* vertexShader = (GX2VertexShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
@@ -208,7 +208,7 @@ void gx2Export_GX2SetVertexShader(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetPixelShader(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetPixelShader(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetPixelShader(0x{:08x})", hCPU->gpr[3]);
 	GX2ReserveCmdSpace(100);
 
 	GX2PixelShader_t* pixelShader = (GX2PixelShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
@@ -276,7 +276,7 @@ void gx2Export_GX2SetPixelShader(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetGeometryShader(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetGeometryShader(0x%08x)\n", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetGeometryShader(0x{:08x})", hCPU->gpr[3]);
 	GX2ReserveCmdSpace(100);
 
 	GX2GeometryShader_t* geometryShader = (GX2GeometryShader_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
@@ -438,7 +438,7 @@ static_assert(offsetof(GX2ComputeShader_t, rBuffer) == 0x74);
 void gx2Export_GX2SetComputeShader(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamTypePtr(computeShader, GX2ComputeShader_t, 0);
-	gx2Log_printf("GX2SetComputeShader(0x%08x)", hCPU->gpr[3]);
+	cemuLog_log(LogType::GX2, "GX2SetComputeShader(0x{:08x})", hCPU->gpr[3]);
 
 	MPTR shaderPtr;
 	uint32 shaderSize;
@@ -489,7 +489,7 @@ void _GX2SubmitUniformReg(uint32 aluRegisterOffset, MPTR virtualAddress, uint32 
 
 void gx2Export_GX2SetVertexUniformReg(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetVertexUniformReg(0x%08x,0x%x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2SetVertexUniformReg(0x{:08x},0x{:x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	_GX2SubmitUniformReg(hCPU->gpr[3] + 0x400, hCPU->gpr[5], hCPU->gpr[4]);
 	cemu_assert_debug((hCPU->gpr[3] + hCPU->gpr[4]) <= 0x400);
 	osLib_returnFromFunction(hCPU, 0);
@@ -497,7 +497,7 @@ void gx2Export_GX2SetVertexUniformReg(PPCInterpreter_t* hCPU)
 
 void gx2Export_GX2SetPixelUniformReg(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetPixelUniformReg(0x%08x,0x%x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2SetPixelUniformReg(0x{:08x},0x{:x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	_GX2SubmitUniformReg(hCPU->gpr[3], hCPU->gpr[5], hCPU->gpr[4]);
 	cemu_assert_debug((hCPU->gpr[3] + hCPU->gpr[4]) <= 0x400);
 	osLib_returnFromFunction(hCPU, 0);
@@ -519,21 +519,21 @@ void _GX2SubmitUniformBlock(uint32 registerBase, uint32 index, MPTR virtualAddre
 
 void gx2Export_GX2SetVertexUniformBlock(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetVertexUniformBlock(0x%08x,0x%x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2SetVertexUniformBlock(0x{:08x},0x{:x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	_GX2SubmitUniformBlock(mmSQ_VTX_UNIFORM_BLOCK_START - mmSQ_TEX_RESOURCE_WORD0, hCPU->gpr[3], hCPU->gpr[5], hCPU->gpr[4]);
 	osLib_returnFromFunction(hCPU, 0);
 }
 
 void gx2Export_GX2SetPixelUniformBlock(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetPixelUniformBlock(0x%08x,0x%x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2SetPixelUniformBlock(0x{:08x},0x{:x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	_GX2SubmitUniformBlock(mmSQ_PS_UNIFORM_BLOCK_START - mmSQ_TEX_RESOURCE_WORD0, hCPU->gpr[3], hCPU->gpr[5], hCPU->gpr[4]);
 	osLib_returnFromFunction(hCPU, 0);
 }
 
 void gx2Export_GX2SetGeometryUniformBlock(PPCInterpreter_t* hCPU)
 {
-	gx2Log_printf("GX2SetGeometryUniformBlock(0x%08x,0x%x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::GX2, "GX2SetGeometryUniformBlock(0x{:08x},0x{:x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	_GX2SubmitUniformBlock(mmSQ_GS_UNIFORM_BLOCK_START - mmSQ_TEX_RESOURCE_WORD0, hCPU->gpr[3], hCPU->gpr[5], hCPU->gpr[4]);
 	osLib_returnFromFunction(hCPU, 0);
 }


### PR DESCRIPTION
Converts all instances of the gx2Log_printf() logging method with the newer cemuLog_log().

Part of #703