### PR TITLE
Logging migration (sndApiLog_printf)

### DIFF
--- a/src/Cafe/OS/libs/snd_core/ax_exports.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_exports.cpp
@@ -97,7 +97,7 @@ namespace snd_core
 		ppcDefineParamS32(device, 0);
 		ppcDefineParamU32BEPtr(funcAddrPtr, 1);
 		sint32 r = AXGetDeviceFinalMixCallback(device, funcAddrPtr);
-		sndApiLog_printf("AXGetDeviceFinalMixCallback(%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_log(LogType::SoundAPI, "AXGetDeviceFinalMixCallback({},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 		osLib_returnFromFunction(hCPU, r);
 	}
 
@@ -105,14 +105,14 @@ namespace snd_core
 	{
 		ppcDefineParamS32(device, 0);
 		ppcDefineParamMPTR(funcAddr, 1);
-		sndApiLog_printf("AXRegisterDeviceFinalMixCallback(%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_log(LogType::SoundAPI, "AXRegisterDeviceFinalMixCallback({},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 		sint32 r = AXRegisterDeviceFinalMixCallback(device, funcAddr);
 		osLib_returnFromFunction(hCPU, r);
 	}
 
 	void export_AXRegisterAppFrameCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXRegisterAppFrameCallback(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXRegisterAppFrameCallback(0x{:08x})", hCPU->gpr[3]);
 		ppcDefineParamMPTR(funcAddr, 0);
 		sint32 r = AXRegisterAppFrameCallback(funcAddr);
 		osLib_returnFromFunction(hCPU, r);
@@ -120,7 +120,7 @@ namespace snd_core
 
 	void export_AXDeregisterAppFrameCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXDeregisterAppFrameCallback(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXDeregisterAppFrameCallback(0x{:08x})", hCPU->gpr[3]);
 		ppcDefineParamMPTR(funcAddr, 0);
 		sint32 r = AXDeregisterAppFrameCallback(funcAddr);
 		osLib_returnFromFunction(hCPU, r);
@@ -128,7 +128,7 @@ namespace snd_core
 
 	void export_AXRegisterFrameCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXRegisterFrameCallback(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXRegisterFrameCallback(0x{:08x})", hCPU->gpr[3]);
 		ppcDefineParamMPTR(funcAddr, 0);
 		sint32 r = AXRegisterFrameCallback(funcAddr);
 		osLib_returnFromFunction(hCPU, r);
@@ -136,7 +136,7 @@ namespace snd_core
 
 	void export_AXRegisterCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXRegisterCallback(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXRegisterCallback(0x{:08x})", hCPU->gpr[3]);
 		ppcDefineParamMPTR(funcAddr, 0);
 		sint32 r = AXRegisterFrameCallback(funcAddr);
 		osLib_returnFromFunction(hCPU, r);
@@ -144,7 +144,7 @@ namespace snd_core
 
 	void export_AXRegisterAuxCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXRegisterAuxCallback(0x%08x,0x%08x,0x%08x,0x%08x,0x%08x) LR %08x", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->spr.LR);
+		cemuLog_log(LogType::SoundAPI, "AXRegisterAuxCallback(0x{:08x},0x{:08x},0x{:08x},0x{:08x},0x{:08x}) LR {:08x}", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->spr.LR);
 		ppcDefineParamU32(device, 0);
 		ppcDefineParamU32(deviceIndex, 1);
 		ppcDefineParamU32(auxBusIndex, 2);
@@ -156,7 +156,7 @@ namespace snd_core
 
 	void export_AXGetAuxCallback(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXGetAuxCallback(0x%08x,0x%08x,0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+		cemuLog_log(LogType::SoundAPI, "AXGetAuxCallback(0x{:08x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
 		ppcDefineParamU32(device, 0);
 		ppcDefineParamU32(deviceIndex, 1);
 		ppcDefineParamU32(auxBusIndex, 2);
@@ -168,7 +168,7 @@ namespace snd_core
 
 	void export_AXSetAuxReturnVolume(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXSetAuxReturnVolume(0x%08x,0x%08x,0x%08x,0x%04x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
+		cemuLog_log(LogType::SoundAPI, "AXSetAuxReturnVolume(0x{:08x},0x{:08x},0x{:08x},0x{:04x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 		ppcDefineParamU32(device, 0);
 		ppcDefineParamU32(deviceIndex, 1);
 		ppcDefineParamU32(auxBusIndex, 2);
@@ -179,7 +179,7 @@ namespace snd_core
 
 	void export_AXGetDeviceMode(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXGetDeviceMode(%d)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXGetDeviceMode({})", hCPU->gpr[3]);
 		ppcDefineParamS32(device, 0);
 		ppcDefineParamU32BEPtr(mode, 1);
 		*mode = AXGetDeviceMode(device);
@@ -188,7 +188,7 @@ namespace snd_core
 
 	void export_AXSetDeviceUpsampleStage(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXSetDeviceUpsampleStage(%d,%d)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_log(LogType::SoundAPI, "AXSetDeviceUpsampleStage({},{})", hCPU->gpr[3], hCPU->gpr[4]);
 		ppcDefineParamS32(device, 0);
 		ppcDefineParamS32(upsampleStage, 1);
 		sint32 r = AXSetDeviceUpsampleStage(device, upsampleStage);
@@ -197,7 +197,7 @@ namespace snd_core
 
 	void export_AXGetDeviceUpsampleStage(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXGetDeviceUpsampleStage(%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_log(LogType::SoundAPI, "AXGetDeviceUpsampleStage({},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 		ppcDefineParamS32(device, 0);
 		ppcDefineParamU32BEPtr(upsampleStagePtr, 1);
 		sint32 r = AXGetDeviceUpsampleStage(device, upsampleStagePtr);
@@ -209,7 +209,7 @@ namespace snd_core
 		ppcDefineParamS32(priority, 0);
 		ppcDefineParamMPTR(callbackEx, 1);
 		ppcDefineParamMPTR(userParam, 2);
-		sndApiLog_printf("AXAcquireVoiceEx(%d,0x%08x,0x%08x)", priority, callbackEx, userParam);
+		cemuLog_log(LogType::SoundAPI, "AXAcquireVoiceEx({},0x{:08x},0x{:08x})", priority, callbackEx, userParam);
 		MEMPTR<AXVPB> r = AXAcquireVoiceEx(priority, callbackEx, userParam);
 		osLib_returnFromFunction(hCPU, r.GetMPTR());
 	}
@@ -219,7 +219,7 @@ namespace snd_core
 		ppcDefineParamS32(priority, 0);
 		ppcDefineParamMPTR(callback, 1);
 		ppcDefineParamMPTR(userParam, 2);
-		sndApiLog_printf("AXAcquireVoice(%d,0x%08x,0x%08x)", priority, callback, userParam);
+		cemuLog_log(LogType::SoundAPI, "AXAcquireVoice({},0x{:08x},0x{:08x})", priority, callback, userParam);
 		MEMPTR<AXVPB> r = AXAcquireVoiceEx(priority, MPTR_NULL, MPTR_NULL);
 		if (r.IsNull() == false)
 		{
@@ -232,7 +232,7 @@ namespace snd_core
 	void export_AXFreeVoice(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamStructPtr(vpb, AXVPB, 0);
-		sndApiLog_printf("AXFreeVoice(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXFreeVoice(0x{:08x})", hCPU->gpr[3]);
 		AXFreeVoice(vpb);
 		osLib_returnFromFunction(hCPU, 0);
 	}
@@ -240,20 +240,20 @@ namespace snd_core
 	void export_AXUserIsProtected(PPCInterpreter_t* hCPU)
 	{
 		sint32 r = AXUserIsProtected();
-		sndApiLog_printf("AXUserIsProtected() -> %s", r!=0?"true":"false");
+		cemuLog_log(LogType::SoundAPI, "AXUserIsProtected() -> {}", r!=0?"true":"false");
 		osLib_returnFromFunction(hCPU, r);
 	}
 
 	void export_AXUserBegin(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXUserBegin()");
+		cemuLog_log(LogType::SoundAPI, "AXUserBegin()");
 		sint32 r = AXUserBegin();
 		osLib_returnFromFunction(hCPU, r);
 	}
 
 	void export_AXUserEnd(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXUserEnd()");
+		cemuLog_log(LogType::SoundAPI, "AXUserEnd()");
 		sint32 r = AXUserEnd();
 		osLib_returnFromFunction(hCPU, r);
 	}
@@ -261,7 +261,7 @@ namespace snd_core
 	void export_AXVoiceBegin(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamStructPtr(vpb, AXVPB, 0);
-		sndApiLog_printf("AXVoiceBegin(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXVoiceBegin(0x{:08x})", hCPU->gpr[3]);
 		sint32 r = AXVoiceBegin(vpb);
 		osLib_returnFromFunction(hCPU, r);
 	}
@@ -269,7 +269,7 @@ namespace snd_core
 	void export_AXVoiceEnd(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamStructPtr(vpb, AXVPB, 0);
-		sndApiLog_printf("AXVoiceEnd(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXVoiceEnd(0x{:08x})", hCPU->gpr[3]);
 		sint32 r = AXVoiceEnd(vpb);
 		osLib_returnFromFunction(hCPU, r);
 	}
@@ -277,7 +277,7 @@ namespace snd_core
 	void export_AXVoiceIsProtected(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamStructPtr(vpb, AXVPB, 0);
-		sndApiLog_printf("AXVoiceIsProtected(0x%08x)", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXVoiceIsProtected(0x{:08x})", hCPU->gpr[3]);
 		sint32 r = AXVoiceProtection_IsProtectedByCurrentThread(vpb)?1:0;
 		osLib_returnFromFunction(hCPU, r);
 	}
@@ -303,7 +303,7 @@ namespace snd_core
 
 	void export_AXCheckVoiceOffsets(PPCInterpreter_t* hCPU)
 	{
-		sndApiLog_printf("AXCheckVoiceOffsets(0x%08x)\n", hCPU->gpr[3]);
+		cemuLog_log(LogType::SoundAPI, "AXCheckVoiceOffsets(0x{:08x})", hCPU->gpr[3]);
 		ppcDefineParamStructPtr(pbOffset, AXPBOFFSET_t, 0);
 
 		uint16 format = _swapEndianU16(pbOffset->format);
@@ -328,7 +328,7 @@ namespace snd_core
 		ppcDefineParamU32(chanIn, 1);
 		ppcDefineParamU32(chanOut, 2);
 		ppcDefineParamMEMPTR(matrix, float32be, 3);
-		sndApiLog_printf("AXSetDeviceRemixMatrix(%d,%d,%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
+		cemuLog_log(LogType::SoundAPI, "AXSetDeviceRemixMatrix({},{},{},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 		const auto result = AXSetDeviceRemixMatrix(device, chanIn, chanOut, matrix);
 		osLib_returnFromFunction(hCPU, result);
 	}
@@ -339,7 +339,7 @@ namespace snd_core
 		ppcDefineParamU32(chanIn, 1);
 		ppcDefineParamU32(chanOut, 2);
 		ppcDefineParamMEMPTR(matrix, MEMPTR<float32be>, 3);
-		sndApiLog_printf("AXGetDeviceRemixMatrix(%d,%d,%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
+		cemuLog_log(LogType::SoundAPI, "AXGetDeviceRemixMatrix({},{},{},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 		const auto result = AXGetDeviceRemixMatrix(device, chanIn, chanOut, matrix);
 		osLib_returnFromFunction(hCPU, result);
 	}

--- a/src/Cafe/OS/libs/snd_core/ax_voice.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_voice.cpp
@@ -1004,7 +1004,7 @@ namespace snd_core
 		{
 			cemu_assert_debug(false);
 		}
-		sndApiLog_printf("Retrieved voice offsets for voice %08x - base %08x current %08x loopFlag %04x loop %08x end %08x", memory_getVirtualOffsetFromPointer(vpb), _swapEndianU32(pbOffset->samples), _swapEndianU32(pbOffset->currentOffset), _swapEndianU16(pbOffset->loopFlag), _swapEndianU32(pbOffset->loopOffset), _swapEndianU32(pbOffset->endOffset));
+		cemuLog_log(LogType::SoundAPI, "Retrieved voice offsets for voice {:08x} - base {:08x} current {:08x} loopFlag {:04x} loop {:08x} end {:08x}", memory_getVirtualOffsetFromPointer(vpb), _swapEndianU32(pbOffset->samples), _swapEndianU32(pbOffset->currentOffset), _swapEndianU16(pbOffset->loopFlag), _swapEndianU32(pbOffset->loopOffset), _swapEndianU32(pbOffset->endOffset));
 	}
 
 	void AXGetVoiceOffsetsEx(AXVPB* vpb, AXPBOFFSET_t* pbOffset, MPTR sampleBase)

--- a/src/Cafe/OS/libs/snd_user/snd_user.cpp
+++ b/src/Cafe/OS/libs/snd_user/snd_user.cpp
@@ -367,7 +367,7 @@ namespace snd
 
 		void MIXInit()
 		{
-			sndApiLog_printf("MIXInit()");
+			cemuLog_log(LogType::SoundAPI, "MIXInit()");
 
 			if (g_snd_user_data.initialized)
 				return;
@@ -388,7 +388,7 @@ namespace snd
 
 		void MIXSetSoundMode(uint32 sound_mode)
 		{
-			sndApiLog_printf("MIXSetSoundMode(0x%x)", sound_mode);
+			cemuLog_log(LogType::SoundAPI, "MIXSetSoundMode(0x{:x})", sound_mode);
 
 			if (sound_mode >= 2)
 				sound_mode = 1;
@@ -398,7 +398,7 @@ namespace snd
 
 		uint32 MIXGetSoundMode()
 		{
-			sndApiLog_printf("MIXGetSoundMode()");
+			cemuLog_log(LogType::SoundAPI, "MIXGetSoundMode()");
 			return g_snd_user_data.device_info.tv_sound_mode;
 		}
 
@@ -548,7 +548,7 @@ namespace snd
 
 		void MIXInitChannel(AXVPB* voice, uint16 mode, uint16 input, uint16 aux1, uint16 aux2, uint16 aux3, uint16 pan, uint16 span, uint16 fader)
 		{
-			sndApiLog_printf("MIXInitChannel(0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x)", MEMPTR(voice).GetMPTR(), mode, input, aux1, aux2, aux3, pan, span, fader);
+			cemuLog_log(LogType::SoundAPI, "MIXInitChannel(0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x})", MEMPTR(voice).GetMPTR(), mode, input, aux1, aux2, aux3, pan, span, fader);
 			cemu_assert_debug(voice);
 
 			AXVoiceBegin(voice);
@@ -579,7 +579,7 @@ namespace snd
 
 		void MIXAssignChannel(AXVPB* voice)
 		{
-			sndApiLog_printf("MIXAssignChannel(0x%x)", MEMPTR(voice).GetMPTR());
+			cemuLog_log(LogType::SoundAPI, "MIXAssignChannel(0x{:x})", MEMPTR(voice).GetMPTR());
 			cemu_assert_debug(voice);
 
 			AXVoiceBegin(voice);
@@ -619,7 +619,7 @@ namespace snd
 
 		void MIXSetInput(AXVPB* voice, uint16 input)
 		{
-			sndApiLog_printf("MIXSetInput(0x%x, 0x%x)", MEMPTR(voice).GetMPTR(), input);
+			cemuLog_log(LogType::SoundAPI, "MIXSetInput(0x{:x}, 0x{:x})", MEMPTR(voice).GetMPTR(), input);
 
 			const uint32 voice_index = voice->index;
 			const auto channel = &g_snd_user_data.mix_channel[voice_index];
@@ -631,7 +631,7 @@ namespace snd
 
 		void MIXUpdateSettings()
 		{
-			sndApiLog_printf("MIXUpdateSettings()");
+			cemuLog_log(LogType::SoundAPI, "MIXUpdateSettings()");
 
 			if (!g_snd_user_data.initialized)
 				return;
@@ -705,7 +705,7 @@ namespace snd
 
 		void MIXSetDeviceSoundMode(uint32 device, uint32 mode)
 		{
-			sndApiLog_printf("MIXSetDeviceSoundMode(0x%x, 0x%x)", device, mode);
+			cemuLog_log(LogType::SoundAPI, "MIXSetDeviceSoundMode(0x{:x}, 0x{:x})", device, mode);
 			cemu_assert_debug(device < AX_DEV_COUNT);
 			cemu_assert_debug(mode <= 4);
 
@@ -729,7 +729,7 @@ namespace snd
 			}
 			else
 			{
-				sndApiLog_printf("ERROR: MIXSetDeviceSoundMode(0x%x, 0x%x) -> wrong device", device, mode);
+				cemuLog_log(LogType::SoundAPI, "ERROR: MIXSetDeviceSoundMode(0x{:x}, 0x{:x}) -> wrong device", device, mode);
 			}
 
 			for (sint32 i = 0; i < g_snd_user_data.max_voices; ++i)
@@ -815,7 +815,7 @@ namespace snd
 
 		void MIXInitInputControl(AXVPB* voice, uint16 input, uint32 mode)
 		{
-			sndApiLog_printf("MIXInitInputControl(0x%x, 0x%x, 0x%x )", MEMPTR(voice).GetMPTR(), input, mode);
+			cemuLog_log(LogType::SoundAPI, "MIXInitInputControl(0x{:x}, 0x{:x}, 0x{:x} )", MEMPTR(voice).GetMPTR(), input, mode);
 			cemu_assert_debug(voice);
 
 			AXVoiceBegin(voice);
@@ -920,7 +920,7 @@ namespace snd
 
 		void SPInitSoundTable(SPSoundTable* soundTable, uint8* samples, uint32be* endOffsetPtr)
 		{
-			sndApiLog_printf("SPInitSoundTable(0x%x, 0x%x, 0x%x )", MEMPTR(soundTable).GetMPTR(), MEMPTR(samples).GetMPTR(), MEMPTR(endOffsetPtr).GetMPTR());
+			cemuLog_log(LogType::SoundAPI, "SPInitSoundTable(0x{:x}, 0x{:x}, 0x{:x} )", MEMPTR(soundTable).GetMPTR(), MEMPTR(samples).GetMPTR(), MEMPTR(endOffsetPtr).GetMPTR());
 			if (!soundTable)
 				return;
 
@@ -984,7 +984,7 @@ namespace snd
 
 		SPSoundEntry* SPGetSoundEntry(SPSoundTable* soundTable, uint32 index)
 		{
-			sndApiLog_printf("SPGetSoundEntry(0x%x, %d)", MEMPTR(soundTable).GetMPTR(), index);
+			cemuLog_log(LogType::SoundAPI, "SPGetSoundEntry(0x{:x}, {})", MEMPTR(soundTable).GetMPTR(), index);
 			if (!soundTable)
 				return nullptr;
 

--- a/src/Cafe/OS/libs/snd_user/snd_user.cpp
+++ b/src/Cafe/OS/libs/snd_user/snd_user.cpp
@@ -762,7 +762,7 @@ namespace snd
 
 		void MIXInitDeviceControl(AXVPB* voice, uint32 device_type, uint32 index, MixControl* control, uint32 mode)
 		{
-			sndApiLog_printf("MIXInitDeviceControl(0x%0x, 0x%x, 0x%x, 0x%x, 0x%x )", MEMPTR(voice).GetMPTR(), device_type, index, MEMPTR(control).GetMPTR(), mode);
+			cemuLog_log(LogType::SoundAPI, "MIXInitDeviceControl(0x{:0x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x} )", MEMPTR(voice).GetMPTR(), device_type, index, MEMPTR(control).GetMPTR(), mode);
 
 			cemu_assert_debug(device_type < AX_DEV_COUNT);
 			cemu_assert_debug(voice);

--- a/src/Cafe/OS/libs/snd_user/snd_user.cpp
+++ b/src/Cafe/OS/libs/snd_user/snd_user.cpp
@@ -594,7 +594,7 @@ namespace snd
 
 		void MIXDRCInitChannel(AXVPB* voice, uint16 mode, uint16 vol1, uint16 vol2, uint16 vol3)
 		{
-			sndApiLog_printf("MIXDRCInitChannel(0x%x, 0x%x, 0x%x, 0x%x)", MEMPTR(voice).GetMPTR(), mode, vol1, vol2, vol3);
+			cemuLog_log(LogType::SoundAPI, "MIXDRCInitChannel(0x{:x}, 0x{:x}, 0x{:x}, 0x{:x}, 0x{:x})", MEMPTR(voice).GetMPTR(), mode, vol1, vol2, vol3);
 			cemu_assert_debug(voice);
 
 			AXVoiceBegin(voice);


### PR DESCRIPTION
Converts all instances of the sndApiLog_printf() logging method with the newer cemuLog_log().

Part of #703