### PR TITLE
Update URLs related towards cemu_graphic_packs repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cemu is currently only available for 64-bit Windows, Linux & macOS devices.
 
 #### Other relevant repositories:
  - [Cemu-Language](https://github.com/cemu-project/Cemu-Language)
- - [Cemu's Community Graphic Packs](https://github.com/ActualMandM/cemu_graphic_packs)
+ - [Cemu's Community Graphic Packs](https://github.com/cemu-project/cemu_graphic_packs)
 
 ## Download
 

--- a/src/gui/DownloadGraphicPacksWindow.cpp
+++ b/src/gui/DownloadGraphicPacksWindow.cpp
@@ -137,7 +137,7 @@ void DownloadGraphicPacksWindow::UpdateThread()
 	{
 		// cemu api request failed, use hardcoded github url
 		cemuLog_log(LogType::Force, "Graphic pack update request failed or returned invalid URL. Using default repository URL instead");
-		githubAPIUrl = "https://api.github.com/repos/slashiee/cemu_graphic_packs/releases/latest";
+		githubAPIUrl = "https://api.github.com/repos/cemu-project/cemu_graphic_packs/releases/latest";
 	}
 	// github API request
 	if (curlDownloadFile(githubAPIUrl.c_str(), &tempDownloadState) == false)


### PR DESCRIPTION
This PR updates the URLs for the graphic pack repo to the new maintainer (cemu-project) in both the README and the hardcoded URL fallback.