### PR TITLE
Logging migration (forceLogDebug_printf)

### DIFF
--- a/src/Cafe/GamePatch.cpp
+++ b/src/Cafe/GamePatch.cpp
@@ -350,7 +350,7 @@ void GamePatch_scan()
 	hleAddr = hle_locate(ffl_floatArrayEndianSwap, NULL, sizeof(ffl_floatArrayEndianSwap));
 	if (hleAddr)
 	{
-		forceLogDebug_printf("HLE: Hook FFL float array endian swap function at 0x%08x", hleAddr);
+		cemuLog_logDebug(LogType::Force, "HLE: Hook FFL float array endian swap function at 0x{:08x}", hleAddr);
 		sint32 functionIndex = hleIndex_h000000003;
 		uint32 opcode = (1 << 26) | (functionIndex); // opcode for HLE: 0x1000 + FunctionIndex
 		memory_write<uint32>(hleAddr, opcode);
@@ -360,7 +360,7 @@ void GamePatch_scan()
 	//hleAddr = hle_locate(xcx_enterCriticalSectionSignature, xcx_enterCriticalSectionMask, sizeof(xcx_enterCriticalSectionSignature));
 	//if (hleAddr)
 	//{
-	//	forceLogDebug_printf("HLE: Hook XCX enterCriticalSection function at 0x%08x", hleAddr);
+	//	cemuLog_logDebug(LogType::Force, "HLE: Hook XCX enterCriticalSection function at 0x{:08x}", hleAddr);
 	//	hleIndex_h000000004 = osLib_getFunctionIndex("hle", "h000000004");
 	//	sint32 functionIndex = hleIndex_h000000004;
 	//	uint32 opcode = (1 << 26) | (functionIndex); // opcode for HLE: 0x1000 + FunctionIndex
@@ -387,7 +387,7 @@ void GamePatch_scan()
 	hleAddr = hle_locate(smash4_softlockFixV0Signature, smash4_softlockFixV0Mask, sizeof(smash4_softlockFixV0Signature));
 	if (hleAddr)
 	{
-		forceLogDebug_printf("Smash softlock fix: 0x%08x", hleAddr);
+		cemuLog_logDebug(LogType::Force, "Smash softlock fix: 0x{:08x}", hleAddr);
 		memory_writeU32(hleAddr+0x20, memory_readU32(hleAddr+0x1C));
 	}
 
@@ -396,7 +396,7 @@ void GamePatch_scan()
 	hleAddr = hle_locate(pmcs_yellowPaintStarCrashV0Signature, nullptr, sizeof(pmcs_yellowPaintStarCrashV0Signature));
 	if (hleAddr)
 	{
-		forceLogDebug_printf("Color Splash crash fix: 0x%08x", hleAddr);
+		cemuLog_logDebug(LogType::Force, "Color Splash crash fix: 0x{:08x}", hleAddr);
 		uint32 funcAddr = PPCInterpreter_makeCallableExportDepr(hleExport_pmcs_yellowPaintStarCrashWorkaround);
 		// set absolute jump
 		uint32 opc = 0x48000000;

--- a/src/Cafe/HW/ACR/ACR.cpp
+++ b/src/Cafe/HW/ACR/ACR.cpp
@@ -31,7 +31,7 @@ namespace HW_ACR
 
 	void ACR_VIDATA_W32(PAddr addr, HWREG::ACR_VI_DATA newValue)
 	{
-		forceLogDebug_printf("ACR_VIDATA write %08x with selected reg %08x", newValue.get_DATA(), g_acr.viAddr.get_ADDR());
+		cemuLog_logDebug(LogType::Force, "ACR_VIDATA write {:08x} with selected reg {:08x}", newValue.get_DATA(), g_acr.viAddr.get_ADDR());
 	}
 
 	/* 0x0D000224 | Controls the selected VI register? */

--- a/src/Cafe/HW/ACR/ACR.cpp
+++ b/src/Cafe/HW/ACR/ACR.cpp
@@ -25,7 +25,7 @@ namespace HW_ACR
 	/* 0x0D00021C | Accesses VI register currently selected by VIADDR */
 	HWREG::ACR_VI_DATA ACR_VIDATA_R32(PAddr addr)
 	{
-		forceLogDebug_printf("ACR_VIDATA read with selected reg %08x", g_acr.viAddr.get_ADDR());
+		cemuLog_logDebug(LogType::Force, "ACR_VIDATA read with selected reg {:08x}", g_acr.viAddr.get_ADDR());
 		return HWREG::ACR_VI_DATA();
 	}
 

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterALU.hpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterALU.hpp
@@ -412,7 +412,7 @@ static void PPCInterpreter_DIVW(PPCInterpreter_t* hCPU, uint32 opcode)
 	sint32 b = hCPU->gpr[rB];
 	if (b == 0)
 	{
-		forceLogDebug_printf("Error: Division by zero! [%08x]\n", (uint32)hCPU->instructionPointer);
+		cemuLog_logDebug(LogType::Force, "Error: Division by zero! [{:08x}]", (uint32)hCPU->instructionPointer);
 		b++;
 	}
 	hCPU->gpr[rD] = a / b;

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterALU.hpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterALU.hpp
@@ -412,7 +412,7 @@ static void PPCInterpreter_DIVW(PPCInterpreter_t* hCPU, uint32 opcode)
 	sint32 b = hCPU->gpr[rB];
 	if (b == 0)
 	{
-		forceLogDebug_printf("Error: Division by zero! [%08X]\n", (uint32)hCPU->instructionPointer);
+		forceLogDebug_printf("Error: Division by zero! [%08x]\n", (uint32)hCPU->instructionPointer);
 		b++;
 	}
 	hCPU->gpr[rD] = a / b;

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterImpl.cpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterImpl.cpp
@@ -237,7 +237,7 @@ public:
 			lookupHash = ~lookupHash;
 		}
 
-		forceLogDebug_printf("DSI exception at 0x%08x LR 0x%08x DataAddress %08x", hCPU->instructionPointer, hCPU->spr.LR, vAddr);
+		cemuLog_logDebug(LogType::Force, "DSI exception at 0x{:08x} DataAddress {:08x}", hCPU->instructionPointer, vAddr);
 
 		generateDSIException(hCPU, vAddr);
 
@@ -378,12 +378,12 @@ public:
 		if (pAddr >= 0x01FFF000 && pAddr < 0x02000000)
 		{
 			debug_printf("Access u32 boot param block 0x%08x IP %08x LR %08x\n", pAddr, hCPU->instructionPointer, hCPU->spr.LR);
-			forceLogDebug_printf("Access u32 boot param block 0x%08x (org %08x) IP %08x LR %08x\n", pAddr, address, hCPU->instructionPointer, hCPU->spr.LR);
+			cemuLog_logDebug(LogType::Force, "Access u32 boot param block 0x{:08x} (org {:08x}) IP {:08x}", pAddr, address, hCPU->instructionPointer);
 		}
 		if (pAddr >= 0xFFEB73B0 && pAddr < (0xFFEB73B0+0x40C))
 		{
 			debug_printf("Access cached u32 boot param block 0x%08x IP %08x LR %08x\n", pAddr, hCPU->instructionPointer, hCPU->spr.LR);
-			forceLogDebug_printf("Access cached u32 boot param block 0x%08x (org %08x) IP %08x LR %08x\n", pAddr, address, hCPU->instructionPointer, hCPU->spr.LR);
+			cemuLog_logDebug(LogType::Force, "Access cached u32 boot param block 0x{:08x} (org {:08x}) IP {:08x}", pAddr, address, hCPU->instructionPointer);
 		}
 
 		if (pAddr >= 0x0c000000 && pAddr < 0x0d100000)

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.cpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.cpp
@@ -12,7 +12,7 @@
 
 void PPCInterpreter_MFMSR(PPCInterpreter_t* hCPU, uint32 Opcode)
 {
-	forceLogDebug_printf("Rare instruction: MFMSR");
+	cemuLog_logDebug(LogType::Force, "Rare instruction: MFMSR");
 	if (hCPU->sprExtended.msr & MSR_PR)
 	{
 		PPC_ASSERT(true);
@@ -28,7 +28,7 @@ void PPCInterpreter_MFMSR(PPCInterpreter_t* hCPU, uint32 Opcode)
 
 void PPCInterpreter_MTMSR(PPCInterpreter_t* hCPU, uint32 Opcode)
 {
-	forceLogDebug_printf("Rare instruction: MTMSR");
+	cemuLog_logDebug(LogType::Force, "Rare instruction: MTMSR");
 	if (hCPU->sprExtended.msr & MSR_PR)
 	{
 		PPC_ASSERT(true);
@@ -43,7 +43,7 @@ void PPCInterpreter_MTMSR(PPCInterpreter_t* hCPU, uint32 Opcode)
 
 void PPCInterpreter_MTFSB1X(PPCInterpreter_t* hCPU, uint32 Opcode)
 {
-	forceLogDebug_printf("Rare instruction: MTFSB1X");
+	cemuLog_logDebug(LogType::Force, "Rare instruction: MTFSB1X");
 	int crbD, n1, n2;
 	PPC_OPC_TEMPL_X(Opcode, crbD, n1, n2);
 	if (crbD != 1 && crbD != 2) 
@@ -212,7 +212,7 @@ void PPCInterpreter_BCLRX(PPCInterpreter_t* hCPU, uint32 Opcode)
 		if (hCPU->spr.CTR == 0)
 		{
 			PPC_ASSERT(true);
-			forceLogDebug_printf("Decrementer underflow!\n");
+			cemuLog_logDebug(LogType::Force, "Decrementer underflow!");
 		}
 		hCPU->spr.CTR--;
 	}
@@ -352,7 +352,7 @@ void PPCInterpreter_ISYNC(PPCInterpreter_t* hCPU, uint32 Opcode)
 
 void PPCInterpreter_RFI(PPCInterpreter_t* hCPU, uint32 Opcode)
 {
-	forceLogDebug_printf("RFI");
+	cemuLog_logDebug(LogType::Force, "RFI");
 	hCPU->sprExtended.msr &= ~(0x87C0FF73 | 0x00040000);
 	hCPU->sprExtended.msr |= hCPU->sprExtended.srr1 & 0x87c0ff73;
 	hCPU->sprExtended.msr |= MSR_RI;

--- a/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.cpp
+++ b/src/Cafe/HW/Espresso/Interpreter/PPCInterpreterOPC.cpp
@@ -331,7 +331,7 @@ void PPCInterpreter_EIEIO(PPCInterpreter_t* hCPU, uint32 Opcode)
 
 void PPCInterpreter_SC(PPCInterpreter_t* hCPU, uint32 Opcode)
 {
-	forceLogDebug_printf("SC executed at 0x%08x", hCPU->instructionPointer);
+	cemuLog_logDebug(LogType::Force, "SC executed at 0x{:08x}", hCPU->instructionPointer);
 	// next instruction
 	PPCInterpreter_nextInstruction(hCPU);
 }

--- a/src/Cafe/HW/Espresso/PPCSchedulerLLE.cpp
+++ b/src/Cafe/HW/Espresso/PPCSchedulerLLE.cpp
@@ -163,7 +163,7 @@ void smdpArea_processCommand(smdpArea_t* smdpArea, smdpCommand_t* cmd)
 	{
 		cmd->ukn08 = 1;
 		// cmd->ukn2C ?
-		forceLogDebug_printf("SMDP command received - todo");
+		cemuLog_logDebug(LogType::Force, "SMDP command received - todo");
 		smdpArea_pushResult(smdpArea, memory_getVirtualOffsetFromPointer(cmd));
 	}
 	else

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
@@ -500,7 +500,7 @@ void PPCRecompiler_init()
 	codeRegionEnd = (codeRegionEnd + PPC_REC_ALLOC_BLOCK_SIZE - 1) & ~(PPC_REC_ALLOC_BLOCK_SIZE - 1);
 
 	uint32 codeRegionSize = codeRegionEnd - PPC_REC_CODE_AREA_START;
-	forceLogDebug_printf("Allocating recompiler tables for range 0x%08x-0x%08x", PPC_REC_CODE_AREA_START, codeRegionEnd);
+	cemuLog_logDebug(LogType::Force, "Allocating recompiler tables for range 0x{:08x}-0x{:08x}", PPC_REC_CODE_AREA_START, codeRegionEnd);
 
 	for (uint32 i = 0; i < codeRegionSize; i += PPC_REC_ALLOC_BLOCK_SIZE)
 	{

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompilerImlRegisterAllocator2.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompilerImlRegisterAllocator2.cpp
@@ -192,7 +192,7 @@ void _PPCRecRA_checkAndTryExtendRange(ppcImlGenContext_t* ppcImlGenContext, PPCR
 {
 	if (routeDepth >= 64)
 	{
-		forceLogDebug_printf("Recompiler RA route maximum depth exceeded for function 0x%08x\n", ppcImlGenContext->functionRef->ppcAddress);
+		cemuLog_logDebug(LogType::Force, "Recompiler RA route maximum depth exceeded for function 0x{:08x}", ppcImlGenContext->functionRef->ppcAddress);
 		return;
 	}
 	route[routeDepth] = currentSegment;

--- a/src/Cafe/HW/Latte/Core/LatteAsyncCommands.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteAsyncCommands.cpp
@@ -120,7 +120,7 @@ void LatteAsyncCommands_checkAndExecute()
 			}
 			else
 			{
-				forceLogDebug_printf("Texture not found for readback");
+				cemuLog_logDebug(LogType::Force, "Texture not found for readback");
 			}
 		}
 		else if (asyncCommand.type == ASYNC_CMD_DELETE_SHADER)

--- a/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
@@ -304,7 +304,7 @@ public:
 	{
 		if ((rangeBegin & 0xF))
 		{
-			forceLogDebug_printf("writeStreamout(): RangeBegin not aligned to 16. Begin %08x End %08x", rangeBegin, rangeEnd);
+			cemuLog_logDebug(LogType::Force, "writeStreamout(): RangeBegin not aligned to 16. Begin {:08x} End {:08x}", rangeBegin, rangeEnd);
 			rangeBegin = (rangeBegin + 0xF) & ~0xF;
 			rangeEnd = std::max(rangeBegin, rangeEnd);
 		}

--- a/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
@@ -313,7 +313,7 @@ public:
 			// todo - add support for 4 byte granularity for streamout writes and cache
 			// used by Affordable Space Adventures and YWW Level 1-8
 			// also used by CoD Ghosts (8 byte granularity)
-			//forceLogDebug_printf("Streamout write size is not aligned to 16 bytes");
+			//cemuLog_logDebug(LogType::Force, "Streamout write size is not aligned to 16 bytes");
 			rangeEnd &= ~0xF;
 		}
 		//cemu_assert_debug((rangeEnd & 0xF) == 0);

--- a/src/Cafe/HW/Latte/Core/LatteCachedFBO.h
+++ b/src/Cafe/HW/Latte/Core/LatteCachedFBO.h
@@ -50,12 +50,12 @@ private:
 			}
 			if (effectiveWidth < rtEffectiveSize.x)
 			{
-				forceLogDebug_printf("Framebuffer has color texture with smaller effective width (%d -> %d)", rtEffectiveSize.x, effectiveWidth);
+				cemuLog_logDebug(LogType::Force, "Framebuffer has color texture with smaller effective width ({} -> {})", rtEffectiveSize.x, effectiveWidth);
 				rtEffectiveSize.x = effectiveWidth;
 			}
 			if (effectiveHeight < rtEffectiveSize.y)
 			{
-				forceLogDebug_printf("Framebuffer has color texture with smaller effective height (%d -> %d)", rtEffectiveSize.y, effectiveHeight);
+				cemuLog_logDebug(LogType::Force, "Framebuffer has color texture with smaller effective height ({} -> {})", rtEffectiveSize.y, effectiveHeight);
 				rtEffectiveSize.y = effectiveHeight;
 			}
 			numViews++;
@@ -72,12 +72,12 @@ private:
 			}
 			if (effectiveWidth < rtEffectiveSize.x)
 			{
-				forceLogDebug_printf("Framebuffer has depth texture with smaller effective width (%d -> %d)", rtEffectiveSize.x, effectiveWidth);
+				cemuLog_logDebug(LogType::Force, "Framebuffer has depth texture with smaller effective width ({} -> {})", rtEffectiveSize.x, effectiveWidth);
 				rtEffectiveSize.x = effectiveWidth;
 			}
 			if (effectiveHeight < rtEffectiveSize.y)
 			{
-				forceLogDebug_printf("Framebuffer has depth texture with smaller effective height (%d -> %d)", rtEffectiveSize.y, effectiveHeight);
+				cemuLog_logDebug(LogType::Force, "Framebuffer has depth texture with smaller effective height ({} -> {})", rtEffectiveSize.y, effectiveHeight);
 				rtEffectiveSize.y = effectiveHeight;
 			}
 			numViews++;

--- a/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
@@ -638,7 +638,7 @@ LatteCMDPtr LatteCP_itDrawIndexAuto(LatteCMDPtr cmd, uint32 nWords, DrawPassCont
 	{
 		uint32 vsProgramCode = ((LatteGPUState.contextRegister[mmSQ_PGM_START_ES] & 0xFFFFFF) << 8);
 		uint32 vsProgramSize = LatteGPUState.contextRegister[mmSQ_PGM_START_ES + 1] << 3;
-		forceLogDebug_printf("Compute %d %08x %08x (unsupported)\n", count, vsProgramCode, vsProgramSize);
+		cemuLog_logDebug(LogType::Force, "Compute {} {:08x} {:08x} (unsupported)", count, vsProgramCode, vsProgramSize);
 	}
 	else
 	{

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -611,7 +611,7 @@ bool LatteMRT::UpdateCurrentFBO()
 				{
 					if (_depthBufferSizeWarningCount < 100)
 					{
-						forceLogDebug_printf("Depth buffer size too small. Effective size: %dx%d Real size: %dx%d Mismatching texture: %08x %dx%d fmt %04x", effectiveWidth, effectiveHeight, depthBufferView->baseTexture->width, depthBufferView->baseTexture->height, depthBufferView->baseTexture->physAddress, depthBufferView->baseTexture->width, depthBufferView->baseTexture->height, (uint32)depthBufferView->baseTexture->format);
+						cemuLog_logDebug(LogType::Force, "Depth buffer size too small. Effective size: {}x{} Real size: {}x{} Mismatching texture: {:08x} {}x{} fmt {:04x}", effectiveWidth, effectiveHeight, depthBufferView->baseTexture->width, depthBufferView->baseTexture->height, depthBufferView->baseTexture->physAddress, depthBufferView->baseTexture->width, depthBufferView->baseTexture->height, (uint32)depthBufferView->baseTexture->format);
 						_depthBufferSizeWarningCount++;
 					}
 				}

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -721,7 +721,7 @@ void LatteRenderTarget_applyTextureColorClear(LatteTexture* texture, uint32 slic
 {
 	if (texture->isDepth)
 	{
-		forceLogDebug_printf("Unsupported clear depth as color");
+		cemuLog_logDebug(LogType::Force, "Unsupported clear depth as color");
 	}
 	else
 	{

--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -357,7 +357,7 @@ void LatteShader_FinishCompilation(LatteDecompilerShader* shader)
 {
 	if (shader->hasError)
 	{
-		forceLogDebug_printf("LatteShader_finishCompilation(): Skipped because of error in shader %llx", shader->baseHash);
+		cemuLog_logDebug(LogType::Force, "LatteShader_finishCompilation(): Skipped because of error in shader {:x}", shader->baseHash);
 		return;
 	}
 	shader->shader->WaitForCompiled();

--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -283,7 +283,7 @@ void LatteShader_UpdatePSInputs(uint32* contextRegisters)
 #ifdef CEMU_DEBUG_ASSERT
 			if (semanticMask[psSemanticId >> 3] & (1 << (psSemanticId & 7)))
 			{
-				forceLogDebug_printf("SemanticId already used");
+				cemuLog_logDebug(LogType::Force, "SemanticId already used");
 			}
 			semanticMask[psSemanticId >> 3] |= (1 << (psSemanticId & 7));
 #endif
@@ -339,7 +339,7 @@ void LatteShader_CreateRendererShader(LatteDecompilerShader* shader, bool compil
 		(shader->baseHash == 0x15bc7edf9de2ed30 || shader->baseHash == 0x83a697d61a3b9202 ||
 		 shader->baseHash == 0x97bc44a5028381c6 || shader->baseHash == 0x24838b84d15a1da1))
 	{
-		forceLogDebug_printf("Filtered shader to avoid AMD crash");
+		cemuLog_logDebug(LogType::Force, "Filtered shader to avoid AMD crash");
 		shader->shader = nullptr;
 		shader->hasError = true;
 		return;

--- a/src/Cafe/HW/Latte/Core/LatteSurfaceCopy.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteSurfaceCopy.cpp
@@ -101,7 +101,7 @@ void LatteSurfaceCopy_copySurfaceNew(MPTR srcPhysAddr, MPTR srcMipAddr, uint32 s
 	// download destination texture if it matches known accessed formats
 	if (destinationTexture->width == 8 && destinationTexture->height == 8 && destinationTexture->tileMode == Latte::E_HWTILEMODE::TM_1D_TILED_THIN1)
 	{
-		forceLogDebug_printf("Texture readback after copy for Bayonetta 2 (phys: 0x%08x)", destinationTexture->physAddress);
+		cemuLog_logDebug(LogType::Force, "Texture readback after copy for Bayonetta 2 (phys: 0x{:08x})", destinationTexture->physAddress);
 		LatteTextureReadback_Initate(destinationView);
 	}
 }

--- a/src/Cafe/HW/Latte/Core/LatteTexture.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTexture.cpp
@@ -303,8 +303,8 @@ void LatteTexture_copyData(LatteTexture* srcTexture, LatteTexture* dstTexture, s
 
 		debug_printf("texture_copyData(): Effective size mismatch\n");
 		cemuLog_logDebug(LogType::Force, "texture_copyData(): Effective size mismatch (due to texture rule)");
-		forceLogDebug_printf("Destination: origResolution %04dx%04d effectiveResolution %04dx%04d fmt %04x mipIndex %d", srcTexture->width, srcTexture->height, effectiveWidth_dst, effectiveHeight_dst, (uint32)dstTexture->format, 0);
-		forceLogDebug_printf("Source:      origResolution %04dx%04d effectiveResolution %04dx%04d fmt %04x mipIndex %d", srcTexture->width, srcTexture->height, effectiveWidth_src, effectiveHeight_src, (uint32)srcTexture->format, 0);
+		cemuLog_logDebug(LogType::Force, "Destination: origResolution {:04}x{:04} effectiveResolution {:04}x{:04} fmt {:04x} mipIndex {}", srcTexture->width, srcTexture->height, effectiveWidth_dst, effectiveHeight_dst, (uint32)dstTexture->format, 0);
+		cemuLog_logDebug(LogType::Force, "Source:      origResolution {:04}x{:04} effectiveResolution {:04}x{:04} fmt {:04x} mipIndex {}", srcTexture->width, srcTexture->height, effectiveWidth_src, effectiveHeight_src, (uint32)srcTexture->format, 0);
 		return;
 	}
 	catchOpenGLError();

--- a/src/Cafe/HW/Latte/Core/LatteTexture.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTexture.cpp
@@ -302,7 +302,7 @@ void LatteTexture_copyData(LatteTexture* srcTexture, LatteTexture* dstTexture, s
 		LatteTexture_getEffectiveSize(dstTexture, &effectiveWidth_src, &effectiveHeight_src, NULL, 0);
 
 		debug_printf("texture_copyData(): Effective size mismatch\n");
-		forceLogDebug_printf("texture_copyData(): Effective size mismatch (due to texture rule)");
+		cemuLog_logDebug(LogType::Force, "texture_copyData(): Effective size mismatch (due to texture rule)");
 		forceLogDebug_printf("Destination: origResolution %04dx%04d effectiveResolution %04dx%04d fmt %04x mipIndex %d", srcTexture->width, srcTexture->height, effectiveWidth_dst, effectiveHeight_dst, (uint32)dstTexture->format, 0);
 		forceLogDebug_printf("Source:      origResolution %04dx%04d effectiveResolution %04dx%04d fmt %04x mipIndex %d", srcTexture->width, srcTexture->height, effectiveWidth_src, effectiveHeight_src, (uint32)srcTexture->format, 0);
 		return;
@@ -384,7 +384,7 @@ void LatteTexture_CopySlice(LatteTexture* srcTexture, sint32 srcSlice, sint32 sr
 			cemuLog_log(LogType::Force, "Source:      {:08x} origResolution {:4}/{:4} effectiveResolution {:4}/{:4} fmt {:04x} mipIndex {} ratioW/H: {:.4}/{:.4}", srcTexture->physAddress, srcTexture->width, srcTexture->height, effectiveWidth_src, effectiveHeight_src, (uint32)srcTexture->format, srcMip, ratioWidth_src, ratioHeight_src);
 			cemuLog_log(LogType::Force, "Destination: {:08x} origResolution {:4}/{:4} effectiveResolution {:4}/{:4} fmt {:04x} mipIndex {} ratioW/H: {:.4}/{:.4}", dstTexture->physAddress, dstTexture->width, dstTexture->height, effectiveWidth_dst, effectiveHeight_dst, (uint32)dstTexture->format, dstMip, ratioWidth_dst, ratioHeight_dst);
 		}
-		//forceLogDebug_printf("If these textures are not meant to share data you can ignore this");
+		//cemuLog_logDebug(LogType::Force, "If these textures are not meant to share data you can ignore this");
 		return;
 	}
 	// todo - store 'lastUpdated' value per slice/mip and copy it's value when copying the slice data
@@ -877,7 +877,7 @@ VIEWCOMPATIBILITY LatteTexture_CanTextureBeRepresentedAsView(LatteTexture* baseT
 		if (baseTexture->isDepth && baseTexture->format != format)
 		{
 			// depth view with different format
-			forceLogDebug_printf("_createMapping(): Incompatible depth view format");
+			cemuLog_logDebug(LogType::Force, "_createMapping(): Incompatible depth view format");
 			return VIEW_NOT_COMPATIBLE;
 		}
 
@@ -929,7 +929,7 @@ VIEWCOMPATIBILITY LatteTexture_CanTextureBeRepresentedAsView(LatteTexture* baseT
 				if (baseTexture->isDepth && baseTexture->format != format)
 				{
 					// depth view with different format
-					forceLogDebug_printf("_createMapping(): Incompatible depth view format");
+					cemuLog_logDebug(LogType::Force, "_createMapping(): Incompatible depth view format");
 					return VIEW_NOT_COMPATIBLE;
 				}
 
@@ -1003,7 +1003,7 @@ LatteTextureView* LatteTexture_CreateMapping(MPTR physAddr, MPTR physMipAddr, si
 {
 	if (format == Latte::E_GX2SURFFMT::INVALID_FORMAT)
 	{
-		forceLogDebug_printf("LatteTexture_CreateMapping(): Invalid format");
+		cemuLog_logDebug(LogType::Force, "LatteTexture_CreateMapping(): Invalid format");
 		return nullptr;
 	}
 	// note: When creating an existing texture, we only allow mip and slice expansion at the end

--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
@@ -818,7 +818,7 @@ void LatteTextureLoader_writeReadbackTextureToMemory(LatteTextureDefinition* tex
 		}
 		else
 		{
-			forceLogDebug_printf("Linear texture readback unsupported for format 0x%04x", (uint32)textureData->format);
+			cemuLog_logDebug(LogType::Force, "Linear texture readback unsupported for format 0x{:04x}", (uint32)textureData->format);
 			debugBreakpoint();
 		}
 		return;

--- a/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureLoader.cpp
@@ -856,7 +856,7 @@ void LatteTextureLoader_writeReadbackTextureToMemory(LatteTextureDefinition* tex
 	}	
 	else
 	{
-		forceLogDebug_printf("Texture readback unsupported format %04x for tileMode 0x%02x", (uint32)textureData->format, textureData->tileMode);
+		cemuLog_logDebug(LogType::Force, "Texture readback unsupported format {:04x} for tileMode 0x{:02x}", (uint32)textureData->format, textureData->tileMode);
 	}
 
 }

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.cpp
@@ -932,7 +932,7 @@ void LatteDecompiler_ParseTEXClause(LatteDecompilerShader* shaderContext, LatteD
 		}
 		else
 		{
-			forceLogDebug_printf("Unsupported tex instruction %d\n", inst0_4);
+			cemuLog_logDebug(LogType::Force, "Unsupported tex instruction {}", inst0_4);
 			shaderContext->hasError = true;
 			break;
 		}

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -310,7 +310,7 @@ void LatteDecompiler_analyzeTEXClause(LatteDecompilerShaderContext* shaderContex
 		{
 			if (texInstruction.textureFetch.textureIndex < 0 || texInstruction.textureFetch.textureIndex >= LATTE_NUM_MAX_TEX_UNITS)
 			{
-				forceLogDebug_printf("Shader %llx has out of bounds texture access (texture %d)", shaderContext->shader->baseHash, (sint32)texInstruction.textureFetch.textureIndex);
+				cemuLog_logDebug(LogType::Force, "Shader {:x} has out of bounds texture access (texture {})", shaderContext->shader->baseHash, (sint32)texInstruction.textureFetch.textureIndex);
 				continue;
 			}
 			if( texInstruction.textureFetch.samplerIndex < 0 || texInstruction.textureFetch.samplerIndex >= 0x12 )

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -984,7 +984,7 @@ void LatteDecompiler_analyze(LatteDecompilerShaderContext* shaderContext, LatteD
 		cemu_assert_debug(false);
 	}
 	if(list_subroutineAddrs.empty() == false)
-		forceLogDebug_printf("Todo - analyze shader subroutine CF stack");
+		cemuLog_logDebug(LogType::Force, "Todo - analyze shader subroutine CF stack");
 	// TF mode
 	if (shaderContext->options->useTFViaSSBO && shaderContext->output->streamoutBufferWriteMask.any())
 	{

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -310,7 +310,7 @@ void LatteDecompiler_analyzeTEXClause(LatteDecompilerShaderContext* shaderContex
 		{
 			if (texInstruction.textureFetch.textureIndex < 0 || texInstruction.textureFetch.textureIndex >= LATTE_NUM_MAX_TEX_UNITS)
 			{
-				cemuLog_logDebug(LogType::Force, "Shader {:x} has out of bounds texture access (texture {})", shaderContext->shader->baseHash, (sint32)texInstruction.textureFetch.textureIndex);
+				cemuLog_logDebug(LogType::Force, "Shader {:16x} has out of bounds texture access (texture {})", shaderContext->shader->baseHash, (sint32)texInstruction.textureFetch.textureIndex);
 				continue;
 			}
 			if( texInstruction.textureFetch.samplerIndex < 0 || texInstruction.textureFetch.samplerIndex >= 0x12 )

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLAttrDecoder.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLAttrDecoder.cpp
@@ -488,7 +488,7 @@ void LatteDecompiler_emitAttributeDecodeGLSL(LatteDecompilerShader* shaderContex
 		}
 		else
 		{
-			forceLogDebug_printf("_emitAttributeDecodeGLSL(): Unsupported fmt {:02x} nfa {} signed {} endian {}\n", attrib->format, attrib->nfa, attrib->isSigned, attrib->endianSwap);
+			cemuLog_logDebug(LogType::Force, "_emitAttributeDecodeGLSL(): Unsupported fmt {:02x} nfa {} signed {} endian {}", attrib->format, attrib->nfa, attrib->isSigned, attrib->endianSwap);
 		}
 	}
 	else

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/LatteTextureViewGL.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/LatteTextureViewGL.cpp
@@ -59,7 +59,7 @@ void LatteTextureViewGL::InitAliasView()
 	if (baseTexture->isDepth)
 	{
 		// depth is handled differently
-		forceLogDebug_printf("Creating depth view");
+		cemuLog_logDebug(LogType::Force, "Creating depth view");
 		cemu_assert(format == texture->format); // todo
 		glInternalFormat = texture->glInternalFormat;
 	}
@@ -73,7 +73,7 @@ void LatteTextureViewGL::InitAliasView()
 	catchOpenGLError();
 	if (firstMip >= texture->maxPossibleMipLevels)
 	{
-		forceLogDebug_printf("_createNewView: Out of bounds mip level requested");
+		cemuLog_logDebug(LogType::Force, "_createNewView: Out of bounds mip level requested");
 		glTextureView(glTexId, glTexTarget, texture->glId_texture, glInternalFormat, texture->maxPossibleMipLevels - 1, numMip, firstSlice, this->numSlice);
 	}
 	else

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -1075,7 +1075,7 @@ void OpenGLRenderer_texture_loadSlice_normal(LatteTexture* hostTextureGeneric, s
 			if (mipIndex < hostTexture->maxPossibleMipLevels)
 				glTexSubImage2D(GL_TEXTURE_2D, mipIndex, 0, 0, effectiveWidth, effectiveHeight, glFormatInfo.glSuppliedFormat, glFormatInfo.glSuppliedFormatType, pixelData);
 			else
-				forceLogDebug_printf("2D texture mip level allocated out of range");
+				cemuLog_logDebug(LogType::Force, "2D texture mip level allocated out of range");
 		}
 	}
 	else if (hostTexture->dim == Latte::E_DIM::DIM_1D)
@@ -1201,12 +1201,12 @@ void OpenGLRenderer::texture_clearSlice(LatteTexture* hostTextureGeneric, sint32
 	{
 		if (formatInfoGL.glIsCompressed)
 		{
-			forceLogDebug_printf("Unsupported clear for compressed texture");
+			cemuLog_logDebug(LogType::Force, "Unsupported clear for compressed texture");
 			return; // todo - create integer texture view to clear compressed textures
 		}
 		if (hostTextureGeneric->isDepth)
 		{
-			forceLogDebug_printf("Unsupported clear for depth texture");
+			cemuLog_logDebug(LogType::Force, "Unsupported clear for depth texture");
 			return; // todo - use depth clear
 		}
 
@@ -1365,7 +1365,7 @@ void OpenGLRenderer::texture_copyImageSubData(LatteTexture* src, sint32 srcMip, 
 		}
 		else
 		{
-			forceLogDebug_printf("_syncSlice() called with unhandled alternative format");
+			cemuLog_logDebug(LogType::Force, "_syncSlice() called with unhandled alternative format");
 			return;
 		}
 	}

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRendererCore.cpp
@@ -467,7 +467,7 @@ void LatteDrawGL_prepareIndicesWithGPUCache(MPTR indexDataMPTR, _INDEX_TYPE inde
 		uint32 h = LatteDrawGL_calculateIndexDataHash(memory_getPointerFromPhysicalOffset(indexDataMPTR), cacheEntryItr->physSize);
 		if (cacheEntryItr->hash != h)
 		{
-			forceLogDebug_printf("IndexData hash changed");
+			cemuLog_logDebug(LogType::Force, "IndexData hash changed");
 			_decodeAndUploadIndexData(cacheEntryItr);
 			cacheEntryItr->hash = h;
 		}
@@ -527,7 +527,7 @@ void LatteDrawGL_prepareIndicesWithGPUCache(MPTR indexDataMPTR, _INDEX_TYPE inde
 void LatteDraw_handleSpecialState8_clearAsDepth()
 {
 	if (LatteGPUState.contextNew.GetSpecialStateValues()[0] == 0)
-		forceLogDebug_printf("Special state 8 requires special state 0 but it is not set?");
+		cemuLog_logDebug(LogType::Force, "Special state 8 requires special state 0 but it is not set?");
 	// get depth buffer information
 	uint32 regDepthBuffer = LatteGPUState.contextRegister[mmDB_HTILE_DATA_BASE];
 	uint32 regDepthSize = LatteGPUState.contextRegister[mmDB_DEPTH_SIZE];

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/TextureReadbackGL.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/TextureReadbackGL.cpp
@@ -76,7 +76,7 @@ LatteTextureReadbackInfoGL::LatteTextureReadbackInfoGL(LatteTextureView* texture
 	}
 	else
 	{
-		forceLogDebug_printf("Unsupported texture readback format %04x\n", (uint32)textureView->format);
+		cemuLog_logDebug(LogType::Force, "Unsupported texture readback format {:04x}", (uint32)textureView->format);
 		return;
 	}
 }

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -173,7 +173,7 @@ RendererOutputShader::RendererOutputShader(const std::string& vertex_source, con
 	}
 	else
 	{
-		forceLogDebug_printf("RendererOutputShader() - todo for Vulkan");
+		cemuLog_logDebug(LogType::Force, "RendererOutputShader() - todo for Vulkan");
 		m_attributes[0].m_loc_texture_src_resolution = -1;
 		m_attributes[0].m_loc_input_resolution = -1;
 		m_attributes[0].m_loc_output_resolution = -1;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -407,6 +407,6 @@ VkSwapchainCreateInfoKHR SwapchainInfoVk::CreateSwapchainCreateInfo(VkSurfaceKHR
 	createInfo.presentMode = ChoosePresentMode(swapchainSupport.presentModes);
 	createInfo.clipped = VK_TRUE;
 
-	forceLogDebug_printf("vulkan presentation mode: %d", createInfo.presentMode);
+	cemuLog_logDebug(LogType::Force, "vulkan presentation mode: {}", createInfo.presentMode);
 	return createInfo;
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
@@ -528,7 +528,7 @@ void PipelineCompiler::InitInputAssemblyState(const Latte::LATTE_VGT_PRIMITIVE_T
 		inputAssembly.primitiveRestartEnable = false;
 		break;
 	default:
-		forceLogDebug_printf("Vulkan-Unsupported: Graphics pipeline with primitive mode %d created", primitiveMode);
+		cemuLog_logDebug(LogType::Force, "Vulkan-Unsupported: Graphics pipeline with primitive mode {} created", primitiveMode);
 		cemu_assert_debug(false);
 	}
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -231,7 +231,7 @@ void VulkanPipelineStableCache::LoadPipelineFromCache(std::span<uint8> fileData)
 		vertexShader = LatteSHRC_FindVertexShader(cachedPipeline->vsHash.baseHash, cachedPipeline->vsHash.auxHash);
 		if (!vertexShader)
 		{
-			forceLogDebug_printf("Vertex shader not found in cache");
+			cemuLog_logDebug(LogType::Force, "Vertex shader not found in cache");
 			return;
 		}
 	}
@@ -241,7 +241,7 @@ void VulkanPipelineStableCache::LoadPipelineFromCache(std::span<uint8> fileData)
 		geometryShader = LatteSHRC_FindGeometryShader(cachedPipeline->gsHash.baseHash, cachedPipeline->gsHash.auxHash);
 		if (!geometryShader)
 		{
-			forceLogDebug_printf("Geometry shader not found in cache");
+			cemuLog_logDebug(LogType::Force, "Geometry shader not found in cache");
 			return;
 		}
 	}
@@ -251,7 +251,7 @@ void VulkanPipelineStableCache::LoadPipelineFromCache(std::span<uint8> fileData)
 		pixelShader = LatteSHRC_FindPixelShader(cachedPipeline->psHash.baseHash, cachedPipeline->psHash.auxHash);
 		if (!pixelShader)
 		{
-			forceLogDebug_printf("Pixel shader not found in cache");
+			cemuLog_logDebug(LogType::Force, "Pixel shader not found in cache");
 			return;
 		}
 	}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -3168,7 +3168,7 @@ void VulkanRenderer::texture_clearSlice(LatteTexture* hostTexture, sint32 sliceI
 			auto imageObj = vkTexture->GetImageObj();
 			imageObj->flagForCurrentCommandBuffer();
 
-			forceLogDebug_printf("Compressed texture (%d/%d fmt %04x) unsupported clear", vkTexture->width, vkTexture->height, (uint32)vkTexture->format);
+			cemuLog_logDebug(LogType::Force, "Compressed texture ({}/{} fmt {:04x}) unsupported clear", vkTexture->width, vkTexture->height, (uint32)vkTexture->format);
 
 			VkImageSubresourceLayers subresourceRange{};
 			subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1967,7 +1967,7 @@ void VulkanRenderer::SubmitCommandBuffer(VkSemaphore signalSemaphore, VkSemaphor
 	if (nextCmdBufferIndex == m_commandBufferSyncIndex)
 	{
 		// force wait for the next command buffer
-		forceLogDebug_printf("Vulkan: Waiting for available command buffer...");
+		cemuLog_logDebug(LogType::Force, "Vulkan: Waiting for available command buffer...");
 		WaitForNextFinishedCommandBuffer();
 	}
 	m_commandBufferIndex = nextCmdBufferIndex;
@@ -2085,7 +2085,7 @@ void VulkanRenderer::PipelineCacheSaveThread(size_t cache_size)
 					file.close();
 
 					cache_size = size;
-					forceLogDebug_printf("pipeline cache saved");
+					cemuLog_logDebug(LogType::Force, "pipeline cache saved");
 				}
 				else
 				{
@@ -2123,7 +2123,7 @@ void VulkanRenderer::CreatePipelineCache()
 			file.read((char*)cacheData.data(), cacheData.size());
 			file.close();
 
-			forceLogDebug_printf("pipeline cache loaded");
+			cemuLog_logDebug(LogType::Force, "pipeline cache loaded");
 		}
 	}
 
@@ -3418,7 +3418,7 @@ void VulkanRenderer::texture_copyImageSubData(LatteTexture* src, sint32 srcMip, 
 
 		if (mipWidth < 4 || mipHeight < 4)
 		{
-			forceLogDebug_printf("vkCmdCopyImage - blocked copy for unsupported uncompressed->compressed copy with dst smaller than 4x4");
+			cemuLog_logDebug(LogType::Force, "vkCmdCopyImage - blocked copy for unsupported uncompressed->compressed copy with dst smaller than 4x4");
 			return;
 		}
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanSurfaceCopy.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanSurfaceCopy.cpp
@@ -894,14 +894,14 @@ void VulkanRenderer::surfaceCopy_copySurfaceWithFormatConversion(LatteTexture* s
 	// todo - if not, we have to use drawcall based copying
 	if (!LatteTexture_doesEffectiveRescaleRatioMatch(srcTextureVk, texSrcMip, dstTextureVk, texDstMip))
 	{
-		forceLogDebug_printf("surfaceCopy_copySurfaceViaDrawcall(): Mismatching dimensions");
+		cemuLog_logDebug(LogType::Force, "surfaceCopy_copySurfaceViaDrawcall(): Mismatching dimensions");
 		return;
 	}
 
 	// check if bpp size matches
 	if (srcTextureVk->GetBPP() != dstTextureVk->GetBPP())
 	{
-		forceLogDebug_printf("surfaceCopy_copySurfaceViaDrawcall(): Mismatching BPP");
+		cemuLog_logDebug(LogType::Force, "surfaceCopy_copySurfaceViaDrawcall(): Mismatching BPP");
 		return;
 	}
 

--- a/src/Cafe/HW/MMU/MMU.cpp
+++ b/src/Cafe/HW/MMU/MMU.cpp
@@ -470,7 +470,7 @@ namespace MMU
 		auto itr = g_mmioHandlerW32->find(address);
 		if (itr == g_mmioHandlerW32->end())
 		{
-			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u32 0x{:08x} from unhandeled address 0x{:08x}", value, address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u32 0x{:08x} from unhandled address 0x{:08x}", value, address);
 			return;
 		}
 		return itr->second(address, value);
@@ -482,7 +482,7 @@ namespace MMU
 		auto itr = g_mmioHandlerW16->find(address);
 		if (itr == g_mmioHandlerW16->end())
 		{
-			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u16 0x{:04x} from unhandeled address 0x{:08x}", (uint32)value, address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u16 0x{:04x} from unhandled address 0x{:08x}", (uint32)value, address);
 			return;
 		}
 		return itr->second(address, value);
@@ -497,7 +497,7 @@ namespace MMU
 		auto itr = g_mmioHandlerR32->find(address);
 		if(itr == g_mmioHandlerR32->end())
 		{
-			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u32 from unhandeled address 0x{:08x}", address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u32 from unhandled address 0x{:08x}", address);
 			return 0;
 		}
 		return itr->second(address);
@@ -509,7 +509,7 @@ namespace MMU
 		auto itr = g_mmioHandlerR16->find(address);
 		if (itr == g_mmioHandlerR16->end())
 		{
-			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u16 from unhandeled address 0x{:08x}", address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u16 from unhandled address 0x{:08x}", address);
 			return 0;
 		}
 		return itr->second(address);

--- a/src/Cafe/HW/MMU/MMU.cpp
+++ b/src/Cafe/HW/MMU/MMU.cpp
@@ -497,7 +497,7 @@ namespace MMU
 		auto itr = g_mmioHandlerR32->find(address);
 		if(itr == g_mmioHandlerR32->end())
 		{
-			//forceLogDebug_printf("[MMU] MMIO read u32 from unhandeled address 0x%08x", address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u32 from unhandeled address 0x{:08x}", address);
 			return 0;
 		}
 		return itr->second(address);
@@ -509,7 +509,7 @@ namespace MMU
 		auto itr = g_mmioHandlerR16->find(address);
 		if (itr == g_mmioHandlerR16->end())
 		{
-			//forceLogDebug_printf("[MMU] MMIO read u16 from unhandeled address 0x%08x", address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO read u16 from unhandeled address 0x{:08x}", address);
 			return 0;
 		}
 		return itr->second(address);

--- a/src/Cafe/HW/MMU/MMU.cpp
+++ b/src/Cafe/HW/MMU/MMU.cpp
@@ -470,7 +470,7 @@ namespace MMU
 		auto itr = g_mmioHandlerW32->find(address);
 		if (itr == g_mmioHandlerW32->end())
 		{
-			//forceLogDebug_printf("[MMU] MMIO write u32 0x%08x from unhandeled address 0x%08x", value, address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u32 0x{:08x} from unhandeled address 0x{:08x}", value, address);
 			return;
 		}
 		return itr->second(address, value);
@@ -482,7 +482,7 @@ namespace MMU
 		auto itr = g_mmioHandlerW16->find(address);
 		if (itr == g_mmioHandlerW16->end())
 		{
-			//forceLogDebug_printf("[MMU] MMIO write u16 0x%04x from unhandeled address 0x%08x", (uint32)value, address);
+			//cemuLog_logDebug(LogType::Force, "[MMU] MMIO write u16 0x{:04x} from unhandeled address 0x{:08x}", (uint32)value, address);
 			return;
 		}
 		return itr->second(address, value);

--- a/src/Cafe/HW/SI/SI.cpp
+++ b/src/Cafe/HW/SI/SI.cpp
@@ -87,7 +87,7 @@ namespace HW_SI
 
 	HWREG::SICOMCSR SI_COMCSR_R32(PAddr addr)
 	{
-		//forceLogDebug_printf("Read SICOMCSR");
+		//cemuLog_logDebug(LogType::Force, "Read SICOMCSR");
 		return g_si.registerState.sicomcsr;
 	}
 

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -317,7 +317,7 @@ namespace iosu
 			FSCVirtualFile* fscFile = sFileHandleTable.GetByHandle(fileHandle);
 			if (!fscFile)
 			{
-				forceLogDebug_printf("__FSACloseFile(): Invalid handle (0x%08x)", fileHandle);
+				cemuLog_logDebug(LogType::Force, "__FSACloseFile(): Invalid handle (0x{:08x})", fileHandle);
 				return (FSStatus)FS_RESULT::ERR_PLACEHOLDER;
 			}
 			// unregister file
@@ -587,7 +587,7 @@ namespace iosu
 			FSCVirtualFile* fscFile = sDirHandleTable.GetByHandle((sint32)cmd->cmdReadDir.dirHandle);
 			if (!fscFile)
 			{
-				forceLogDebug_printf("CloseDir: Invalid handle (0x%08x)", (sint32)cmd->cmdReadDir.dirHandle);
+				cemuLog_logDebug(LogType::Force, "CloseDir: Invalid handle (0x{:08x})", (sint32)cmd->cmdReadDir.dirHandle);
 				return (FSStatus)FS_RESULT::ERR_PLACEHOLDER;
 			}
 			sDirHandleTable.ReleaseHandle(cmd->cmdReadDir.dirHandle);

--- a/src/Cafe/IOSU/legacy/iosu_acp.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_acp.cpp
@@ -309,7 +309,7 @@ namespace iosu
 						}
 						else
 						{
-							forceLogDebug_printf("ACPGetSaveDataTitleIdList(): Missing meta.xml for save %08x-%08x", titleIdHigh, titleIdLow);
+							cemuLog_logDebug(LogType::Force, "ACPGetSaveDataTitleIdList(): Missing meta.xml for save {:08x}-{:08x}", titleIdHigh, titleIdLow);
 						}
 					}
 					fsc_close(fscDirIteratorTitleIdLow);

--- a/src/Cafe/IOSU/legacy/iosu_act.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_act.cpp
@@ -595,7 +595,7 @@ int iosuAct_thread()
 				}
 				else
 				{
-					forceLogDebug_printf("Gen UUID unknown mode %d", actCemuRequest->uuidName);
+					cemuLog_logDebug(LogType::Force, "Gen UUID unknown mode {}", actCemuRequest->uuidName);
 				}
 				actCemuRequest->setACTReturnCode(0);
 			}

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -252,7 +252,7 @@ namespace iosu
 
 	size_t task_download_header_callback(char* ptr, size_t size, size_t nitems, void* userdata)
 	{
-		//forceLogDebug_printf("\tHeader: %s", ptr);
+		//cemuLog_logDebug(LogType::Force, "\tHeader: {}", ptr);
 
 		return size * nitems;
 	}
@@ -292,7 +292,7 @@ namespace iosu
 				task->content_type = ContentType::kText;
 			else
 			{
-				forceLogDebug_printf("task_header_callback: unknown content type > %s", type);
+				cemuLog_logDebug(LogType::Force, "task_header_callback: unknown content type > {}", type);
 			}
 		}
 		else if (starts_with(ptr, "Last-Modified: "))
@@ -301,7 +301,7 @@ namespace iosu
 		}
 
 		//cemuLog_logDebug(LogType::Force, "task_header_callback: len {} ({}) and type {}", task->content_length, task->result_buffer.capacity(), task->content_type);
-		//forceLogDebug_printf("\t%s", ptr);
+		//cemuLog_logDebug(LogType::Force, "\t{}", ptr);
 		return size * nitems;
 	}
 
@@ -310,7 +310,7 @@ namespace iosu
 		auto task_settings = (TaskSetting*)param;
 		if (task_settings->taskType == kRawDlTaskSetting)
 		{
-			forceLogDebug_printf("sslctx_function: adding client cert: %d", (int)task_settings->settings[TaskSetting::kClientCert]);
+			cemuLog_logDebug(LogType::Force, "sslctx_function: adding client cert: {}", (int)task_settings->settings[TaskSetting::kClientCert]);
 			if (!iosuCrypto_addClientCertificate(sslctx, task_settings->settings[TaskSetting::kClientCert]))
 				assert_dbg();
 
@@ -319,7 +319,7 @@ namespace iosu
 			{
 				if (task_settings->settings[location] != 0)
 				{
-					forceLogDebug_printf("sslctx_function: adding ca cert: %d", (int)task_settings->settings[location]);
+					cemuLog_logDebug(LogType::Force, "sslctx_function: adding ca cert: {}", (int)task_settings->settings[location]);
 					if (!iosuCrypto_addCACertificate(sslctx, task_settings->settings[location]))
 					{
 						cemuLog_log(LogType::Force, "Failed to load CA certificate file");
@@ -601,11 +601,11 @@ namespace iosu
 		if (curl_result != CURLE_OK)
 		{
 #ifdef CEMU_DEBUG_ASSERT
-			forceLogDebug_printf("curl error buff: %s", errbuf);
+			cemuLog_logDebug(LogType::Force, "curl error buff: {}", errbuf);
 #endif
 			it->turn_state = kError;
 			it->wait_state = TRUE;
-			forceLogDebug_printf("task_run curl fail: %d", curl_result);
+			cemuLog_logDebug(LogType::Force, "task_run curl fail: {}", curl_result);
 			return BUILD_NN_RESULT(NN_RESULT_LEVEL_FATAL, NN_RESULT_MODULE_NN_BOSS, 0);
 		}
 		else
@@ -653,7 +653,7 @@ namespace iosu
 
 				char targetFileName[TaskSetting::kFileNameLen + 1]{};
 				strncpy(targetFileName, (char*)&it->task_settings.settings[TaskSetting::kNbdlFileName], TaskSetting::kFileNameLen);
-				forceLogDebug_printf("\tnbdl task target filename: \"%s\"", targetFileName);
+				cemuLog_logDebug(LogType::Force, "\tnbdl task target filename: \"{}\"", targetFileName);
 				const bool hasFileName = targetFileName[0] != '\0';
 
 				while (!it->queued_files.empty())
@@ -796,7 +796,7 @@ namespace iosu
 					}
 					catch (const std::exception& ex)
 					{
-						forceLogDebug_printf("file error: %s", ex.what());
+						cemuLog_logDebug(LogType::Force, "file error: {}", ex.what());
 					}
 
 					if (hasFileName)
@@ -805,7 +805,7 @@ namespace iosu
 			}
 			catch (const std::exception& ex)
 			{
-				forceLogDebug_printf("dir error: %s", ex.what());
+				cemuLog_logDebug(LogType::Force, "dir error: {}", ex.what());
 			}
 		}
 
@@ -865,7 +865,7 @@ namespace iosu
 		{
 			if (timeout != 0 && (uint32)std::chrono::duration_cast<std::chrono::seconds>(tick_cached() - start).count() >= timeout)
 			{
-				forceLogDebug_printf("task_wait: timeout reached -> %d seconds passed", timeout);
+				cemuLog_logDebug(LogType::Force, "task_wait: timeout reached -> {} seconds passed", timeout);
 				return false;
 			}
 

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -239,7 +239,7 @@ namespace iosu
 		//	task->result_buffer.resize(task->result_buffer.size() + writeByteSize);
 		//writeByteSize = min(writeByteSize, task->result_buffer.capacity() - task->processed_length);
 
-		//forceLogDebug_printf("task_write_callback: %d (processed: %d)", writeByteSize, task->processed_length);
+		//cemuLog_logDebug(LogType::Force, "task_write_callback: {} (processed: {})", writeByteSize, task->processed_length);
 		if (writeByteSize > 0)
 		{
 			//memcpy(task->result_buffer.data() + task->processed_length, ptr, writeByteSize);

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -633,7 +633,7 @@ namespace iosu
 
 			break;
 		case ContentType::kText:
-			cemuLog_logDebug(LogType::Force, "task_run returns text: {}", it->result_buffer.data());
+			cemuLog_logDebug(LogType::Force, "task_run returns text: {}", fmt::ptr(it->result_buffer.data()));
 			break;
 		}
 

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -612,14 +612,14 @@ namespace iosu
 		{
 			if (it->http_status_code != 200)
 			{
-				forceLogDebug_printf("BOSS task_run: Received unexpected HTTP response code");
+				cemuLog_logDebug(LogType::Force, "BOSS task_run: Received unexpected HTTP response code");
 			}
 			if (it->http_status_code == 404)
 			{
 				// todo - is this correct behavior?
 				it->turn_state = kError;
 				it->wait_state = TRUE;
-				forceLogDebug_printf("task_run failed due to 404 error");
+				cemuLog_logDebug(LogType::Force, "task_run failed due to 404 error");
 				return BUILD_NN_RESULT(NN_RESULT_LEVEL_FATAL, NN_RESULT_MODULE_NN_BOSS, 0);
 			}
 		}

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -633,7 +633,7 @@ namespace iosu
 
 			break;
 		case ContentType::kText:
-			forceLogDebug_printf("task_run returns text: %.*s", it->content_length, it->result_buffer.data());
+			cemuLog_logDebug(LogType::Force, "task_run returns text: {}", it->result_buffer.data());
 			break;
 		}
 

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -300,7 +300,7 @@ namespace iosu
 			// TODO timestamp (?)
 		}
 
-		//forceLogDebug_printf("task_header_callback: len %d (%d) and type %d", task->content_length, task->result_buffer.capacity(), task->content_type);
+		//cemuLog_logDebug(LogType::Force, "task_header_callback: len {} ({}) and type {}", task->content_length, task->result_buffer.capacity(), task->content_type);
 		//forceLogDebug_printf("\t%s", ptr);
 		return size * nitems;
 	}
@@ -457,7 +457,7 @@ namespace iosu
 			it->wait_state = TRUE;
 			return BUILD_NN_RESULT(NN_RESULT_LEVEL_SUCCESS, NN_RESULT_MODULE_NN_BOSS, 0);
 		}
-		forceLogDebug_printf("task run state: %d | exec: %d (tasks: %d)", it->turn_state, it->exec_count, g_boss.tasks.size());
+		cemuLog_logDebug(LogType::Force, "task run state: {} | exec: {} (tasks: {})", it->turn_state, it->exec_count, g_boss.tasks.size());
 		it->turn_state = kRunning;
 		it->exec_count++;
 
@@ -704,7 +704,7 @@ namespace iosu
 					curl_result = curl_easy_perform(curl);
 					if (curl_result != CURLE_OK)
 					{
-						forceLogDebug_printf("task_run curl failed on file download (%d): %s > %s", curl_result, file.file_name.c_str(), file.url.c_str());
+						cemuLog_logDebug(LogType::Force, "task_run curl failed on file download ({}): {} > {}", curl_result, file.file_name, file.url);
 						if (hasFileName)
 						{
 							turnstate = kError;
@@ -727,7 +727,7 @@ namespace iosu
 
 					if(it->processed_file_size != file.size)
 					{
-						forceLogDebug_printf("task_run file download size mismatch: %s > %s > %d from %d bytes", file.file_name.c_str(), file.url.c_str(), it->processed_file_size, file.size);
+						cemuLog_logDebug(LogType::Force, "task_run file download size mismatch: {} > {} > {} from {} bytes", file.file_name, file.url, it->processed_file_size, file.size);
 						if (hasFileName)
 						{
 							turnstate = kError;

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -45,7 +45,7 @@ namespace iosu
 
 		void notificationHandler(NexFriends::NOTIFICATION_TYPE type, uint32 pid)
 		{
-			forceLogDebug_printf("Friends::Notification %02x pid %08x", type, pid);
+			cemuLog_logDebug(LogType::Force, "Friends::Notification {:02x} pid {:08x}", type, pid);
 			if(GetConfig().notification.friends)
 			{
 				std::unique_lock lock(g_friend_notification_mutex);

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -174,7 +174,7 @@ namespace iosu
 			}
 			else
 			{
-				forceLogDebug_printf("IOSU_FPD: Failed to acquire nex token for friend server");
+				cemuLog_logDebug(LogType::Force, "IOSU_FPD: Failed to acquire nex token for friend server");
 			}
 		}
 
@@ -542,7 +542,7 @@ namespace iosu
 				uint64 mid = _swapEndianU64(fpdCemuRequest->markFriendRequest.messageIdList.GetPtr()[i]);
 				if (mid == 0)
 				{
-					forceLogDebug_printf("MarkFriendRequestAsReceivedAsync - Invalid messageId");
+					cemuLog_logDebug(LogType::Force, "MarkFriendRequestAsReceivedAsync - Invalid messageId");
 					continue;
 				}
 				messageIds[count] = mid;

--- a/src/Cafe/IOSU/legacy/iosu_ioctl.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_ioctl.cpp
@@ -17,7 +17,7 @@ sint32 iosuIoctl_pushAndWait(uint32 ioctlHandle, ioQueueEntry_t* ioQueueEntry)
 {
 	if (ioctlHandle != IOS_DEVICE_ACT && ioctlHandle != IOS_DEVICE_ACP_MAIN && ioctlHandle != IOS_DEVICE_MCP && ioctlHandle != IOS_DEVICE_BOSS && ioctlHandle != IOS_DEVICE_NIM && ioctlHandle != IOS_DEVICE_FPD)
 	{
-		forceLogDebug_printf("Unsupported IOSU device %d", ioctlHandle);
+		cemuLog_logDebug(LogType::Force, "Unsupported IOSU device {}", ioctlHandle);
 		cemu_assert_debug(false);
 		return 0;
 	}

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -430,7 +430,7 @@ bool RPLLoader_LoadSingleSection(RPLModule* rplLoaderContext, sint32 sectionInde
 
 	uint32 mappingOffset = (uint32)section->virtualAddress - (uint32)regionMappingInfo->baseAddress;
 	if (mappingOffset >= 0x10000000)
-		forceLogDebug_printf("Suspicious section mapping offset: 0x%08x", mappingOffset);
+		cemuLog_logDebug(LogType::Force, "Suspicious section mapping offset: 0x{:08x}", mappingOffset);
 	uint32 sectionAddress = mappedAddress + mappingOffset;
 
 	rplLoaderContext->sectionAddressTable2[sectionIndex].ptr = memory_getPointerFromVirtualOffset(sectionAddress);
@@ -1304,7 +1304,7 @@ bool RPLLoader_ApplyRelocs(RPLModule* rplLoaderContext, sint32 relaSectionIndex,
 		}
 		if (relocSymbolIndex >= symbolCount)
 		{
-			forceLogDebug_printf("reloc with symbol index out of range 0x%04x", (uint32)relocSymbolIndex);
+			cemuLog_logDebug(LogType::Force, "reloc with symbol index out of range 0x{:04x}", (uint32)relocSymbolIndex);
 			reloc++;
 			continue;
 		}
@@ -1313,7 +1313,7 @@ bool RPLLoader_ApplyRelocs(RPLModule* rplLoaderContext, sint32 relaSectionIndex,
 
 		if ((uint32)sym->sectionIndex >= (uint32)rplLoaderContext->rplHeader.sectionTableEntryCount)
 		{
-			forceLogDebug_printf("reloc with sectionIndex out of range 0x%04x", (uint32)sym->sectionIndex);
+			cemuLog_logDebug(LogType::Force, "reloc with sectionIndex out of range 0x{:04x}", (uint32)sym->sectionIndex);
 			reloc++;
 			continue;
 		}
@@ -1528,7 +1528,7 @@ void RPLLoader_BeginCemuhookCRC(RPLModule* rpl)
 			auto ret = inflate(&strm, Z_FULL_FLUSH);
 			if (ret != Z_OK && ret != Z_STREAM_END || strm.avail_in != 0 || strm.avail_out != 0)
 			{
-				forceLogDebug_printf("RPLLoader-CRC: Unable to decompress section %d", i);
+				cemuLog_logDebug(LogType::Force, "RPLLoader-CRC: Unable to decompress section {}", i);
 				cemuLog_logDebug(LogType::Force, "zRet {} availIn {} availOut {}", ret, (sint32)strm.avail_in, (sint32)strm.avail_out);
 				cemu_assert_debug(false);
 				free(rawData);
@@ -2070,7 +2070,7 @@ bool RPLLoader_LoadFromVirtualPath(rplDependency_t* dependency, char* filePath)
 	uint8* rplData = fsc_extractFile(filePath, &rplSize);
 	if (rplData)
 	{
-		forceLogDebug_printf("Loading: %s", filePath);
+		cemuLog_logDebug(LogType::Force, "Loading: {}", filePath);
 		dependency->rplLoaderContext = rpl_loadFromMem(rplData, rplSize, filePath);
 		free(rplData);
 		return true;

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -1529,7 +1529,7 @@ void RPLLoader_BeginCemuhookCRC(RPLModule* rpl)
 			if (ret != Z_OK && ret != Z_STREAM_END || strm.avail_in != 0 || strm.avail_out != 0)
 			{
 				forceLogDebug_printf("RPLLoader-CRC: Unable to decompress section %d", i);
-				forceLogDebug_printf("zRet %d availIn %d availOut %d", ret, (sint32)strm.avail_in, (sint32)strm.avail_out);
+				cemuLog_logDebug(LogType::Force, "zRet {} availIn {} availOut {}", ret, (sint32)strm.avail_in, (sint32)strm.avail_out);
 				cemu_assert_debug(false);
 				free(rawData);
 				inflateEnd(&strm);

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -231,13 +231,13 @@ bool RPLLoader_ProcessHeaders(std::string_view moduleName, uint8* rplData, uint3
 	rplSectionEntryNew_t* fileinfoSection = rplLoaderContext->sectionTablePtr + ((uint32)rplLoaderContext->rplHeader.sectionTableEntryCount - 1);
 	if (fileinfoSection->fileOffset == 0 || (uint32)fileinfoSection->fileOffset >= rplSize || (uint32)fileinfoSection->type != SHT_RPL_FILEINFO)
 	{
-		forceLogDebug_printf("RPLLoader: Last section not FILEINFO");
+		cemuLog_logDebug(LogType::Force, "RPLLoader: Last section not FILEINFO");
 	}
 	// verify that section n-2 is CRCs
 	rplSectionEntryNew_t* crcSection = rplLoaderContext->sectionTablePtr + ((uint32)rplLoaderContext->rplHeader.sectionTableEntryCount - 2);
 	if (crcSection->fileOffset == 0 || (uint32)crcSection->fileOffset >= rplSize || (uint32)crcSection->type != SHT_RPL_CRCS)
 	{
-		forceLogDebug_printf("RPLLoader: The section before FILEINFO must be CRCs");
+		cemuLog_logDebug(LogType::Force, "RPLLoader: The section before FILEINFO must be CRCs");
 	}
 	// load FILEINFO section
 	if (fileinfoSection->sectionSize < sizeof(RPLFileInfoData))
@@ -1018,7 +1018,7 @@ bool RPLLoader_FixImportSymbols(RPLModule* rplLoaderContext, sint32 symtabSectio
 #ifdef CEMU_DEBUG_ASSERT
 					if (nameOffset > 0)
 					{
-						forceLogDebug_printf("export not found - force lookup in function exports");
+						cemuLog_logDebug(LogType::Force, "export not found - force lookup in function exports");
 						// workaround - force look up export in function exports
 						char* exportNameData = (char*)((uint8*)ctxExportModule->exportFDataPtr - 8);
 						for (uint32 f = 0; f < ctxExportModule->exportFCount; f++)

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -1503,14 +1503,14 @@ void RPLLoader_BeginCemuhookCRC(RPLModule* rpl)
 			rawSize = decompressedSize;
 			if (rawSize >= 1024*1024*1024)
 			{
-				forceLogDebug_printf("RPLLoader-CRC: Cannot load section %d which is too large (%u bytes)", i, decompressedSize);
+				cemuLog_logDebug(LogType::Force, "RPLLoader-CRC: Cannot load section {} which is too large ({} bytes)", i, decompressedSize);
 				cemu_assert_debug(false);
 				continue;
 			}
 			rawData = (uint8*)malloc(decompressedSize);
 			if (rawData == nullptr)
 			{
-				forceLogDebug_printf("RPLLoader-CRC: Failed to allocate memory for uncompressed section %d (%u bytes)", i, decompressedSize);
+				cemuLog_logDebug(LogType::Force, "RPLLoader-CRC: Failed to allocate memory for uncompressed section {} ({} bytes)", i, decompressedSize);
 				cemu_assert_debug(false);
 				continue;
 			}
@@ -1630,7 +1630,7 @@ RPLModule* rpl_loadFromMem(uint8* rplData, sint32 size, char* name)
 		return nullptr;
 	}
 
-	forceLogDebug_printf("Load %s Code-Offset: -0x%x", name, rpl->regionMappingBase_text.GetMPTR() - 0x02000000);
+	cemuLog_logDebug(LogType::Force, "Load {} Code-Offset: -0x{:x}", name, rpl->regionMappingBase_text.GetMPTR() - 0x02000000);
 
 	// sdata (r2/r13)
 	uint32 sdataBaseAddress = rpl->fileInfo.sdataBase1; // base + 0x8000

--- a/src/Cafe/OS/common/PPCConcurrentQueue.h
+++ b/src/Cafe/OS/common/PPCConcurrentQueue.h
@@ -21,7 +21,7 @@ public:
 		//OSThread_t* currentThread = coreinit::OSGetCurrentThread();
 		//cemu_assert_debug(thread == nullptr || currentThread == thread);
 
-		// forceLogDebug_printf("push suspend count: %d", _swapEndianU32(thread->suspend) - m_suspendCount);
+		// cemuLog_logDebug(LogType::Force, "push suspend count: {}", _swapEndianU32(thread->suspend) - m_suspendCount);
 
 		//__OSLockScheduler();
 
@@ -46,7 +46,7 @@ public:
 
 		//thread = coreinitThread_getCurrentThread(ppcInterpreterCurrentInstance);
 
-		// forceLogDebug_printf("pop suspend count: %d", _swapEndianU32(thread->suspend) + m_suspendCount);
+		// cemuLog_logDebug(LogType::Force, "pop suspend count: {}", _swapEndianU32(thread->suspend) + m_suspendCount);
 
 		__OSLockScheduler();
 		if (m_queue.empty())

--- a/src/Cafe/OS/libs/coreinit/coreinit.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit.cpp
@@ -257,7 +257,7 @@ namespace coreinit
 
 	void coreinitExport_ENVGetEnvironmentVariable(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("ENVGetEnvironmentVariable(\"%s\",0x08x,0x%x)\n", (char*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]), hCPU->gpr[4], hCPU->gpr[5]);
+		cemuLog_logDebug(LogType::Force, "ENVGetEnvironmentVariable(\"{}\",0x08x,0x{:x})", (char*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]), hCPU->gpr[4], hCPU->gpr[5]);
 		char* envKeyStr = (char*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 		char* outputString = (char*)memory_getPointerFromVirtualOffset(hCPU->gpr[4]);
 		sint32 outputStringMaxLen = (sint32)hCPU->gpr[5];

--- a/src/Cafe/OS/libs/coreinit/coreinit.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit.cpp
@@ -284,13 +284,13 @@ namespace coreinit
 
 	uint32 OSGetBootPMFlags()
 	{
-		forceLogDebug_printf("OSGetBootPMFlags() - placeholder");
+		cemuLog_logDebug(LogType::Force, "OSGetBootPMFlags() - placeholder");
 		return 0;
 	}
 
 	uint32 OSGetSystemMode()
 	{
-		forceLogDebug_printf("OSGetSystemMode() - placeholder");
+		cemuLog_logDebug(LogType::Force, "OSGetSystemMode() - placeholder");
 		// if this returns 2, barista softlocks shortly after boot
 		return 0;
 	}

--- a/src/Cafe/OS/libs/coreinit/coreinit_Alarm.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Alarm.cpp
@@ -249,7 +249,7 @@ namespace coreinit
 		if (existingAlarmItr != g_activeAlarms.end())
 		{
 			// delete existing alarm
-			forceLogDebug_printf("__OSInitiateAlarm() called on alarm which was already active");
+			cemuLog_logDebug(LogType::Force, "__OSInitiateAlarm() called on alarm which was already active");
 			OSHostAlarmDestroy(existingAlarmItr->second);
 			g_activeAlarms.erase(existingAlarmItr);
 		}

--- a/src/Cafe/OS/libs/coreinit/coreinit_FG.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FG.cpp
@@ -184,7 +184,7 @@ namespace coreinit
 
 	void coreinitExport_OSCopyFromClipboard(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("OSCopyFromClipboard(0x%x,0x%x)\n", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_logDebug(LogType::Force, "OSCopyFromClipboard(0x{:x},0x{:x})", hCPU->gpr[3], hCPU->gpr[4]);
 		ppcDefineParamMEMPTR(buffer, void, 0);
 		ppcDefineParamMEMPTR(size, uint32be, 1);
 		bool r = OSCopyFromClipboard(buffer.GetPtr(), size.GetPtr());

--- a/src/Cafe/OS/libs/coreinit/coreinit_IM.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_IM.cpp
@@ -48,7 +48,7 @@ namespace coreinit
 
 	void coreinitExport_IMGetAPDPeriod(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("IMGetAPDPeriod(0x%08x)\n", hCPU->gpr[3]);
+		cemuLog_logDebug(LogType::Force, "IMGetAPDPeriod(0x{:08x})", hCPU->gpr[3]);
 		// parameters:
 		// r3	uint32*		returns the number of seconds until auto-shutdown occurs
 		memory_writeU32(hCPU->gpr[3], 600);

--- a/src/Cafe/OS/libs/coreinit/coreinit_IM.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_IM.cpp
@@ -57,7 +57,7 @@ namespace coreinit
 
 	void coreinitExport_IM_GetParameter(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("IM_GetParameter()");
+		cemuLog_logDebug(LogType::Force, "IM_GetParameter()");
 
 		ppcDefineParamS32(imHandle, 0); // handle from IM_Open()
 		ppcDefineParamS32(uknR4, 1);
@@ -81,7 +81,7 @@ namespace coreinit
 
 	void coreinitExport_IM_GetRuntimeParameter(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("IM_GetRuntimeParameter()");
+		cemuLog_logDebug(LogType::Force, "IM_GetRuntimeParameter()");
 
 		ppcDefineParamS32(parameterId, 0);
 		ppcDefineParamStructPtr(output, void, 1);

--- a/src/Cafe/OS/libs/coreinit/coreinit_IOS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_IOS.cpp
@@ -58,7 +58,7 @@ sint32 __depr__IOS_Ioctl(uint32 fd, uint32 request, void* inBuffer, uint32 inSiz
 		default:
 		{
 			// todo
-			forceLogDebug_printf("Unsupported Ioctl command");
+			cemuLog_logDebug(LogType::Force, "Unsupported Ioctl command");
 		}
 	}
 	return 0;

--- a/src/Cafe/OS/libs/coreinit/coreinit_Init.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Init.cpp
@@ -119,7 +119,7 @@ void CafeInit()
 		}
 		else
 		{
-			forceLogDebug_printf("Unable to find end of rpx file name in arg string");
+			cemuLog_logDebug(LogType::Force, "Unable to find end of rpx file name in arg string");
 		}
 	}
 	// setup UGQR

--- a/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
@@ -294,7 +294,7 @@ namespace coreinit
 		ppcDefineParamStructPtr(deviceList, MCPDevice_t, 2);
 		ppcDefineParamU32(deviceListSize, 3);
 
-		forceLogDebug_printf("MCP_DeviceList() - placeholder LR %08x", hCPU->spr.LR);
+		forceLogDebug_printf("MCP_DeviceList()");
 
 		sint32 maxDeviceCount = deviceListSize / sizeof(MCPDevice_t);
 
@@ -331,7 +331,7 @@ namespace coreinit
 		ppcDefineParamStructPtr(deviceList, MCPDevice_t, 2);
 		ppcDefineParamU32(deviceListSize, 3);
 
-		forceLogDebug_printf("MCP_FullDeviceList() - placeholder LR %08x", hCPU->spr.LR);
+		forceLogDebug_printf("MCP_FullDeviceList()");
 
 		MCP_DeviceListEx(mcpHandle, deviceCount, deviceList, deviceListSize, true);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
@@ -103,7 +103,7 @@ void coreinitExport_MCP_TitleListByAppType(PPCInterpreter_t* hCPU)
 
 void coreinitExport_MCP_TitleList(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("MCP_TitleList(...) unimplemented");
+	cemuLog_logDebug(LogType::Force, "MCP_TitleList(...) unimplemented");
 	ppcDefineParamU32(mcpHandle, 0);
 	ppcDefineParamU32BEPtr(countOutput, 1);
 	ppcDefineParamStructPtr(titleList, MCPTitleInfo, 2);
@@ -125,7 +125,7 @@ void coreinitExport_MCP_TitleList(PPCInterpreter_t* hCPU)
 
 void coreinitExport_MCP_TitleCount(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("MCP_TitleCount(): Untested");
+	cemuLog_logDebug(LogType::Force, "MCP_TitleCount(): Untested");
 	ppcDefineParamU32(mcpHandle, 0);
 
 	mcpPrepareRequest();
@@ -142,7 +142,7 @@ void coreinitExport_MCP_GetTitleInfo(PPCInterpreter_t* hCPU)
 	ppcDefineParamU64(titleId, 2);
 	ppcDefineParamStructPtr(titleList, MCPTitleInfo, 4);
 
-	forceLogDebug_printf("MCP_GetTitleInfo() called");
+	cemuLog_logDebug(LogType::Force, "MCP_GetTitleInfo() called");
 
 	mcpPrepareRequest();
 	mcpRequest->requestCode = IOSU_MCP_GET_TITLE_INFO;
@@ -168,7 +168,7 @@ void coreinitExport_MCP_GetTitleInfoByTitleAndDevice(PPCInterpreter_t* hCPU)
 	ppcDefineParamStr(device, 4); // e.g. "odd"
 	ppcDefineParamStructPtr(titleList, MCPTitleInfo, 5);
 
-	forceLogDebug_printf("MCP_GetTitleInfoByTitleAndDevice() called (todo - device type support)");
+	cemuLog_logDebug(LogType::Force, "MCP_GetTitleInfoByTitleAndDevice() called (todo - device type support)");
 
 	mcpPrepareRequest();
 	mcpRequest->requestCode = IOSU_MCP_GET_TITLE_INFO;
@@ -180,7 +180,7 @@ void coreinitExport_MCP_GetTitleInfoByTitleAndDevice(PPCInterpreter_t* hCPU)
 
 	if (mcpRequest->titleListRequest.titleCount == 0)
 	{
-		forceLogDebug_printf("MCP_GetTitleInfoByTitleAndDevice() no title found");
+		cemuLog_logDebug(LogType::Force, "MCP_GetTitleInfoByTitleAndDevice() no title found");
 		osLib_returnFromFunction(hCPU, BUILD_NN_RESULT(NN_RESULT_LEVEL_STATUS, NN_RESULT_MODULE_MCP, 0)); // E-Shop/nn_vctl.rpl expects error to be returned when no title is found
 		return;
 	}
@@ -209,7 +209,7 @@ namespace coreinit
 	void export_MCP_Get4SecondOffStatus(PPCInterpreter_t* hCPU)
 	{
 		// r3 = mcpHandle
-		forceLogDebug_printf("MCP_Get4SecondOffStatus(...) placeholder");
+		cemuLog_logDebug(LogType::Force, "MCP_Get4SecondOffStatus(...) placeholder");
 		// if this returns 1 then Barista will display the warning about cold-shutdown ('Holding the POWER button for at least four seconds...')
 		osLib_returnFromFunction(hCPU, 0);
 	}
@@ -230,7 +230,7 @@ namespace coreinit
 
 		*titleCount = 1;
 
-		forceLogDebug_printf("MCP_TitleListByDevice() - placeholder");
+		cemuLog_logDebug(LogType::Force, "MCP_TitleListByDevice() - placeholder");
 
 		osLib_returnFromFunction(hCPU, 0);
 	}
@@ -343,7 +343,7 @@ namespace coreinit
 		ppcDefineParamU32(mcpHandle, 0);
 		ppcDefineParamU32BEPtr(unknownParam, 1);
 
-		forceLogDebug_printf("MCP_UpdateCheckContext() - placeholder (might be wrong)");
+		cemuLog_logDebug(LogType::Force, "MCP_UpdateCheckContext() - placeholder (might be wrong)");
 
 		*unknownParam = 1;
 
@@ -356,7 +356,7 @@ namespace coreinit
 		ppcDefineParamU32(mcpHandle, 0);
 		ppcDefineParamMPTR(callbackMPTR, 1);
 
-		forceLogDebug_printf("MCP_TitleListUpdateGetNext() - placeholder/unimplemented");
+		cemuLog_logDebug(LogType::Force, "MCP_TitleListUpdateGetNext() - placeholder/unimplemented");
 
 		// this callback is to let the app know when the title list changed?
 
@@ -365,7 +365,7 @@ namespace coreinit
 
 	void export_MCP_GetOverlayAppInfo(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("MCP_GetOverlayAppInfo(...) placeholder");
+		cemuLog_logDebug(LogType::Force, "MCP_GetOverlayAppInfo(...) placeholder");
 		ppcDefineParamU32(mcpHandle, 0);
 		ppcDefineParamU32(appType, 1);
 		ppcDefineParamU32(uknR5, 2);

--- a/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
@@ -71,7 +71,7 @@ sint32 MCP_GetSysProdSettings(MCPHANDLE mcpHandle, SysProdSettings* sysProdSetti
 
 void coreinitExport_MCP_GetSysProdSettings(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("MCP_GetSysProdSettings(0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_logDebug(LogType::Force, "MCP_GetSysProdSettings(0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 	sint32 result = MCP_GetSysProdSettings(hCPU->gpr[3], (SysProdSettings*)memory_getPointerFromVirtualOffset(hCPU->gpr[4]));
 	osLib_returnFromFunction(hCPU, result);
 }
@@ -194,7 +194,7 @@ namespace coreinit
 
 	void export_MCP_GetSystemVersion(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("MCP_GetSystemVersion(%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_logDebug(LogType::Force, "MCP_GetSystemVersion({},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 		ppcDefineParamU32(mcpHandle, 0);
 		ppcDefineParamStructPtr(systemVersion, mcpSystemVersion_t, 1);
 
@@ -554,7 +554,7 @@ void coreinitExport_UCReadSysConfig(PPCInterpreter_t* hCPU)
 		}
 		else
 		{
-			forceLogDebug_printf("Unsupported SCI value: %s Size %08x\n", ucParam->settingName, ucParam->ukn4_size);
+			cemuLog_logDebug(LogType::Force, "Unsupported SCI value: {} Size {:08x}", ucParam->settingName, ucParam->ukn4_size);
 		}
 	}
 	osLib_returnFromFunction(hCPU, 0); // 0 -> success

--- a/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
@@ -78,7 +78,7 @@ void coreinitExport_MCP_GetSysProdSettings(PPCInterpreter_t* hCPU)
 
 void coreinitExport_MCP_TitleListByAppType(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("MCP_TitleListByAppType(0x%08x,0x%08x,0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+	cemuLog_logDebug(LogType::Force, "MCP_TitleListByAppType(0x{:08x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
 
 	ppcDefineParamU32(mcpHandle, 0);
 	ppcDefineParamU32(appType, 1);

--- a/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MCP.cpp
@@ -294,7 +294,7 @@ namespace coreinit
 		ppcDefineParamStructPtr(deviceList, MCPDevice_t, 2);
 		ppcDefineParamU32(deviceListSize, 3);
 
-		forceLogDebug_printf("MCP_DeviceList()");
+		cemuLog_logDebug(LogType::Force, "MCP_DeviceList()");
 
 		sint32 maxDeviceCount = deviceListSize / sizeof(MCPDevice_t);
 
@@ -331,7 +331,7 @@ namespace coreinit
 		ppcDefineParamStructPtr(deviceList, MCPDevice_t, 2);
 		ppcDefineParamU32(deviceListSize, 3);
 
-		forceLogDebug_printf("MCP_FullDeviceList()");
+		cemuLog_logDebug(LogType::Force, "MCP_FullDeviceList()");
 
 		MCP_DeviceListEx(mcpHandle, deviceCount, deviceList, deviceListSize, true);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_MEM_ExpHeap.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MEM_ExpHeap.cpp
@@ -948,7 +948,7 @@ void export_MEMSetGroupIDForExpHeap(PPCInterpreter_t* hCPU)
 void export_MEMGetGroupIDForExpHeap(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(heap, MEMHeapBase, 0);
-	forceLogDebug_printf("MEMGetGroupIDForExpHeap(0x%08x)", heap.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "MEMGetGroupIDForExpHeap(0x{:08x})", heap.GetMPTR());
 	uint16 oldGroupId = MEMGetGroupIDForExpHeap(heap.GetPtr());
 	osLib_returnFromFunction(hCPU, oldGroupId);
 }

--- a/src/Cafe/OS/libs/coreinit/coreinit_Memory.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Memory.cpp
@@ -184,7 +184,7 @@ namespace coreinit
 				titleId == 0x0005000010135E00 // US
 				)
 			{
-				forceLogDebug_printf("Hack: Reduce available memory to simulate loaded RPLs");
+				cemuLog_logDebug(LogType::Force, "Hack: Reduce available memory to simulate loaded RPLs");
 				currentRPLAllocatorOffset += (48 * 1024 * 1024); // 48MB
 			}
 			memAddr = currentRPLAllocatorOffset;

--- a/src/Cafe/OS/libs/coreinit/coreinit_OSScreen.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_OSScreen.cpp
@@ -96,7 +96,7 @@ namespace coreinit
 	{
 		ppcDefineParamU32(screenIndex, 0);
 		cemu_assert(screenIndex < 2);
-		forceLogDebug_printf("OSScreenFlipBuffersEx %d", screenIndex);
+		cemuLog_logDebug(LogType::Force, "OSScreenFlipBuffersEx {}", screenIndex);
 		LatteGPUState.osScreen.screen[screenIndex].flipRequestCount++;
 		_updateCurrentDrawScreen(screenIndex);
 		osLib_returnFromFunction(hCPU, 0);

--- a/src/Cafe/OS/libs/coreinit/coreinit_SysHeap.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_SysHeap.cpp
@@ -19,7 +19,7 @@ namespace coreinit
 		ppcDefineParamU32(size, 0);
 		ppcDefineParamS32(alignment, 1);
 		MEMPTR<void> mem = OSAllocFromSystem(size, alignment);
-		forceLogDebug_printf("OSAllocFromSystem(0x%x, %d) -> 0x%08x", size, alignment, mem.GetMPTR());
+		cemuLog_logDebug(LogType::Force, "OSAllocFromSystem(0x{:x}, {}) -> 0x{:08x}", size, alignment, mem.GetMPTR());
 		osLib_returnFromFunction(hCPU, mem.GetMPTR());
 	}
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -346,7 +346,7 @@ namespace coreinit
 		if (thread->state != OSThread_t::THREAD_STATE::STATE_NONE && thread->state != OSThread_t::THREAD_STATE::STATE_MORIBUND)
 		{
 			// unsure about this case
-			forceLogDebug_printf("OSRunThread called on thread which cannot be ran");
+			cemuLog_logDebug(LogType::Force, "OSRunThread called on thread which cannot be ran");
 			__OSUnlockScheduler();
 			return false;
 		}
@@ -536,7 +536,7 @@ namespace coreinit
 		else if (thread->state != OSThread_t::THREAD_STATE::STATE_MORIBUND)
 		{
 			// cannot join detached and active threads
-			forceLogDebug_printf("Cannot join detached active thread");
+			cemuLog_logDebug(LogType::Force, "Cannot join detached active thread");
 			__OSUnlockScheduler();
 			return false;
 		}

--- a/src/Cafe/OS/libs/dmae/dmae.cpp
+++ b/src/Cafe/OS/libs/dmae/dmae.cpp
@@ -88,7 +88,7 @@ void dmaeExport_DMAESemaphore(PPCInterpreter_t* hCPU)
 	}
 	else if (actionType == 0) // wait
 	{
-		forceLogDebug_printf("DMAESemaphore: Unsupported wait operation");
+		cemuLog_logDebug(LogType::Force, "DMAESemaphore: Unsupported wait operation");
 		semaphore->fetch_sub(1);
 	}
 	else

--- a/src/Cafe/OS/libs/dmae/dmae.cpp
+++ b/src/Cafe/OS/libs/dmae/dmae.cpp
@@ -93,7 +93,7 @@ void dmaeExport_DMAESemaphore(PPCInterpreter_t* hCPU)
 	}
 	else
 	{
-		forceLogDebug_printf("DMAESemaphore unknown action type %d", actionType);
+		cemuLog_logDebug(LogType::Force, "DMAESemaphore unknown action type {}", actionType);
 		cemu_assert_debug(false);
 	}
 

--- a/src/Cafe/OS/libs/drmapp/drmapp.cpp
+++ b/src/Cafe/OS/libs/drmapp/drmapp.cpp
@@ -5,7 +5,7 @@ namespace drmapp
 {
 	uint32 NupChkIsFinished(uint32 ukn)
 	{
-		forceLogDebug_printf("drmapp.NupChkIsFinished() - placeholder");
+		cemuLog_logDebug(LogType::Force, "drmapp.NupChkIsFinished() - placeholder");
 		return 1;
 	}
 

--- a/src/Cafe/OS/libs/erreula/erreula.cpp
+++ b/src/Cafe/OS/libs/erreula/erreula.cpp
@@ -171,21 +171,21 @@ namespace erreula
 	void export_IsDecideSelectButtonError(PPCInterpreter_t* hCPU)
 	{
 		if (g_errEula.buttonPressed)
-			forceLogDebug_printf("IsDecideSelectButtonError: TRUE");
+			cemuLog_logDebug(LogType::Force, "IsDecideSelectButtonError: TRUE");
 		osLib_returnFromFunction(hCPU, g_errEula.buttonPressed);
 	}
 
 	void export_IsDecideSelectLeftButtonError(PPCInterpreter_t* hCPU)
 	{
 		if (g_errEula.buttonPressed)
-			forceLogDebug_printf("IsDecideSelectLeftButtonError: TRUE");
+			cemuLog_logDebug(LogType::Force, "IsDecideSelectLeftButtonError: TRUE");
 		osLib_returnFromFunction(hCPU, g_errEula.buttonPressed);
 	}
 
 	void export_IsDecideSelectRightButtonError(PPCInterpreter_t* hCPU)
 	{
 		if (g_errEula.rightButtonPressed)
-			forceLogDebug_printf("IsDecideSelectRightButtonError: TRUE");
+			cemuLog_logDebug(LogType::Force, "IsDecideSelectRightButtonError: TRUE");
 		osLib_returnFromFunction(hCPU, g_errEula.rightButtonPressed);
 	}
 
@@ -205,7 +205,7 @@ namespace erreula
 		uint32 result = RESULTTYPE_NONE;
 		if (g_errEula.buttonPressed || g_errEula.rightButtonPressed)
 		{
-			forceLogDebug_printf("GetResultType: FINISH");
+			cemuLog_logDebug(LogType::Force, "GetResultType: FINISH");
 			result = RESULTTYPE_FINISH;
 		}
 

--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -336,7 +336,7 @@ void _GX2SubmitToTCL()
 	// do nothing if called from non-main GX2 core
 	if (GX2::sGX2MainCoreIndex != coreIndex)
 	{
-		forceLogDebug_printf("_GX2SubmitToTCL() called on non-main GX2 core");
+		cemuLog_logDebug(LogType::Force, "_GX2SubmitToTCL() called on non-main GX2 core");
 		return;
 	}
 	if( gx2WriteGatherPipe.displayListStart[coreIndex] != MPTR_NULL )

--- a/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
@@ -22,13 +22,13 @@ void gx2Export_GX2InitColorBufferRegs(PPCInterpreter_t* hCPU)
 	uint32 pitchHeight = (surfaceInfo.height * surfaceInfo.pitch) >> 6;
 #ifdef CEMU_DEBUG_ASSERT
 	if (colorBuffer->viewNumSlices != _swapEndianU32(1))
-		forceLogDebug_printf("GX2InitColorBufferRegs(): With unsupported slice count %d", _swapEndianU32(colorBuffer->viewNumSlices));
+		cemuLog_logDebug(LogType::Force, "GX2InitColorBufferRegs(): With unsupported slice count {}", _swapEndianU32(colorBuffer->viewNumSlices));
 	if (surfaceInfo.pitch < 7)
-		forceLogDebug_printf("GX2InitColorBufferRegs(): Pitch too small (pitch = %d)", surfaceInfo.pitch);
+		cemuLog_logDebug(LogType::Force, "GX2InitColorBufferRegs(): Pitch too small (pitch = {})", surfaceInfo.pitch);
 	if ((surfaceInfo.pitch & 7) != 0)
-		forceLogDebug_printf("GX2InitColorBufferRegs(): Pitch has invalid alignment (pitch = %d)", surfaceInfo.pitch);
+		cemuLog_logDebug(LogType::Force, "GX2InitColorBufferRegs(): Pitch has invalid alignment (pitch = {})", surfaceInfo.pitch);
 	if (pitchHeight == 0)
-		forceLogDebug_printf("GX2InitColorBufferRegs(): Invalid value (pitchHeight = %d)", pitchHeight);
+		cemuLog_logDebug(LogType::Force, "GX2InitColorBufferRegs(): Invalid value (pitchHeight = {})", pitchHeight);
 #endif
 
 	uint32 cSize = ((surfaceInfo.pitch >> 3) - 1) & 0x3FF;

--- a/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
@@ -220,7 +220,7 @@ void gx2Export_GX2SetDepthBuffer(PPCInterpreter_t* hCPU)
 
 	if( viewMip > 0 )
 	{
-		forceLogDebug_printf("GX2SetDepthBuffer: Unsupported non-zero mip (%d) Pointer: %08X Base: %08X", viewMip, regHTileDataBase, 0);
+		cemuLog_logDebug(LogType::Force, "GX2SetDepthBuffer: Unsupported non-zero mip ({}) Pointer: {:08x} Base: {:08x}", viewMip, regHTileDataBase, 0);
 	}
 
 	// setup depthbuffer info register

--- a/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
@@ -208,7 +208,7 @@ void gx2Surface_GX2CopySurface(GX2Surface* srcSurface, uint32 srcMip, uint32 src
 	if( srcHwFormat != dstHwFormat )
 	{
 		// mismatching format
-		forceLogDebug_printf("GX2CopySurface(): Format mismatch\n");
+		cemuLog_logDebug(LogType::Force, "GX2CopySurface(): Format mismatch");
 		return;
 	}
 

--- a/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Surface_Copy.cpp
@@ -379,7 +379,7 @@ typedef struct
 
 void gx2Export_GX2CopySurfaceEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GX2CopySurfaceEx(0x%08x,%d,%d,0x%08x,%d,%d,%d,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->gpr[8], hCPU->gpr[9], hCPU->gpr[10], memory_readU32(hCPU->gpr[1]+0x8));
+	cemuLog_logDebug(LogType::Force, "GX2CopySurfaceEx(0x{:08x},{},{},0x{:08x},{},{},{},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->gpr[8], hCPU->gpr[9], hCPU->gpr[10], memory_readU32(hCPU->gpr[1]+0x8));
 	GX2Surface* srcSurface = (GX2Surface*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 	uint32 srcMip = hCPU->gpr[4];
 	uint32 srcSlice = hCPU->gpr[5];
@@ -394,7 +394,7 @@ void gx2Export_GX2CopySurfaceEx(PPCInterpreter_t* hCPU)
 	GX2Point_t* rectDst = (GX2Point_t*)memory_getPointerFromVirtualOffset(pointDstArrayMPTR);
 	for (sint32 i = 0; i < rectCount; i++)
 	{
-		forceLogDebug_printf("rect left-top: %d/%d size: %d/%d", _swapEndianU32(rectSrc->left), _swapEndianU32(rectSrc->top), _swapEndianU32(rectSrc->right) - _swapEndianU32(rectSrc->left), _swapEndianU32(rectSrc->bottom) - _swapEndianU32(rectSrc->top));
+		cemuLog_logDebug(LogType::Force, "rect left-top: {}/{} size: {}/{}", _swapEndianU32(rectSrc->left), _swapEndianU32(rectSrc->top), _swapEndianU32(rectSrc->right) - _swapEndianU32(rectSrc->left), _swapEndianU32(rectSrc->bottom) - _swapEndianU32(rectSrc->top));
 	}
 
 #ifdef CEMU_DEBUG_ASSERT

--- a/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
@@ -370,7 +370,7 @@ void GX2TilingAperature_RetileTexture(ActiveTilingAperature* tilingAperture, boo
 	}
 
 	//double benchmarkTime = benchmarkTimer_stop(timerTilingStart);
-	//forceLogDebug_printf("TilingAperture res %04dx%04d fmt %04x tm %02x mip %d isWrite %d", (uint32)tilingAperture->surface.width, (uint32)tilingAperture->surface.height, (uint32)tilingAperture->surface.format, (uint32)tilingAperture->surface.tileMode, tilingAperture->mipLevel, doWrite?1:0);
+	//cemuLog_logDebug(LogType::Force, "TilingAperture res {:04}x{:04} fmt {:04x} tm {:02x} mip {} isWrite {}", (uint32)tilingAperture->surface.width, (uint32)tilingAperture->surface.height, (uint32)tilingAperture->surface.format, (uint32)tilingAperture->surface.tileMode, tilingAperture->mipLevel, doWrite?1:0);
 	//forceLogDebug_printf("Tiling took %.4lfms", benchmarkTime);
 }
 

--- a/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_TilingAperture.cpp
@@ -371,7 +371,7 @@ void GX2TilingAperature_RetileTexture(ActiveTilingAperature* tilingAperture, boo
 
 	//double benchmarkTime = benchmarkTimer_stop(timerTilingStart);
 	//cemuLog_logDebug(LogType::Force, "TilingAperture res {:04}x{:04} fmt {:04x} tm {:02x} mip {} isWrite {}", (uint32)tilingAperture->surface.width, (uint32)tilingAperture->surface.height, (uint32)tilingAperture->surface.format, (uint32)tilingAperture->surface.tileMode, tilingAperture->mipLevel, doWrite?1:0);
-	//forceLogDebug_printf("Tiling took %.4lfms", benchmarkTime);
+	//cemuLog_logDebug(LogType::Force, "Tiling took {:.4}ms", benchmarkTime);
 }
 
 void gx2Export_GX2AllocateTilingApertureEx(PPCInterpreter_t* hCPU)

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -1105,7 +1105,7 @@ namespace H264
 				// end of sequence
 				break;
 			default:
-				forceLogDebug_printf("Unsupported NAL unit type %d", nal_unit_type);
+				cemuLog_logDebug(LogType::Force, "Unsupported NAL unit type {}", nal_unit_type);
 				cemu_assert_unimplemented();
 				// todo
 				break;

--- a/src/Cafe/OS/libs/h264_avc/parser/H264Parser.cpp
+++ b/src/Cafe/OS/libs/h264_avc/parser/H264Parser.cpp
@@ -395,7 +395,7 @@ void parseNAL_ref_pic_list_modification(const h264State_seq_parameter_set_t& sps
 			}
 			if (sliceHeader->pic_list_modification1Count > 0)
 			{
-				forceLogDebug_printf("sliceHeader->pic_list_modification1Count non-zero is not supported");
+				cemuLog_logDebug(LogType::Force, "sliceHeader->pic_list_modification1Count non-zero is not supported");
 				cemu_assert_unimplemented();
 			}
 		}

--- a/src/Cafe/OS/libs/h264_avc/parser/H264Parser.cpp
+++ b/src/Cafe/OS/libs/h264_avc/parser/H264Parser.cpp
@@ -855,7 +855,7 @@ void h264Parse(h264ParserState_t* h264ParserState, h264ParserOutput_t* output, u
 			// seen in Cocoto Magic Circus 2 intro video
 			break;
 		default:
-			forceLogDebug_printf("Unsupported NAL unit type %d", nal_unit_type);
+			cemuLog_logDebug(LogType::Force, "Unsupported NAL unit type {}", nal_unit_type);
 			cemu_assert_debug(false);
 			// todo
 			break;
@@ -945,7 +945,7 @@ sint32 h264GetUnitLength(h264ParserState_t* h264ParserState, uint8* data, uint32
 			// end of sequence
 			break;
 		default:
-			forceLogDebug_printf("Unsupported NAL unit type %d", nal_unit_type);
+			cemuLog_logDebug(LogType::Force, "Unsupported NAL unit type {}", nal_unit_type);
 			assert_dbg(); // todo - NAL 10 is used in DKC TF
 			// todo
 			break;

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -546,7 +546,7 @@ void export_curl_multi_info_read(PPCInterpreter_t* hCPU)
 
 	CURLMsg* msg = ::curl_multi_info_read(curlm->curlm, msgsInQueue.GetPtr());
 
-	forceLogDebug_printf("curl_multi_info_read - todo");
+	cemuLog_logDebug(LogType::Force, "curl_multi_info_read - todo");
 	if (msg)
 	{
 		MEMPTR<CURLMsg_t> result{ PPCCoreCallback(g_nlibcurl.malloc.GetMPTR(), ppcsizeof<CURLMsg_t>()) };
@@ -898,7 +898,7 @@ int sockopt_callback(void* clientp, curl_socket_t curlfd, curlsocktype purpose)
 {
 	CURL_t* curl = (CURL_t*)clientp;
 
-	forceLogDebug_printf("sockopt_callback called!");
+	cemuLog_logDebug(LogType::Force, "sockopt_callback called!");
 
 	sint32 r = 0;
 
@@ -1220,7 +1220,7 @@ void export_curl_easy_getinfo(PPCInterpreter_t* hCPU)
 		}
 		case CURLINFO_CONTENT_TYPE:
 		{
-			//forceLogDebug_printf("CURLINFO_CONTENT_TYPE not supported");
+			//cemuLog_logDebug(LogType::Force, "CURLINFO_CONTENT_TYPE not supported");
 			//*(uint32*)parameter.GetPtr() = MPTR_NULL;
 			char* contentType = nullptr;
 			result = curl_easy_getinfo(curlObj, CURLINFO_REDIRECT_URL, &contentType);
@@ -1315,7 +1315,7 @@ void export_curl_slist_free_all(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(list, curl_slist_t, 0);
 
-	forceLogDebug_printf("export_curl_slist_free_all: TODO");
+	cemuLog_logDebug(LogType::Force, "export_curl_slist_free_all: TODO");
 
 	osLib_returnFromFunction(hCPU, 0);
 }

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -441,7 +441,7 @@ void export_curl_multi_perform(PPCInterpreter_t* hCPU)
 	int tempRunningHandles = 0;
 	CURLMcode result = curl_multi_perform(curlm->curlm, &tempRunningHandles);
 	*(runningHandles.GetPtr()) = tempRunningHandles;
-	forceLogDebug_printf("curl_multi_perform(0x%08x, 0x%08x) -> 0x%x (running handles: %d) LR: 0x%08x", curlm.GetMPTR(), runningHandles.GetMPTR(), result, tempRunningHandles, hCPU->spr.LR);
+	cemuLog_logDebug(LogType::Force, "curl_multi_perform(0x{:08x}, 0x{:08x}) -> 0x{:x} (running handles: {})", curlm.GetMPTR(), runningHandles.GetMPTR(), result, tempRunningHandles);
 	//const uint32 result = SendOrderToWorker(curlm.GetPtr(), QueueOrder_MultiPerform);
 
 	osLib_returnFromFunction(hCPU, result);

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -958,7 +958,7 @@ int progress_callback(void* clientp, double dltotal, double dlnow, double ultota
 	if (msg.order != QueueOrder_CBDone)
 		cemu_assert_suspicious();
 	
-	forceLogDebug_printf("progress_callback(%.02lf, %.02lf, %.02lf, %.02lf) -> %d", dltotal, dlnow, ultotal, ulnow, msg.result);
+	cemuLog_logDebug(LogType::Force, "progress_callback({:.02}, {:.02}, {:.02}, {:.02}) -> {}", dltotal, dlnow, ultotal, ulnow, msg.result);
 	return msg.result;
 }
 

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -272,7 +272,7 @@ uint32 SendOrderToWorker(CURL_t* curl, QueueOrder order, uint32 arg1 = 0)
 			sendMsg.order = QueueOrder_CBDone;
 			cemuLog_logDebug(LogType::Force, "QueueOrder_ReadCB size: {} nitems: {}", msg.read_cb.size, msg.read_cb.nitems);
 			sendMsg.result = PPCCoreCallback(curl->fread_func_set.GetMPTR(), tmp.GetMPTR(), msg.read_cb.size, msg.read_cb.nitems, curl->in_set.GetMPTR());
-			forceLogDebug_printf("readcb size: %d", (sint32)sendMsg.result);
+			cemuLog_logDebug(LogType::Force, "readcb size: {}", (sint32)sendMsg.result);
 			if (sendMsg.result > 0)
 				memcpy(msg.read_cb.buffer, tmp.GetPointer(), sendMsg.result);
 
@@ -362,7 +362,7 @@ CURLcode curl_global_init(uint32 flags)
 void export_curl_multi_init(PPCInterpreter_t* hCPU)
 {
 	CURLMPtr result{ PPCCoreCallback(g_nlibcurl.calloc, 1, ppcsizeof<CURLM_t>()) };
-	forceLogDebug_printf("curl_multi_init() -> 0x%08x", result.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_multi_init() -> 0x{:08x}", result.GetMPTR());
 	if (result)
 	{
 		memset(result.GetPtr(), 0, sizeof(CURLM_t));
@@ -641,7 +641,7 @@ void export_curl_share_setopt(PPCInterpreter_t* hCPU)
 void export_curl_share_init(PPCInterpreter_t* hCPU)
 {
 	CURLSHPtr result{ PPCCoreCallback(g_nlibcurl.calloc.GetMPTR(), (uint32)1, ppcsizeof<CURLSH_t>()) };
-	forceLogDebug_printf("curl_share_init() -> 0x%08x", result.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_share_init() -> 0x{:08x}", result.GetMPTR());
 	if (result)
 	{
 		memset(result.GetPtr(), 0, sizeof(CURLSH_t));
@@ -701,7 +701,7 @@ void export_curl_easy_init(PPCInterpreter_t* hCPU)
 
 	// Curl_open
 	CURLPtr result{ PPCCoreCallback(g_nlibcurl.calloc.GetMPTR(), (uint32)1, ppcsizeof<CURL_t>()) };
-	forceLogDebug_printf("curl_easy_init() -> 0x%08x", result.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_easy_init() -> 0x{:08x}", result.GetMPTR());
 	if (result)
 	{
 		memset(result.GetPtr(), 0, sizeof(CURL_t));
@@ -743,7 +743,7 @@ void export_curl_easy_pause(PPCInterpreter_t* hCPU)
 void export_curl_easy_cleanup(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(curl, CURL_t, 0);
-	forceLogDebug_printf("curl_easy_cleanup(0x%08x)", curl.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_easy_cleanup(0x{:08x})", curl.GetMPTR());
 
 	curlDebug_cleanup(curl.GetPtr());
 
@@ -761,7 +761,7 @@ void export_curl_easy_cleanup(PPCInterpreter_t* hCPU)
 void export_curl_easy_reset(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(curl, CURL_t, 0);
-	forceLogDebug_printf("curl_easy_reset(0x%08x)", curl.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_easy_reset(0x{:08x})", curl.GetMPTR());
 	// curl_apply_default_proxy_config();
 	::curl_easy_reset(curl->curl);
 	osLib_returnFromFunction(hCPU, 0);
@@ -772,7 +772,7 @@ int ssl_verify_callback(int preverify_ok, X509_STORE_CTX* ctx)
 	if (preverify_ok) return preverify_ok;
 	int err = X509_STORE_CTX_get_error(ctx);
 	if(err != 0)
-		forceLogDebug_printf("ssl_verify_callback: Error %d but allow certificate anyway", err);
+		cemuLog_logDebug(LogType::Force, "ssl_verify_callback: Error {} but allow certificate anyway", err);
 	X509_STORE_CTX_set_error(ctx, 0);
 	return 1;
 }
@@ -1104,7 +1104,7 @@ void export_curl_easy_setopt(PPCInterpreter_t* hCPU)
 			bool isFirst = true;
 			for (curl_slist_t* ppcList = (curl_slist_t*)parameter.GetPtr(); ppcList; ppcList = ppcList->next.GetPtr())
 			{
-				forceLogDebug_printf("curl_slist_append: %s", ppcList->data.GetPtr());
+				cemuLog_logDebug(LogType::Force, "curl_slist_append: {}", ppcList->data.GetPtr());
 				curlDebug_logEasySetOptStr(curl.GetPtr(), isFirst?"CURLOPT_HTTPHEADER" : "CURLOPT_HTTPHEADER(continue)", (const char*)ppcList->data.GetPtr());
 				list = ::curl_slist_append(list, ppcList->data.GetPtr());
 				isFirst = false;
@@ -1167,7 +1167,7 @@ void export_curl_easy_perform(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(curl, CURL_t, 0);
 	curlDebug_markActiveRequest(curl.GetPtr());
 	curlDebug_notifySubmitRequest(curl.GetPtr());
-	forceLogDebug_printf("curl_easy_perform(0x%08x)", curl.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_easy_perform(0x{:08x})", curl.GetMPTR());
 	const uint32 result = SendOrderToWorker(curl.GetPtr(), QueueOrder_Perform);
 	cemuLog_logDebug(LogType::Force, "curl_easy_perform(0x{:08x}) -> 0x{:x} DONE", curl.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
@@ -1261,7 +1261,7 @@ void export_curl_easy_strerror(PPCInterpreter_t* hCPU)
 	const char* error = curl_easy_strerror((CURLcode)code);
 	if (error)
 	{
-		forceLogDebug_printf("curl_easy_strerror: %s", error);
+		cemuLog_logDebug(LogType::Force, "curl_easy_strerror: {}", error);
 		int len = (int)strlen(error) + 1;
 		result = coreinit_allocFromSysArea(len, 4);
 		memcpy(result.GetPtr(), error, len);

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -228,7 +228,7 @@ uint32 SendOrderToWorker(CURL_t* curl, QueueOrder order, uint32 arg1 = 0)
 	OSThread_t* currentThread = coreinitThread_getCurrentThreadDepr(ppcInterpreterCurrentInstance);
 	curl->curlThread = currentThread;
 
-	// forceLogDebug_printf("CURRENTTHREAD: 0x%p -> %d",currentThread, order)
+	// cemuLog_logDebug(LogType::Force, "CURRENTTHREAD: 0x{} -> {}",currentThread, order)
 
 	PPCConcurrentQueue<QueueMsg_t> callerQueue;
 	ConcurrentQueue<QueueMsg_t> threadQueue;
@@ -270,7 +270,7 @@ uint32 SendOrderToWorker(CURL_t* curl, QueueOrder order, uint32 arg1 = 0)
 
 			QueueMsg_t sendMsg = {};
 			sendMsg.order = QueueOrder_CBDone;
-			forceLogDebug_printf("QueueOrder_ReadCB size: %d nitems: %d", msg.read_cb.size, msg.read_cb.nitems);
+			cemuLog_logDebug(LogType::Force, "QueueOrder_ReadCB size: {} nitems: {}", msg.read_cb.size, msg.read_cb.nitems);
 			sendMsg.result = PPCCoreCallback(curl->fread_func_set.GetMPTR(), tmp.GetMPTR(), msg.read_cb.size, msg.read_cb.nitems, curl->in_set.GetMPTR());
 			forceLogDebug_printf("readcb size: %d", (sint32)sendMsg.result);
 			if (sendMsg.result > 0)
@@ -423,7 +423,7 @@ void export_curl_multi_cleanup(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(curlm, CURLM_t, 0);
 	CURLMcode result = ::curl_multi_cleanup(curlm->curlm);
-	forceLogDebug_printf("curl_multi_cleanup(0x%08x) -> 0x%x", curlm.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_multi_cleanup(0x{:08x}) -> 0x{:x}", curlm.GetMPTR(), result);
 	curlm->curl.clear();
 	PPCCoreCallback(g_nlibcurl.free.GetMPTR(), curlm.GetMPTR());
 	osLib_returnFromFunction(hCPU, result);
@@ -434,7 +434,7 @@ void export_curl_multi_perform(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(curlm, CURLM_t, 0);
 	ppcDefineParamMEMPTR(runningHandles, uint32be, 1);
 
-	//forceLogDebug_printf("curl_multi_perform(0x%08x, 0x%08x)", curlm.GetMPTR(), runningHandles.GetMPTR());
+	//cemuLog_logDebug(LogType::Force, "curl_multi_perform(0x{:08x}, 0x{:08x})", curlm.GetMPTR(), runningHandles.GetMPTR());
 
 	//g_callerQueue = curlm->callerQueue;
 	//g_threadQueue = curlm->threadQueue;
@@ -656,7 +656,7 @@ void export_curl_share_cleanup(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(curlsh, CURLSH_t, 0);
 	uint32 result = ::curl_share_cleanup(curlsh->curlsh);
-	forceLogDebug_printf("curl_share_cleanup(0x%08x) -> 0x%x", curlsh.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_share_cleanup(0x{:08x}) -> 0x{:x}", curlsh.GetMPTR(), result);
 	PPCCoreCallback(g_nlibcurl.free.GetMPTR(), curlsh.GetMPTR());
 	osLib_returnFromFunction(hCPU, 0);
 }
@@ -732,11 +732,11 @@ void export_curl_easy_pause(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(curl, CURL_t, 0);
 	ppcDefineParamS32(bitmask, 1);
-	forceLogDebug_printf("curl_easy_pause(0x%08x, 0x%x)", curl.GetMPTR(), bitmask);
+	cemuLog_logDebug(LogType::Force, "curl_easy_pause(0x{:08x}, 0x{:x})", curl.GetMPTR(), bitmask);
 
 	//const CURLcode result = ::curl_easy_pause(curl->curl, bitmask);
 	const uint32 result = SendOrderToWorker(curl.GetPtr(), QueueOrder_Pause, bitmask);
-	forceLogDebug_printf("curl_easy_pause(0x%08x, 0x%x) DONE", curl.GetMPTR(), bitmask);
+	cemuLog_logDebug(LogType::Force, "curl_easy_pause(0x{:08x}, 0x{:x}) DONE", curl.GetMPTR(), bitmask);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -993,7 +993,7 @@ void export_curl_easy_setopt(PPCInterpreter_t* hCPU)
 		case CURLOPT_URL:
 		{
 			curlDebug_logEasySetOptStr(curl.GetPtr(), "CURLOPT_URL", (const char*)parameter.GetPtr());
-			forceLogDebug_printf("curl_easy_setopt(%d) [%s]", option, parameter.GetPtr());
+			cemuLog_logDebug(LogType::Force, "curl_easy_setopt({}) [{}]", option, parameter.GetPtr());
 			result = ::curl_easy_setopt(curlObj, (CURLoption)option, parameter.GetPtr());
 			break;
 		}
@@ -1001,7 +1001,7 @@ void export_curl_easy_setopt(PPCInterpreter_t* hCPU)
 		case CURLOPT_PROXY:
 		case CURLOPT_USERAGENT:
 		{
-			forceLogDebug_printf("curl_easy_setopt(%d) [%s]", option, parameter.GetPtr());
+			cemuLog_logDebug(LogType::Force, "curl_easy_setopt({}) [{}]", option, parameter.GetPtr());
 			result = ::curl_easy_setopt(curlObj, (CURLoption)option, parameter.GetPtr());
 			break;
 		}
@@ -1009,7 +1009,7 @@ void export_curl_easy_setopt(PPCInterpreter_t* hCPU)
 		case CURLOPT_POSTFIELDS:
 		{
 			curlDebug_logEasySetOptStr(curl.GetPtr(), "CURLOPT_POSTFIELDS", (const char*)parameter.GetPtr());
-			forceLogDebug_printf("curl_easy_setopt(%d) [%s]", option, parameter.GetPtr());
+			cemuLog_logDebug(LogType::Force, "curl_easy_setopt({}) [{}]", option, parameter.GetPtr());
 			result = ::curl_easy_setopt(curlObj, (CURLoption)option, parameter.GetPtr());
 			break;
 		}
@@ -1169,7 +1169,7 @@ void export_curl_easy_perform(PPCInterpreter_t* hCPU)
 	curlDebug_notifySubmitRequest(curl.GetPtr());
 	forceLogDebug_printf("curl_easy_perform(0x%08x)", curl.GetMPTR());
 	const uint32 result = SendOrderToWorker(curl.GetPtr(), QueueOrder_Perform);
-	forceLogDebug_printf("curl_easy_perform(0x%08x) -> 0x%x DONE", curl.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_easy_perform(0x{:08x}) -> 0x{:x} DONE", curl.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -385,7 +385,7 @@ void export_curl_multi_add_handle(PPCInterpreter_t* hCPU)
 	if (result == CURLM_OK)
 		curlm->curl.push_back(curl.GetPtr());
 
-	forceLogDebug_printf("curl_multi_add_handle(0x%08x, 0x%08x) -> 0x%x", curlm.GetMPTR(), curl.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_multi_add_handle(0x{:08x}, 0x{:08x}) -> 0x{:x}", curlm.GetMPTR(), curl.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -401,7 +401,7 @@ void export_curl_multi_remove_handle(PPCInterpreter_t* hCPU)
 		curlm->curl.erase(std::remove(curlm->curl.begin(), curlm->curl.end(), (void*)curl.GetPtr()), curlm->curl.end());
 	}
 
-	forceLogDebug_printf("curl_multi_remove_handle(0x%08x, 0x%08x) -> 0x%x", curlm.GetMPTR(), curl.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_multi_remove_handle(0x{:08x}, 0x{:08x}) -> 0x{:x}", curlm.GetMPTR(), curl.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -415,7 +415,7 @@ void export_curl_multi_timeout(PPCInterpreter_t* hCPU)
 	CURLMcode result = ::curl_multi_timeout(curlm->curlm, &timeoutLE);
 	*timeoParam = (uint32)timeoutLE;
 
-	forceLogDebug_printf("curl_multi_timeout(0x%08x, 0x%08x [%d]) -> 0x%x", curlm.GetMPTR(), timeoParam.GetMPTR(), timeoutLE, result);
+	cemuLog_logDebug(LogType::Force, "curl_multi_timeout(0x{:08x}, 0x{:08x} [{}]) -> 0x{:x}", curlm.GetMPTR(), timeoParam.GetMPTR(), timeoutLE, result);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -531,10 +531,10 @@ void export_curl_multi_setopt(PPCInterpreter_t* hCPU)
 		result = ::curl_multi_setopt(curlm->curlm, (CURLMoption)option, parameter.GetMPTR());
 		break;
 	default:
-		forceLogDebug_printf("curl_multi_setopt(0x%08x, %d, 0x%08x) unsupported option", curlm.GetMPTR(), option, parameter.GetMPTR());
+		cemuLog_logDebug(LogType::Force, "curl_multi_setopt(0x{:08x}, {}, 0x{:08x}) unsupported option", curlm.GetMPTR(), option, parameter.GetMPTR());
 	}
 
-	forceLogDebug_printf("curl_multi_setopt(0x%08x, %d, 0x%08x) -> 0x%x", curlm.GetMPTR(), option, parameter.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_multi_setopt(0x{:08x}, {}, 0x{:08x}) -> 0x{:x}", curlm.GetMPTR(), option, parameter.GetMPTR(), result);
 
 	osLib_returnFromFunction(hCPU, result);
 }
@@ -634,7 +634,7 @@ void export_curl_share_setopt(PPCInterpreter_t* hCPU)
 		default:
 			cemu_assert_unimplemented();
 	}
-	forceLogDebug_printf("curl_share_setopt(0x%08x, 0x%x, 0x%08x) -> 0x%x", share.GetMPTR(), option, parameter.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_share_setopt(0x{:08x}, 0x{:x}, 0x{:08x}) -> 0x{:x}", share.GetMPTR(), option, parameter.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -857,7 +857,7 @@ size_t header_callback(char* buffer, size_t size, size_t nitems, void* userdata)
 	cemu_assert_debug((size*nitems) < 500);
 	memcpy(debug, buffer, size*nitems);
 	debug[size*nitems] = 0;
-	forceLogDebug_printf("header_callback(0x%p, 0x%x, 0x%x, 0x%08x) [%s]", (void*)buffer, size, nitems, curl->writeheader.GetMPTR(), debug);
+	cemuLog_logDebug(LogType::Force, "header_callback(0x{}, 0x{:x}, 0x{:x}, 0x{:08x}) [{}]", (void*)buffer, size, nitems, curl->writeheader.GetMPTR(), debug);
 #endif
 	return msg.result;
 }
@@ -870,7 +870,7 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata)
 	//StackAllocator<char> tmp(size * nmemb);
 	//memcpy(tmp.GetPointer(), ptr, size * nmemb);
 
-	forceLogDebug_printf("write_callback(0x%p 0x%x, 0x%x, 0x%08x)", (void*)ptr, size, nmemb, curl->out.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "write_callback(0x{} 0x{:x}, 0x{:x}, 0x{:08x})", (void*)ptr, size, nmemb, curl->out.GetMPTR());
 
 	if (g_callerQueue == nullptr || g_threadQueue == nullptr)
 	{
@@ -909,7 +909,7 @@ size_t read_callback(char* buffer, size_t size, size_t nitems, void* instream)
 {
 	CURL_t* curl = (CURL_t*)instream;
 
-	forceLogDebug_printf("read_callback(0x%p, 0x%x, 0x%x, 0x%08x) [func: 0x%x]", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), curl->fread_func_set.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "read_callback(0x{}, 0x{:x}, 0x{:x}, 0x{:08x}) [func: 0x{:x}]", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), curl->fread_func_set.GetMPTR());
 
 	if (g_callerQueue == nullptr || g_threadQueue == nullptr)
 	{
@@ -925,14 +925,14 @@ size_t read_callback(char* buffer, size_t size, size_t nitems, void* instream)
 	msg.read_cb.size = (uint32)size;
 	msg.read_cb.nitems = (uint32)std::min<uint32>(nitems, 0x4000); // limit this to 16KB which is the limit in nlibcurl.rpl (Super Mario Maker crashes on level upload if the size is too big)
 
-	forceLogDebug_printf("read_callback(0x%p, 0x%x, 0x%x, 0x%08x) [func: 0x%x] PUSH", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), curl->fread_func_set.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "read_callback(0x{}, 0x{:x}, 0x{:x}, 0x{:08x}) [func: 0x{:x}] PUSH", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), curl->fread_func_set.GetMPTR());
 	g_callerQueue->push(msg, curl->curlThread);
 
 	msg = g_threadQueue->pop();
 	if (msg.order != QueueOrder_CBDone)
 		cemu_assert_suspicious();
 
-	forceLogDebug_printf("read_callback(0x%p, 0x%x, 0x%x, 0x%08x) DONE Result: %d", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), msg.result);
+	cemuLog_logDebug(LogType::Force, "read_callback(0x{}, 0x{:x}, 0x{:x}, 0x{:08x}) DONE Result: {}", (void*)buffer, size, nitems, curl->in_set.GetMPTR(), msg.result);
 
 	return msg.result;
 }
@@ -1154,10 +1154,10 @@ void export_curl_easy_setopt(PPCInterpreter_t* hCPU)
 			break;
 		}
 		default:
-			forceLogDebug_printf("curl_easy_setopt(0x%08x, %d, 0x%08x) unsupported option", curl.GetMPTR(), option, parameter.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "curl_easy_setopt(0x{:08x}, {}, 0x{:08x}) unsupported option", curl.GetMPTR(), option, parameter.GetMPTR());
 	}
 
-	forceLogDebug_printf("curl_easy_setopt(0x%08x, %d, 0x%08x) -> 0x%x", curl.GetMPTR(), option, parameter.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_easy_setopt(0x{:08x}, {}, 0x{:08x}) -> 0x{:x}", curl.GetMPTR(), option, parameter.GetMPTR(), result);
 
 	osLib_returnFromFunction(hCPU, result);
 }
@@ -1241,7 +1241,7 @@ void export_curl_easy_getinfo(PPCInterpreter_t* hCPU)
 			result = curl_easy_getinfo(curlObj, (CURLINFO)info, (double*)parameter.GetPtr());
 	}
 
-	forceLogDebug_printf("curl_easy_getinfo(0x%08x, 0x%x, 0x%08x) -> 0x%x", curl.GetMPTR(), info, parameter.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_easy_getinfo(0x{:08x}, 0x{:x}, 0x{:08x}) -> 0x{:x}", curl.GetMPTR(), info, parameter.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -1278,7 +1278,7 @@ void export_curl_slist_append(PPCInterpreter_t* hCPU)
 	MEMPTR<char> dupdata{ PPCCoreCallback(g_nlibcurl.strdup.GetMPTR(), data.GetMPTR()) };
 	if (!dupdata)
 	{
-		forceLogDebug_printf("curl_slist_append(0x%08x, 0x%08x [%s]) -> 0x00000000", list.GetMPTR(), data.GetMPTR(), data.GetPtr());
+		cemuLog_logDebug(LogType::Force, "curl_slist_append(0x{:08x}, 0x{:08x} [{}]) -> 0x00000000", list.GetMPTR(), data.GetMPTR(), data.GetPtr());
 		osLib_returnFromFunction(hCPU, 0);
 		return;
 	}
@@ -1304,7 +1304,7 @@ void export_curl_slist_append(PPCInterpreter_t* hCPU)
 	else
 		PPCCoreCallback(g_nlibcurl.free.GetMPTR(), dupdata.GetMPTR());
 
-	forceLogDebug_printf("curl_slist_append(0x%08x, 0x%08x [%s]) -> 0x%08x", list.GetMPTR(), data.GetMPTR(), data.GetPtr(), result.GetMPTR());
+	cemuLog_logDebug(LogType::Force, "curl_slist_append(0x{:08x}, 0x{:08x} [{}]) -> 0x{:08x}", list.GetMPTR(), data.GetMPTR(), data.GetPtr(), result.GetMPTR());
 	if(list)
 		osLib_returnFromFunction(hCPU, list.GetMPTR());
 	else
@@ -1349,7 +1349,7 @@ void export_curl_global_init_mem(PPCInterpreter_t* hCPU)
 		}
 	}
 
-	forceLogDebug_printf("curl_global_init_mem(0x%x, 0x%08x, 0x%08x, 0x%08x, 0x%08x, 0x%08x) -> 0x%08x", flags, m.GetMPTR(), f.GetMPTR(), r.GetMPTR(), s.GetMPTR(), c.GetMPTR(), result);
+	cemuLog_logDebug(LogType::Force, "curl_global_init_mem(0x{:x}, 0x{:08x}, 0x{:08x}, 0x{:08x}, 0x{:08x}, 0x{:08x}) -> 0x{:08x}", flags, m.GetMPTR(), f.GetMPTR(), r.GetMPTR(), s.GetMPTR(), c.GetMPTR(), result);
 	osLib_returnFromFunction(hCPU, result);
 }
 

--- a/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
+++ b/src/Cafe/OS/libs/nlibcurl/nlibcurl.cpp
@@ -568,7 +568,7 @@ void export_curl_multi_info_read(PPCInterpreter_t* hCPU)
 		else
 			result->curl = nullptr;
 
-		forceLogDebug_printf("curl_multi_info_read(0x%08x, 0x%08x [%d]) -> 0x%08x (0x%x, 0x%08x, 0x%x)", curlm.GetMPTR(), msgsInQueue.GetMPTR(), *msgsInQueue.GetPtr(),
+		cemuLog_logDebug(LogType::Force, "curl_multi_info_read(0x{:08x}, 0x{:08x} [{}]) -> 0x{:08x} (0x{:x}, 0x{:08x}, 0x{:x})", curlm.GetMPTR(), msgsInQueue.GetMPTR(), *msgsInQueue.GetPtr(),			
 			result.GetMPTR(), msg->msg, result->curl.GetMPTR(), msg->data.result);
 		osLib_returnFromFunction(hCPU, result.GetMPTR());
 	}

--- a/src/Cafe/OS/libs/nlibnss/nlibnss.cpp
+++ b/src/Cafe/OS/libs/nlibnss/nlibnss.cpp
@@ -5,7 +5,7 @@ namespace nlibnss
 {
 	int NSSExportDeviceCertChain(uint8* uknPtr1, uint32be* uknLength1, uint8* uknPtr2, uint32be* uknLength2, uint32 uknR7, uint32 uknR8)
 	{
-		forceLogDebug_printf("NSSExportDeviceCertChain called but not implemented");
+		cemuLog_logDebug(LogType::Force, "NSSExportDeviceCertChain called but not implemented");
 		cemu_assert_debug(false);
 
 		// uknR3 = pointer (can be null, in which case only length is written)

--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -34,7 +34,7 @@ static_assert(TRUE == 1, "TRUE not 1");
 
 void nn_acExport_IsApplicationConnected(PPCInterpreter_t* hCPU)
 {
-	//forceLogDebug_printf("nn_ac.IsApplicationConnected(0x%08x)", hCPU->gpr[3]);
+	//cemuLog_logDebug(LogType::Force, "nn_ac.IsApplicationConnected(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamMEMPTR(connected, uint8, 0);
 	if (connected)
 		*connected = TRUE;

--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -77,7 +77,7 @@ void nn_acExport_GetStatus(PPCInterpreter_t* hCPU)
 void nn_acExport_GetConnectResult(PPCInterpreter_t* hCPU)
 {
 	// GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status
-	forceLogDebug_printf("nn_ac.GetConnectResult(0x%08x) LR %08x", hCPU->spr.LR, hCPU->gpr[3]);
+	forceLogDebug_printf("nn_ac.GetConnectResult(0x%08x)", hCPU->gpr[3]);
 	ppcDefineParamMEMPTR(result, uint32, 0);
 	const uint32 nnResultCode = BUILD_NN_RESULT(NN_RESULT_LEVEL_SUCCESS, NN_RESULT_MODULE_NN_AC, 0);
 	if (result)

--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -13,14 +13,14 @@
 
 void nn_acExport_ConnectAsync(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_ac.ConnectAsync();");
+	cemuLog_logDebug(LogType::Force, "nn_ac.ConnectAsync();");
 	uint32 nnResultCode = BUILD_NN_RESULT(NN_RESULT_LEVEL_SUCCESS, NN_RESULT_MODULE_NN_AC, 0);
 	osLib_returnFromFunction(hCPU, nnResultCode);
 }
 
 void nn_acExport_Connect(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_ac.Connect();");
+	cemuLog_logDebug(LogType::Force, "nn_ac.Connect();");
 
 	// Terraria expects this (or GetLastErrorCode) to return 0 on success
 	// investigate on the actual console
@@ -56,7 +56,7 @@ void nn_acExport_GetConnectStatus(PPCInterpreter_t* hCPU)
 
 void nn_acExport_GetLastErrorCode(PPCInterpreter_t* hCPU)
 {
-	//forceLogDebug_printf("nn_ac.GetLastErrorCode();");
+	//cemuLog_logDebug(LogType::Force, "nn_ac.GetLastErrorCode();");
 	ppcDefineParamMEMPTR(errorCode, uint32, 0);
 	if (errorCode)
 		*errorCode = 0;
@@ -66,7 +66,7 @@ void nn_acExport_GetLastErrorCode(PPCInterpreter_t* hCPU)
 
 void nn_acExport_GetStatus(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_ac.GetStatus();");
+	cemuLog_logDebug(LogType::Force, "nn_ac.GetStatus();");
 	ppcDefineParamMEMPTR(status, uint32, 0);
 	if (status)
 		*status = AC_STATUS_OK;
@@ -159,7 +159,7 @@ void _GetLocalIPAndSubnetMask(uint32& localIp, uint32& subnetMask)
 
 void nnAcExport_GetAssignedAddress(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetAssignedAddress() called");
+	cemuLog_logDebug(LogType::Force, "GetAssignedAddress() called");
 	ppcDefineParamU32BEPtr(ipAddrOut, 0);
 
 	uint32 localIp;
@@ -174,7 +174,7 @@ void nnAcExport_GetAssignedAddress(PPCInterpreter_t* hCPU)
 
 void nnAcExport_GetAssignedSubnet(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetAssignedSubnet() called");
+	cemuLog_logDebug(LogType::Force, "GetAssignedSubnet() called");
 
 	ppcDefineParamU32BEPtr(subnetMaskOut, 0);
 
@@ -206,7 +206,7 @@ void nnAcExport_IsSystemConnected(PPCInterpreter_t* hCPU)
 	ppcDefineParamTypePtr(isConnectedOut, uint8, 0);
 	ppcDefineParamTypePtr(apTypeOut, uint32be, 1);
 
-	forceLogDebug_printf("nn_ac.IsSystemConnected() - placeholder");
+	cemuLog_logDebug(LogType::Force, "nn_ac.IsSystemConnected() - placeholder");
 	*apTypeOut = 0; // ukn
 	*isConnectedOut = 1;
 
@@ -215,7 +215,7 @@ void nnAcExport_IsSystemConnected(PPCInterpreter_t* hCPU)
 
 void nnAcExport_IsConfigExisting(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_ac.IsConfigExisting() - placeholder");
+	cemuLog_logDebug(LogType::Force, "nn_ac.IsConfigExisting() - placeholder");
 
 	ppcDefineParamU32(configId, 0);
 	ppcDefineParamTypePtr(isConfigExisting, uint8, 1);

--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -77,7 +77,7 @@ void nn_acExport_GetStatus(PPCInterpreter_t* hCPU)
 void nn_acExport_GetConnectResult(PPCInterpreter_t* hCPU)
 {
 	// GetConnectStatus__Q2_2nn2acFPQ3_2nn2ac6Status
-	forceLogDebug_printf("nn_ac.GetConnectResult(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_ac.GetConnectResult(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamMEMPTR(result, uint32, 0);
 	const uint32 nnResultCode = BUILD_NN_RESULT(NN_RESULT_LEVEL_SUCCESS, NN_RESULT_MODULE_NN_AC, 0);
 	if (result)

--- a/src/Cafe/OS/libs/nn_acp/nn_acp.cpp
+++ b/src/Cafe/OS/libs/nn_acp/nn_acp.cpp
@@ -350,7 +350,7 @@ namespace acp
 	void export_ACPCheckTitleNotReferAccountLaunch(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamU64(titleId, 0);
-		forceLogDebug_printf("ACPCheckTitleNotReferAccountLaunch(): Placeholder");
+		cemuLog_logDebug(LogType::Force, "ACPCheckTitleNotReferAccountLaunch(): Placeholder");
 
 		osLib_returnFromFunction(hCPU, 0);
 	}
@@ -359,7 +359,7 @@ namespace acp
 	{
 		ppcDefineParamStructPtr(acpMetaData, acpMetaData_t, 0);
 		
-		forceLogDebug_printf("ACPGetLaunchMetaData(): Placeholder");
+		cemuLog_logDebug(LogType::Force, "ACPGetLaunchMetaData(): Placeholder");
 
 		acpPrepareRequest();
 		acpRequest->requestCode = IOSU_ACP_GET_TITLE_META_DATA;
@@ -375,7 +375,7 @@ namespace acp
 	{
 		ppcDefineParamStructPtr(acpMetaXml, acpMetaXml_t, 0);
 
-		forceLogDebug_printf("ACPGetLaunchMetaXml(): Placeholder");
+		cemuLog_logDebug(LogType::Force, "ACPGetLaunchMetaXml(): Placeholder");
 
 		acpPrepareRequest();
 		acpRequest->requestCode = IOSU_ACP_GET_TITLE_META_XML;

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -131,7 +131,7 @@ void nnActExport_CreateConsoleAccount(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetNumOfAccounts(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetNumOfAccounts()\n");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetNumOfAccounts()");
 	osLib_returnFromFunction(hCPU, numAccounts); // account count
 }
 
@@ -213,7 +213,7 @@ uint32 IsNetworkAccount(uint8* isNetworkAccount, uint8 slot)
 
 void nnActExport_IsNetworkAccount(PPCInterpreter_t* hCPU)
 {
-	//forceLogDebug_printf("nn_act.IsNetworkAccount()\n");
+	//cemuLog_logDebug(LogType::Force, "nn_act.IsNetworkAccount()");
 	uint8 isNetAcc = 0;
 	IsNetworkAccount(&isNetAcc, 0xFE);
 	osLib_returnFromFunction(hCPU, isNetAcc);
@@ -230,7 +230,7 @@ void nnActExport_IsNetworkAccountEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetSimpleAddressId(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetSimpleAddressId()\n");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetSimpleAddressId()");
 
 	uint32be simpleAddressId;
 	nn::act::GetSimpleAddressIdEx(&simpleAddressId, iosu::act::ACT_SLOT_CURRENT);
@@ -253,7 +253,7 @@ void nnActExport_GetSimpleAddressIdEx(PPCInterpreter_t* hCPU)
 void nnActExport_GetPrincipalId(PPCInterpreter_t* hCPU)
 {
 	// return error for non-nnid accounts?
-	forceLogDebug_printf("nn_act.GetPrincipalId()\n");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetPrincipalId()");
 	uint32be principalId;
 	GetPrincipalIdEx(&principalId, iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, (uint32)principalId);
@@ -285,7 +285,7 @@ void nnActExport_GetTransferableIdEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetPersistentId(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetPersistentId()");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetPersistentId()");
 	uint32 persistentId = nn::act::GetPersistentIdEx(iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, persistentId);
 }
@@ -325,7 +325,7 @@ void nnActExport_IsParentalControlCheckEnabled(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetHostServerSettings(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetHostServerSettings() - stub");
+	cemuLog_logDebug(LogType::Force, "GetHostServerSettings() - stub");
 	ppcDefineParamStr(ukn, 1);
 	strcpy(ukn, "");
 	osLib_returnFromFunction(hCPU, 0x00000000);
@@ -333,7 +333,7 @@ void nnActExport_GetHostServerSettings(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMii(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetMii(...)\n");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetMii(...)");
 	ppcDefineParamUStr(miiData, 0);
 	uint32 r = nn::act::GetMiiEx(miiData, iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, r);
@@ -341,7 +341,7 @@ void nnActExport_GetMii(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMiiEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetMiiEx(...)\n");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetMiiEx(...)");
 	ppcDefineParamUStr(miiData, 0);
 	ppcDefineParamU8(slot, 1);
 	uint32 r = nn::act::GetMiiEx(miiData, slot);
@@ -507,7 +507,7 @@ void nnActExport_GetParentalControlSlotNoEx(PPCInterpreter_t* hCPU)
 void nnActExport_GetDefaultAccount(PPCInterpreter_t* hCPU)
 {
 	// todo
-	forceLogDebug_printf("GetDefaultAccount(): Return 1?");
+	cemuLog_logDebug(LogType::Force, "GetDefaultAccount(): Return 1?");
 	osLib_returnFromFunction(hCPU, 1);
 }
 
@@ -515,13 +515,13 @@ void nnActExport_GetSlotNo(PPCInterpreter_t* hCPU)
 {
 	// id of active account
 	// uint8 GetSlotNo(void);
-	forceLogDebug_printf("nn_act.GetSlotNo()");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetSlotNo()");
 	osLib_returnFromFunction(hCPU, 1); // 1 is the first slot (0 is invalid)
 }
 
 void nnActExport_GetSlotNoEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetSlotNoEx(...)");
+	cemuLog_logDebug(LogType::Force, "nn_act.GetSlotNoEx(...)");
 	// get slot no by uuid
 	ppcDefineParamUStr(uuid, 0);
 
@@ -544,7 +544,7 @@ void nnActExport_GetSlotNoEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_Initialize(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.Initialize()");
+	cemuLog_logDebug(LogType::Force, "nn_act.Initialize()");
 
 	nn::act::Initialize();
 
@@ -666,7 +666,7 @@ void nnActExport_GetUtcOffsetEx(PPCInterpreter_t* hCPU)
 
 	*utcOffsetOut = 0;
 
-	forceLogDebug_printf("GetUtcOffsetEx stub");
+	cemuLog_logDebug(LogType::Force, "GetUtcOffsetEx stub");
 
 	osLib_returnFromFunction(hCPU, 0);
 }

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -124,7 +124,7 @@ namespace act
 
 void nnActExport_CreateConsoleAccount(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("CreateConsoleAccount(...)");
+	cemuLog_logDebug(LogType::Force, "CreateConsoleAccount(...)");
 	//numAccounts++;
 	osLib_returnFromFunction(hCPU, 0);
 }
@@ -350,7 +350,7 @@ void nnActExport_GetMiiEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMiiImageEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetMiiImageEx unimplemented");
+	cemuLog_logDebug(LogType::Force, "GetMiiImageEx unimplemented");
 
 	osLib_returnFromFunction(hCPU, 0);
 }
@@ -553,7 +553,7 @@ void nnActExport_Initialize(PPCInterpreter_t* hCPU)
 
 void nnActExport_HasNfsAccount(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("Called nn_act.HasNfsAccount");
+	cemuLog_logDebug(LogType::Force, "Called nn_act.HasNfsAccount");
 	osLib_returnFromFunction(hCPU, 1); // Nfs = Nintendo Friend System? (Splatoon tries to call nn_fp.RegisterAccount if we set this to false)
 }
 
@@ -585,7 +585,7 @@ void nnActExport_AcquireNexServiceToken(PPCInterpreter_t* hCPU)
 
 	memcpy(token, actRequest->resultBinary.binBuffer, sizeof(nexServiceToken_t));
 
-	forceLogDebug_printf("Called nn_act.AcquireNexServiceToken");
+	cemuLog_logDebug(LogType::Force, "Called nn_act.AcquireNexServiceToken");
 	osLib_returnFromFunction(hCPU, getNNReturnCode(resultCode, actRequest));
 }
 
@@ -627,7 +627,7 @@ void nnActExport_AcquireIndependentServiceToken2(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(clientId, const char, 1);
 	ppcDefineParamU32(cacheDurationInSeconds, 2); 
 	uint32 result = AcquireIndependentServiceToken(token, clientId.GetPtr(), cacheDurationInSeconds);
-	forceLogDebug_printf("Called nn_act.AcquireIndependentServiceToken2");
+	cemuLog_logDebug(LogType::Force, "Called nn_act.AcquireIndependentServiceToken2");
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -635,7 +635,7 @@ void nnActExport_AcquireEcServiceToken(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(pEcServiceToken, independentServiceToken_t, 0);
 	uint32 result = AcquireIndependentServiceToken(pEcServiceToken.GetPtr(), "71a6f5d6430ea0183e3917787d717c46", 0);
-	forceLogDebug_printf("Called nn_act.AcquireEcServiceToken");
+	cemuLog_logDebug(LogType::Force, "Called nn_act.AcquireEcServiceToken");
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -662,7 +662,7 @@ void nnActExport_GetUtcOffsetEx(PPCInterpreter_t* hCPU)
 	ppcDefineParamU32BEPtr(utcOffsetOut, 0);
 	ppcDefineParamU32(uknParam, 1);
 
-	forceLogDebug_printf("Called nn_act.GetUtcOffsetEx");
+	cemuLog_logDebug(LogType::Force, "Called nn_act.GetUtcOffsetEx");
 
 	*utcOffsetOut = 0;
 

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -644,7 +644,7 @@ void nnActExport_AcquirePrincipalIdByAccountId(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(principalId, uint32be, 0);
 	ppcDefineParamMEMPTR(nnid, char, 1);
 	ppcDefineParamU32(ukn, 2); // some option, can be 0 or 1 ?
-	forceLogDebug_printf("nn_act.AcquirePrincipalIdByAccountId(0x%08x,\"%s\", %d) - last param unknown", principalId.GetMPTR(), nnid.GetPtr(), ukn);
+	cemuLog_logDebug(LogType::Force, "nn_act.AcquirePrincipalIdByAccountId(0x{:08x},\"{}\", {}) - last param unknown", principalId.GetMPTR(), nnid.GetPtr(), ukn);
 	actPrepareRequest2();
 	actRequest->requestCode = IOSU_ARC_ACQUIREPIDBYNNID;
 	strcpy(actRequest->clientId, nnid.GetPtr());

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -616,7 +616,7 @@ void nnActExport_AcquireIndependentServiceToken(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(token, independentServiceToken_t, 0);
 	ppcDefineParamMEMPTR(serviceToken, const char, 1);
 	uint32 result =  AcquireIndependentServiceToken(token.GetPtr(), serviceToken.GetPtr(), 0);
-	forceLogDebug_printf("nn_act.AcquireIndependentServiceToken(0x%p, %s) -> %x | LR %08x", (void*)token.GetPtr(), serviceToken.GetPtr(), result, hCPU->spr.LR);
+	cemuLog_logDebug(LogType::Force, "nn_act.AcquireIndependentServiceToken(0x{}, {}) -> {:x}", (void*)token.GetPtr(), serviceToken.GetPtr(), result);
 	cemuLog_logDebug(LogType::Force, "Token: {}", serviceToken.GetPtr());
 	osLib_returnFromFunction(hCPU, result);
 }

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -240,7 +240,7 @@ void nnActExport_GetSimpleAddressId(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetSimpleAddressIdEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetSimpleAddressIdEx(0x%08x, %d)\n", hCPU->gpr[3], hCPU->gpr[4] & 0xFF);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetSimpleAddressIdEx(0x{:08x}, {})", hCPU->gpr[3], hCPU->gpr[4] & 0xFF);
 
 	ppcDefineParamU32BEPtr(simpleAddressId, 0);
 	ppcDefineParamU8(slot, 1);
@@ -262,7 +262,7 @@ void nnActExport_GetPrincipalId(PPCInterpreter_t* hCPU)
 void nnActExport_GetPrincipalIdEx(PPCInterpreter_t* hCPU)
 {
 	// return error for non-nnid accounts?
-	forceLogDebug_printf("nn_act.GetPrincipalIdEx(0x%08x, %d)\n", hCPU->gpr[3], hCPU->gpr[4]&0xFF);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetPrincipalIdEx(0x{:08x}, {})", hCPU->gpr[3], hCPU->gpr[4]&0xFF);
 	ppcDefineParamU32BEPtr(principalId, 0);
 	ppcDefineParamU8(slot, 1);
 	GetPrincipalIdEx(principalId, slot);
@@ -379,7 +379,7 @@ void nnActExport_GetMiiName(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMiiNameEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetMiiNameEx(0x%08x, %d)", hCPU->gpr[3], hCPU->gpr[4] & 0xFF);
+	cemuLog_logDebug(LogType::Force, "GetMiiNameEx(0x{:08x}, {})", hCPU->gpr[3], hCPU->gpr[4] & 0xFF);
 	ppcDefineParamWStrBE(miiName, 0);
 	ppcDefineParamU8(slot, 1);
 
@@ -460,7 +460,7 @@ void nnActExport_GetUuid(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetUuidEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetUuidEx(0x%08x,0x%02x)", hCPU->gpr[3], hCPU->gpr[3]&0xFF);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetUuidEx(0x{:08x},0x{:02x})", hCPU->gpr[3], hCPU->gpr[3]&0xFF);
 	ppcDefineParamUStr(uuid, 0);
 	ppcDefineParamU8(slot, 1);
 	nn::act::GetUuidEx(uuid, slot);
@@ -487,7 +487,7 @@ void nnActExport_GetAccountId(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetAccountIdEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetAccountIdEx(0x%08x, 0x%02x)", hCPU->gpr[3], hCPU->gpr[3] & 0xFF);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetAccountIdEx(0x{:08x}, 0x{:02x})", hCPU->gpr[3], hCPU->gpr[3] & 0xFF);
 	ppcDefineParamUStr(accId, 0);
 	ppcDefineParamU8(slot, 1);
 	GetAccountIdEx((char*)accId, slot);
@@ -497,7 +497,7 @@ void nnActExport_GetAccountIdEx(PPCInterpreter_t* hCPU)
 void nnActExport_GetParentalControlSlotNoEx(PPCInterpreter_t* hCPU)
 {
 	// GetParentalControlSlotNoEx(uint8* output, uint8 slot)
-	forceLogDebug_printf("nn_act.GetParentalControlSlotNoEx(0x%08x, 0x%02x)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetParentalControlSlotNoEx(0x{:08x}, 0x{:02x})", hCPU->gpr[3], hCPU->gpr[4]);
 	//memory_writeU8(hCPU->gpr[3], 0x01); // returned slot no (slot indices start at 1)
 	memory_writeU8(hCPU->gpr[3], 1); // 0 -> No parental control for slot?
 	//memory_writeU8(hCPU->gpr[3], 0); // 0 -> No parental control for slot?

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -137,7 +137,7 @@ void nnActExport_GetNumOfAccounts(PPCInterpreter_t* hCPU)
 
 void nnActExport_IsSlotOccupied(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.IsSlotOccupied(%d)\n", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_act.IsSlotOccupied({})", hCPU->gpr[3]);
 	ppcDefineParamU8(slot, 0);
 	
 	osLib_returnFromFunction(hCPU, nn::act::GetPersistentIdEx(slot) != 0 ? 1 : 0);
@@ -222,7 +222,7 @@ void nnActExport_IsNetworkAccount(PPCInterpreter_t* hCPU)
 void nnActExport_IsNetworkAccountEx(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamU8(slot, 0);
-	forceLogDebug_printf("nn_act.IsNetworkAccountEx(%d)\n", slot);
+	cemuLog_logDebug(LogType::Force, "nn_act.IsNetworkAccountEx({})", slot);
 	uint8 isNetAcc = 0;
 	IsNetworkAccount(&isNetAcc, slot);
 	osLib_returnFromFunction(hCPU, isNetAcc);
@@ -293,7 +293,7 @@ void nnActExport_GetPersistentId(PPCInterpreter_t* hCPU)
 void nnActExport_GetPersistentIdEx(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamU8(slot, 0);
-	forceLogDebug_printf("nn_act.GetPersistentIdEx(%d)", slot);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetPersistentIdEx({})", slot);
 
 	uint32 persistentId = nn::act::GetPersistentIdEx(slot);
 
@@ -302,7 +302,7 @@ void nnActExport_GetPersistentIdEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetCountry(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetCountry(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetCountry(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStr(country, 0);
 	uint32 r = GetCountryEx(country, iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, r);
@@ -311,7 +311,7 @@ void nnActExport_GetCountry(PPCInterpreter_t* hCPU)
 bool g_isParentalControlCheckEnabled = false;
 void nnActExport_EnableParentalControlCheck(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.EnableParentalControlCheck(%d)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_act.EnableParentalControlCheck({})", hCPU->gpr[3]);
 	ppcDefineParamU8(isEnabled, 0);
 	g_isParentalControlCheckEnabled = isEnabled != 0;
 	osLib_returnFromFunction(hCPU, 0);
@@ -319,7 +319,7 @@ void nnActExport_EnableParentalControlCheck(PPCInterpreter_t* hCPU)
 
 void nnActExport_IsParentalControlCheckEnabled(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.IsParentalControlCheckEnabled() -> %d", g_isParentalControlCheckEnabled);
+	cemuLog_logDebug(LogType::Force, "nn_act.IsParentalControlCheckEnabled() -> {}", g_isParentalControlCheckEnabled);
 	osLib_returnFromFunction(hCPU, g_isParentalControlCheckEnabled);
 }
 
@@ -357,7 +357,7 @@ void nnActExport_GetMiiImageEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMiiName(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetMiiName(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "GetMiiName(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamWStrBE(miiName, 0);
 
 	StackAllocator<FFLData_t> miiData;
@@ -452,7 +452,7 @@ void nnActExport_UpdateMii(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetUuid(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetUuid(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetUuid(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamUStr(uuid, 0);
 	nn::act::GetUuidEx(uuid, iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, 0); // 0 -> result ok
@@ -479,7 +479,7 @@ void nnActExport_GetUuidEx2(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetAccountId(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetAccountId(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetAccountId(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamUStr(accId, 0);
 	GetAccountIdEx((char*)accId, iosu::act::ACT_SLOT_CURRENT);
 	osLib_returnFromFunction(hCPU, 0);
@@ -617,7 +617,7 @@ void nnActExport_AcquireIndependentServiceToken(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(serviceToken, const char, 1);
 	uint32 result =  AcquireIndependentServiceToken(token.GetPtr(), serviceToken.GetPtr(), 0);
 	forceLogDebug_printf("nn_act.AcquireIndependentServiceToken(0x%p, %s) -> %x | LR %08x", (void*)token.GetPtr(), serviceToken.GetPtr(), result, hCPU->spr.LR);
-	forceLogDebug_printf("Token: %s", serviceToken.GetPtr());
+	cemuLog_logDebug(LogType::Force, "Token: {}", serviceToken.GetPtr());
 	osLib_returnFromFunction(hCPU, result);
 }
 

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -276,7 +276,7 @@ void nnActExport_GetTransferableIdEx(PPCInterpreter_t* hCPU)
 	ppcDefineParamU32(unique, 1);
 	ppcDefineParamU8(slot, 2);
 
-	forceLogDebug_printf("nn_act.GetTransferableIdEx(0x%08x, 0x%08x, %d)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5] & 0xFF);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetTransferableIdEx(0x{:08x}, 0x{:08x}, {})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5] & 0xFF);
 	
 	uint32 r = GetTransferableIdEx(transferableId, unique, slot);
 
@@ -469,7 +469,7 @@ void nnActExport_GetUuidEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetUuidEx2(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_act.GetUuidEx(0x%08x,0x%02x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_logDebug(LogType::Force, "nn_act.GetUuidEx(0x{:08x},0x{:02x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	ppcDefineParamUStr(uuid, 0);
 	ppcDefineParamU8(slot, 1);
 	ppcDefineParamS32(name, 2);

--- a/src/Cafe/OS/libs/nn_act/nn_act.cpp
+++ b/src/Cafe/OS/libs/nn_act/nn_act.cpp
@@ -124,7 +124,7 @@ namespace act
 
 void nnActExport_CreateConsoleAccount(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("CreateConsoleAccount(...) LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("CreateConsoleAccount(...)");
 	//numAccounts++;
 	osLib_returnFromFunction(hCPU, 0);
 }
@@ -350,7 +350,7 @@ void nnActExport_GetMiiEx(PPCInterpreter_t* hCPU)
 
 void nnActExport_GetMiiImageEx(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("GetMiiImageEx unimplemented LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("GetMiiImageEx unimplemented");
 
 	osLib_returnFromFunction(hCPU, 0);
 }
@@ -553,7 +553,7 @@ void nnActExport_Initialize(PPCInterpreter_t* hCPU)
 
 void nnActExport_HasNfsAccount(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("Called nn_act.HasNfsAccount LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("Called nn_act.HasNfsAccount");
 	osLib_returnFromFunction(hCPU, 1); // Nfs = Nintendo Friend System? (Splatoon tries to call nn_fp.RegisterAccount if we set this to false)
 }
 
@@ -585,7 +585,7 @@ void nnActExport_AcquireNexServiceToken(PPCInterpreter_t* hCPU)
 
 	memcpy(token, actRequest->resultBinary.binBuffer, sizeof(nexServiceToken_t));
 
-	forceLogDebug_printf("Called nn_act.AcquireNexServiceToken LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("Called nn_act.AcquireNexServiceToken");
 	osLib_returnFromFunction(hCPU, getNNReturnCode(resultCode, actRequest));
 }
 
@@ -627,7 +627,7 @@ void nnActExport_AcquireIndependentServiceToken2(PPCInterpreter_t* hCPU)
 	ppcDefineParamMEMPTR(clientId, const char, 1);
 	ppcDefineParamU32(cacheDurationInSeconds, 2); 
 	uint32 result = AcquireIndependentServiceToken(token, clientId.GetPtr(), cacheDurationInSeconds);
-	forceLogDebug_printf("Called nn_act.AcquireIndependentServiceToken2 LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("Called nn_act.AcquireIndependentServiceToken2");
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -635,7 +635,7 @@ void nnActExport_AcquireEcServiceToken(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamMEMPTR(pEcServiceToken, independentServiceToken_t, 0);
 	uint32 result = AcquireIndependentServiceToken(pEcServiceToken.GetPtr(), "71a6f5d6430ea0183e3917787d717c46", 0);
-	forceLogDebug_printf("Called nn_act.AcquireEcServiceToken LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("Called nn_act.AcquireEcServiceToken");
 	osLib_returnFromFunction(hCPU, result);
 }
 
@@ -662,7 +662,7 @@ void nnActExport_GetUtcOffsetEx(PPCInterpreter_t* hCPU)
 	ppcDefineParamU32BEPtr(utcOffsetOut, 0);
 	ppcDefineParamU32(uknParam, 1);
 
-	forceLogDebug_printf("Called nn_act.GetUtcOffsetEx LR %08x", hCPU->spr.LR);
+	forceLogDebug_printf("Called nn_act.GetUtcOffsetEx");
 
 	*utcOffsetOut = 0;
 

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -419,7 +419,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		Result SetFileName(NbdlTaskSetting_t* thisptr, const char* fileName)
 		{
-			forceLogDebug_printf("nn_boss_NbdlTaskSetting_t_SetFileName(0x%08x, %s)", MEMPTR(thisptr).GetMPTR(), fileName ? fileName : "\"\"");
+			cemuLog_logDebug(LogType::Force, "nn_boss_NbdlTaskSetting_t_SetFileName(0x{:08x}, {})", MEMPTR(thisptr).GetMPTR(), fileName ? fileName : "\"\"");
 
 			if (!fileName || strnlen(fileName, TaskSetting_t::kFileNameLen) == TaskSetting_t::kFileNameLen)
 			{

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -1674,7 +1674,7 @@ void nnBossNsDataExport_read(PPCInterpreter_t* hCPU)
 	ppcDefineParamStr(buffer, 1);
 	ppcDefineParamS32(length, 2);
 
-	forceLogDebug_printf("nsData read LR %08x (filename %s)", hCPU->spr.LR, nsData->name);
+	forceLogDebug_printf("nsData read (filename %s)", nsData->name);
 
 	uint32 r = nnBossNsData_read(nsData, nullptr, buffer, length);
 
@@ -1689,7 +1689,7 @@ void nnBossNsDataExport_readWithSizeOut(PPCInterpreter_t* hCPU)
 	ppcDefineParamS32(length, 3);
 
 	uint32 r = nnBossNsData_read(nsData, sizeOut, buffer, length);
-	forceLogDebug_printf("nsData readWithSizeOut LR %08x (filename %s length 0x%x) Result: %d Sizeout: %llx", hCPU->spr.LR, nsData->name, length, r, _swapEndianU64(*sizeOut));
+	forceLogDebug_printf("nsData readWithSizeOut (filename %s length 0x%x) Result: %d Sizeout: %llx", nsData->name, length, r, _swapEndianU64(*sizeOut));
 
 	osLib_returnFromFunction(hCPU, r);
 }
@@ -1702,7 +1702,7 @@ void nnBossNsDataExport_seek(PPCInterpreter_t* hCPU)
 
 	uint32 r = nnBossNsData_seek(nsData, seekPos, mode);
 
-	forceLogDebug_printf("nsData seek LR %08x (filename %s seek 0x%x) Result: %d", hCPU->spr.LR, nsData->name, (uint32)seekPos, r);
+	forceLogDebug_printf("nsData seek (filename %s seek 0x%x) Result: %d", nsData->name, (uint32)seekPos, r);
 
 	osLib_returnFromFunction(hCPU, r);
 }

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -220,7 +220,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		TitleId_t* ctor2(TitleId_t* thisptr, uint32 filler, uint64 titleId)
 		{
-			forceLogDebug_printf("nn_boss_TitleId_ctor2(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_TitleId_ctor2(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new Task_t
@@ -234,7 +234,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		TitleId_t* cctor(TitleId_t* thisptr, TitleId_t* titleId)
 		{
-			forceLogDebug_printf("nn_boss_TitleId_cctor(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_TitleId_cctor(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new Task_t
@@ -248,7 +248,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		bool operator_ne(TitleId_t* thisptr, TitleId_t* titleId)
 		{
-			forceLogDebug_printf("nn_boss_TitleId_operator_ne(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_TitleId_operator_ne(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			return thisptr->u64 != titleId->u64;
 		}
 	}
@@ -436,7 +436,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 	{
 		RawUlTaskSetting_t* ctor(RawUlTaskSetting_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_RawUlTaskSetting_ctor(0x%x) TODO", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_RawUlTaskSetting_ctor(0x{:x}) TODO", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new RawUlTaskSetting_t
@@ -461,7 +461,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 	{
 		RawDlTaskSetting_t* ctor(RawDlTaskSetting_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_RawDlTaskSetting_ctor(0x%x) TODO", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_RawDlTaskSetting_ctor(0x{:x}) TODO", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new RawDlTaskSetting_t
@@ -600,7 +600,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 	{
 		Title_t* ctor(Title_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_Title_ctor(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Title_ctor(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new Task_t
@@ -617,7 +617,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 	{
 		DirectoryName_t* ctor(DirectoryName_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_DirectoryName_ctor(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_DirectoryName_ctor(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new Task_t
@@ -631,7 +631,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		
 		const char* operator_const_char(DirectoryName_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_DirectoryName_operator_const_char(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_DirectoryName_operator_const_char(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			return thisptr->name;
 		}
 	}
@@ -1155,7 +1155,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		bossStorage_t* ctor(bossStorage_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_Storage_ctor(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Storage_ctor(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new RawDlTaskSetting_t
@@ -1215,7 +1215,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 	{
 		AlmightyStorage_t* ctor(AlmightyStorage_t* thisptr)
 		{
-			forceLogDebug_printf("nn_boss_AlmightyStorage_ctor(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_AlmightyStorage_ctor(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 			{
 				// thisptr = new RawDlTaskSetting_t
@@ -1233,7 +1233,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		uint32 Initialize(AlmightyStorage_t* thisptr, TitleId_t* titleId, const char* storageName, uint32 accountId, StorageKind storageKind)
 		{
-			forceLogDebug_printf("nn_boss_AlmightyStorage_Initialize(0x%x)", MEMPTR(thisptr).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_AlmightyStorage_Initialize(0x{:x})", MEMPTR(thisptr).GetMPTR());
 			if (!thisptr)
 				return 0xc0203780;
 

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -328,7 +328,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		Result SetServiceToken(NetTaskSetting_t* thisptr, const uint8* serviceToken)
 		{
-			forceLogDebug_printf("nn_boss_NetTaskSetting_SetServiceToken(0x%x, 0x%x)", MEMPTR(thisptr).GetMPTR(), MEMPTR(serviceToken).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_SetServiceToken(0x{:x}, 0x{:x})", MEMPTR(thisptr).GetMPTR(), MEMPTR(serviceToken).GetMPTR());
 			forceLogDebug_printf("\t->%s", serviceToken);
 			memcpy(&thisptr->settings[TaskSetting_t::kServiceToken], serviceToken, TaskSetting_t::kServiceTokenLen);
 			return 0x200080;
@@ -336,7 +336,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		Result AddInternalCaCert(NetTaskSetting_t* thisptr, char certId)
 		{
-			forceLogDebug_printf("nn_boss_NetTaskSetting_AddInternalCaCert(0x%x, 0x%x)", MEMPTR(thisptr).GetMPTR(), (int)certId);
+			cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_AddInternalCaCert(0x{:x}, 0x{:x})", MEMPTR(thisptr).GetMPTR(), (int)certId);
 
 			uint32 location = TaskSetting_t::kCACert;
 			for(int i = 0; i < 3; ++i)
@@ -356,7 +356,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		void SetInternalClientCert(NetTaskSetting_t* thisptr, char certId)
 		{
-			forceLogDebug_printf("nn_boss_NetTaskSetting_SetInternalClientCert(0x%x, 0x%x)", MEMPTR(thisptr).GetMPTR(), (int)certId);
+			cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_SetInternalClientCert(0x{:x}, 0x{:x})", MEMPTR(thisptr).GetMPTR(), (int)certId);
 			thisptr->settings[TaskSetting_t::kClientCert] = (uint8)certId;
 		}
 	}
@@ -686,7 +686,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamMEMPTR(taskId, const char, 1);
-			forceLogDebug_printf("nn_boss_Task_Initialize1(0x%08x, %s)", thisptr.GetMPTR(), taskId.GetPtr());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Initialize1(0x{:08x}, {})", thisptr.GetMPTR(), taskId.GetPtr());
 			const Result result = Initialize(thisptr.GetPtr(), taskId.GetPtr());
 			osLib_returnFromFunction(hCPU, result);
 		}
@@ -784,7 +784,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamU8(isForegroundRun, 1);
-			forceLogDebug_printf("nn_boss_Task_Run(0x%08x, %d)", thisptr.GetMPTR(), isForegroundRun);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Run(0x{:08x}, {})", thisptr.GetMPTR(), isForegroundRun);
 			if (isForegroundRun != 0)
 			{
 				//peterBreak();
@@ -807,7 +807,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamU8(executeImmediately, 1);
-			forceLogDebug_printf("nn_boss_Task_StartScheduling(0x%08x, %d)", thisptr.GetMPTR(), executeImmediately);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_StartScheduling(0x{:08x}, {})", thisptr.GetMPTR(), executeImmediately);
 
 			bossPrepareRequest();
 			bossRequest->requestCode = IOSU_NN_BOSS_TASK_START_SCHEDULING;
@@ -849,7 +849,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 			__depr__IOS_Ioctlv(IOS_DEVICE_BOSS, IOSU_BOSS_REQUEST_CEMU, 1, 1, bossBufferVector);
 
-			forceLogDebug_printf("nn_boss_Task_IsRegistered(0x%08x) -> %d", thisptr.GetMPTR(), bossRequest->returnCode);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_IsRegistered(0x{:08x}) -> {}", thisptr.GetMPTR(), bossRequest->returnCode);
 
 			osLib_returnFromFunction(hCPU, bossRequest->returnCode);
 		}
@@ -881,7 +881,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			// RegisterForImmediateRun__Q3_2nn4boss4TaskFRCQ3_2nn4boss11TaskSetting
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamMEMPTR(settings, TaskSetting_t, 1);
-			forceLogDebug_printf("nn_boss_Task_RegisterForImmediateRun(0x%08x, 0x%08x)", thisptr.GetMPTR(), settings.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_RegisterForImmediateRun(0x{:08x}, 0x{:08x})", thisptr.GetMPTR(), settings.GetMPTR());
 
 			bossPrepareRequest();
 			bossRequest->requestCode = IOSU_NN_BOSS_TASK_REGISTER;
@@ -916,7 +916,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamMEMPTR(settings, TaskSetting_t, 1);
-			forceLogDebug_printf("nn_boss_Task_Register(0x%08x, 0x%08x)", thisptr.GetMPTR(), settings.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Register(0x{:08x}, 0x{:08x})", thisptr.GetMPTR(), settings.GetMPTR());
 
 			if (hCPU->gpr[4] == 0)
 			{
@@ -1523,7 +1523,7 @@ void nnBossNsDataExport_Exist(PPCInterpreter_t* hCPU)
 		if (fadTable)
 		{
 			fileExists = nnBossStorageFad_getIndexByName(fadTable, nsData->name) >= 0;
-			forceLogDebug_printf("\t(%s) -> %d", nsData->name, fileExists);
+			cemuLog_logDebug(LogType::Force, "\t({}) -> {}", nsData->name, fileExists);
 			free(fadTable);
 		}
 	}

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -299,7 +299,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		{
 			if(name == nullptr || strnlen(name, 0x80) == 0x80)
 			{
-				forceLogDebug_printf("nn_boss_NetTaskSetting_AddCaCert: name size is invalid");
+				cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_AddCaCert: name size is invalid");
 				return 0xC0203780;
 			}
 
@@ -350,7 +350,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 				location += TaskSetting_t::kCACert;
 			}
 		
-			forceLogDebug_printf("nn_boss_NetTaskSetting_AddInternalCaCert: can't store certificate");
+			cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_AddInternalCaCert: can't store certificate");
 			return 0xA0220D00;
 		}
 
@@ -383,7 +383,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		void export_ctor(PPCInterpreter_t* hCPU)
 		{
 			ppcDefineParamMEMPTR(thisptr, NbdlTaskSetting_t, 0);
-			forceLogDebug_printf("nn_boss_NbdlTaskSetting_ctor");
+			cemuLog_logDebug(LogType::Force, "nn_boss_NbdlTaskSetting_ctor");
 			ctor(thisptr.GetPtr());
 			osLib_returnFromFunction(hCPU, thisptr.GetMPTR());
 		}
@@ -532,7 +532,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		void export_ctor(PPCInterpreter_t* hCPU)
 		{
 			ppcDefineParamMEMPTR(thisptr, PlayReportSetting_t, 0);
-			forceLogDebug_printf("nn_boss_PlayReportSetting_ctor TODO");
+			cemuLog_logDebug(LogType::Force, "nn_boss_PlayReportSetting_ctor TODO");
 			if (!thisptr)
 			{
 				assert_dbg();
@@ -561,7 +561,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 			if(!ptr || value == 0 || value > 0x19000)
 			{
-				forceLogDebug_printf("nn_boss_PlayReportSetting_Initialize: invalid parameter");
+				cemuLog_logDebug(LogType::Force, "nn_boss_PlayReportSetting_Initialize: invalid parameter");
 				osLib_returnFromFunction(hCPU, 0);
 			}
 
@@ -788,7 +788,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (isForegroundRun != 0)
 			{
 				//peterBreak();
-				forceLogDebug_printf("export_Run foreground run");
+				cemuLog_logDebug(LogType::Force, "export_Run foreground run");
 			}
 
 			bossPrepareRequest();
@@ -920,7 +920,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 			if (hCPU->gpr[4] == 0)
 			{
-				forceLogDebug_printf("nn_boss_Task_Register - crash workaround (fix me)");
+				cemuLog_logDebug(LogType::Force, "nn_boss_Task_Register - crash workaround (fix me)");
 				osLib_returnFromFunction(hCPU, 0);
 				return;
 			}
@@ -1112,13 +1112,13 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 	void export_Initialize(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("nn_boss_Initialize()");
+		cemuLog_logDebug(LogType::Force, "nn_boss_Initialize()");
 		osLib_returnFromFunction(hCPU, Initialize());
 	}
 
 	void export_GetBossState(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("nn_boss.GetBossState() - stub");
+		cemuLog_logDebug(LogType::Force, "nn_boss.GetBossState() - stub");
 		osLib_returnFromFunction(hCPU, 7);
 	}
 
@@ -1288,7 +1288,7 @@ void nnBossDataNameExport_opPCc(PPCInterpreter_t* hCPU)
 void nnBossStorageExport_ct(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(storage, nn::boss::Storage::bossStorage_t, 0);
-	forceLogDebug_printf("Constructor for boss storage called");
+	cemuLog_logDebug(LogType::Force, "Constructor for boss storage called");
 	// todo
 	memset(storage, 0, sizeof(nn::boss::Storage::bossStorage_t));
 	osLib_returnFromFunction(hCPU, memory_getVirtualOffsetFromPointer(storage));
@@ -1297,7 +1297,7 @@ void nnBossStorageExport_ct(PPCInterpreter_t* hCPU)
 void nnBossStorageExport_exist(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(storage, nn::boss::Storage::bossStorage_t, 0);
-	forceLogDebug_printf("nn_boss.Storage_Exist(...) TODO");
+	cemuLog_logDebug(LogType::Force, "nn_boss.Storage_Exist(...) TODO");
 
 	// todo
 	osLib_returnFromFunction(hCPU, 1);
@@ -1374,7 +1374,7 @@ void nnBossStorageExport_getDataList(PPCInterpreter_t* hCPU)
 	ppcDefineParamStructPtr(dataList, bossDataName_t, 1);
 	ppcDefineParamS32(maxEntries, 2);
 	ppcDefineParamU32BEPtr(outputEntryCount, 3);
-	forceLogDebug_printf("boss storage getDataList()");
+	cemuLog_logDebug(LogType::Force, "boss storage getDataList()");
 
 	// initialize titleId of storage if not already done
 	nnBossStorage_prepareTitleId(storage);
@@ -1417,7 +1417,7 @@ typedef struct
 
 void nnBossNsDataExport_ct(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nnBossNsDataExport_ct");
+	cemuLog_logDebug(LogType::Force, "nnBossNsDataExport_ct");
 	ppcDefineParamStructPtr(nsData, nsData_t, 0);
 	if (!nsData)
 		assert_dbg();
@@ -1492,7 +1492,7 @@ std::string nnBossNsDataExport_GetPath(nsData_t* nsData)
 void nnBossNsDataExport_DeleteRealFileWithHistory(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(nsData, nsData_t, 0);
-	forceLogDebug_printf("nn_boss.NsData_DeleteRealFileWithHistory(...)");
+	cemuLog_logDebug(LogType::Force, "nn_boss.NsData_DeleteRealFileWithHistory(...)");
 
 	if (nsData->storage.storageKind == nn::boss::kStorageKind_NBDL)
 	{
@@ -1512,7 +1512,7 @@ void nnBossNsDataExport_DeleteRealFileWithHistory(PPCInterpreter_t* hCPU)
 
 void nnBossNsDataExport_Exist(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("nn_boss.NsData_Exist(...)");
+	cemuLog_logDebug(LogType::Force, "nn_boss.NsData_Exist(...)");
 	ppcDefineParamStructPtr(nsData, nsData_t, 0);
 
 	bool fileExists = false;

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -394,7 +394,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamMEMPTR(bossCode, const char, 1);
 			ppcDefineParamU64(directorySizeLimit, 2);
 			ppcDefineParamMEMPTR(directoryName, const char, 4);
-			forceLogDebug_printf("nn_boss_NbdlTaskSetting_Initialize(0x%08x, %s, 0x%llx, 0x%08x)", thisptr.GetMPTR(), bossCode.GetPtr(), directorySizeLimit, directoryName.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_NbdlTaskSetting_Initialize(0x{:08x}, {}, 0x{:x}, 0x{:08x})", thisptr.GetMPTR(), bossCode.GetPtr(), directorySizeLimit, directoryName.GetMPTR());
 
 			if(!bossCode || strnlen(bossCode.GetPtr(), 0x20) == 0x20)
 			{
@@ -479,7 +479,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 
 		Result Initialize(RawDlTaskSetting_t* thisptr, const char* url, bool newArrival, bool led, const char* fileName, const char* directoryName)
 		{
-			forceLogDebug_printf("nn_boss_RawDlTaskSetting_Initialize(0x%x, 0x%x, %d, %d, 0x%x, 0x%x)", MEMPTR(thisptr).GetMPTR(), MEMPTR(url).GetMPTR(), newArrival, led, MEMPTR(fileName).GetMPTR(), MEMPTR(directoryName).GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_RawDlTaskSetting_Initialize(0x{:x}, 0x{:x}, {}, {}, 0x{:x}, 0x{:x})", MEMPTR(thisptr).GetMPTR(), MEMPTR(url).GetMPTR(), newArrival, led, MEMPTR(fileName).GetMPTR(), MEMPTR(directoryName).GetMPTR());
 			if (!url)
 			{
 				return 0xC0203780;
@@ -557,7 +557,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamMEMPTR(ptr, void*, 1);
 			ppcDefineParamU32(value, 2);
 			ppcDefineParamMEMPTR(directoryName, const char, 4);
-			//forceLogDebug_printf("nn_boss_PlayReportSetting_Initialize(0x%08x, %s, 0x%llx, 0x%08x)", thisptr.GetMPTR(), ptr.GetPtr(), directorySizeLimit, directoryName.GetMPTR());
+			//cemuLog_logDebug(LogType::Force, "nn_boss_PlayReportSetting_Initialize(0x{:08x}, {}, 0x{:x}, 0x{:08x})", thisptr.GetMPTR(), ptr.GetPtr(), directorySizeLimit, directoryName.GetMPTR());
 
 			if(!ptr || value == 0 || value > 0x19000)
 			{
@@ -588,7 +588,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamU32(value, 2);
 			
 			// TODO
-			forceLogDebug_printf("nn_boss_PlayReportSetting_Set(0x%08x, %s, 0x%x) TODO", thisptr.GetMPTR(), key.GetPtr(), value);
+			cemuLog_logDebug(LogType::Force, "nn_boss_PlayReportSetting_Set(0x{:08x}, {}, 0x{:x}) TODO", thisptr.GetMPTR(), key.GetPtr(), value);
 			
 			osLib_returnFromFunction(hCPU, 1);
 		}
@@ -667,7 +667,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamMEMPTR(taskId, const char, 1);
 			ppcDefineParamU32(accountId, 2);
-			forceLogDebug_printf("nn_boss_Task_Initialize3(0x%08x, %s, 0x%x)", thisptr.GetMPTR(), taskId.GetPtr(), accountId);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Initialize3(0x{:08x}, {}, 0x{:x})", thisptr.GetMPTR(), taskId.GetPtr(), accountId);
 			const Result result = Initialize(thisptr.GetPtr(), taskId.GetPtr(), accountId);
 			osLib_returnFromFunction(hCPU, result);
 		}
@@ -677,7 +677,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamU8(slotId, 1);
 			ppcDefineParamMEMPTR(taskId, const char, 2);
-			forceLogDebug_printf("nn_boss_Task_Initialize2(0x%08x, %d, %s)", thisptr.GetMPTR(), slotId, taskId.GetPtr());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Initialize2(0x{:08x}, {}, {})", thisptr.GetMPTR(), slotId, taskId.GetPtr());
 			const Result result = Initialize(thisptr.GetPtr(), slotId, taskId.GetPtr());
 			osLib_returnFromFunction(hCPU, result);
 		}
@@ -860,7 +860,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
 			ppcDefineParamU32(timeout, 1);
 			ppcDefineParamU32(waitState, 2);
-			forceLogDebug_printf("nn_boss_Task_Wait(0x%08x, 0x%x, %d)", thisptr.GetMPTR(), timeout, waitState);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Wait(0x{:08x}, 0x{:x}, {})", thisptr.GetMPTR(), timeout, waitState);
 
 			bossPrepareRequest();
 			bossRequest->requestCode = IOSU_NN_BOSS_TASK_WAIT;
@@ -957,7 +957,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (execCount)
 				*execCount = bossRequest->u32.exec_count;
 
-			forceLogDebug_printf("nn_boss_Task_GetTurnState(0x%08x, 0x%08x) -> %d", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u32.result);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_GetTurnState(0x{:08x}, 0x{:08x}) -> {}", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u32.result);
 
 			osLib_returnFromFunction(hCPU, bossRequest->u32.result);
 			//osLib_returnFromFunction(hCPU, 7); // 7 -> finished? 0x11 -> Error (Splatoon doesn't like it when we return 0x11 for Nbdl tasks) RETURN FINISHED
@@ -979,7 +979,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (execCount)
 				*execCount = bossRequest->u64.exec_count;
 
-			forceLogDebug_printf("nn_boss_Task_GetContentLength(0x%08x, 0x%08x) -> 0x%llx", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u64.result);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_GetContentLength(0x{:08x}, 0x{:08x}) -> 0x{:x}", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u64.result);
 
 			osLib_returnFromFunction64(hCPU, bossRequest->u64.result);
 		}
@@ -1000,7 +1000,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (execCount)
 				*execCount = bossRequest->u64.exec_count;
 
-			forceLogDebug_printf("nn_boss_Task_GetProcessedLength(0x%08x, 0x%08x) -> 0x%llx", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u64.result);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_GetProcessedLength(0x{:08x}, 0x{:08x}) -> 0x{:x}", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u64.result);
 
 			osLib_returnFromFunction64(hCPU, bossRequest->u64.result);
 		}
@@ -1021,7 +1021,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (execCount)
 				*execCount = bossRequest->u32.exec_count;
 
-			forceLogDebug_printf("nn_boss_Task_GetHttpStatusCode(0x%08x, 0x%08x) -> %d", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u32.result);
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_GetHttpStatusCode(0x{:08x}, 0x{:08x}) -> {}", thisptr.GetMPTR(), execCount.GetMPTR(), bossRequest->u32.result);
 
 			osLib_returnFromFunction(hCPU, bossRequest->u32.result);
 		}
@@ -1183,7 +1183,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 			if (!dirName)
 				return 0xC0203780;
 
-			forceLogDebug_printf("boss::Storage::Initialize(%s, 0x%08x, %d)", dirName, accountId, type);
+			cemuLog_logDebug(LogType::Force, "boss::Storage::Initialize({}, 0x{:08x}, {})", dirName, accountId, type);
 
 			thisptr->storageKind = type;
 			thisptr->titleId.u64 = 0;

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -1674,7 +1674,7 @@ void nnBossNsDataExport_read(PPCInterpreter_t* hCPU)
 	ppcDefineParamStr(buffer, 1);
 	ppcDefineParamS32(length, 2);
 
-	forceLogDebug_printf("nsData read (filename %s)", nsData->name);
+	cemuLog_logDebug(LogType::Force, "nsData read (filename {})", nsData->name);
 
 	uint32 r = nnBossNsData_read(nsData, nullptr, buffer, length);
 
@@ -1689,7 +1689,7 @@ void nnBossNsDataExport_readWithSizeOut(PPCInterpreter_t* hCPU)
 	ppcDefineParamS32(length, 3);
 
 	uint32 r = nnBossNsData_read(nsData, sizeOut, buffer, length);
-	forceLogDebug_printf("nsData readWithSizeOut (filename %s length 0x%x) Result: %d Sizeout: %llx", nsData->name, length, r, _swapEndianU64(*sizeOut));
+	cemuLog_logDebug(LogType::Force, "nsData readWithSizeOut (filename {} length 0x{:x}) Result: {} Sizeout: {:x}", nsData->name, length, r, _swapEndianU64(*sizeOut));
 
 	osLib_returnFromFunction(hCPU, r);
 }
@@ -1702,7 +1702,7 @@ void nnBossNsDataExport_seek(PPCInterpreter_t* hCPU)
 
 	uint32 r = nnBossNsData_seek(nsData, seekPos, mode);
 
-	forceLogDebug_printf("nsData seek (filename %s seek 0x%x) Result: %d", nsData->name, (uint32)seekPos, r);
+	cemuLog_logDebug(LogType::Force, "nsData seek (filename {} seek 0x{:x}) Result: {}", nsData->name, (uint32)seekPos, r);
 
 	osLib_returnFromFunction(hCPU, r);
 }

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -329,7 +329,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		Result SetServiceToken(NetTaskSetting_t* thisptr, const uint8* serviceToken)
 		{
 			cemuLog_logDebug(LogType::Force, "nn_boss_NetTaskSetting_SetServiceToken(0x{:x}, 0x{:x})", MEMPTR(thisptr).GetMPTR(), MEMPTR(serviceToken).GetMPTR());
-			forceLogDebug_printf("\t->%s", serviceToken);
+			cemuLog_logDebug(LogType::Force, "\t->{}", fmt::ptr(serviceToken));
 			memcpy(&thisptr->settings[TaskSetting_t::kServiceToken], serviceToken, TaskSetting_t::kServiceTokenLen);
 			return 0x200080;
 		}
@@ -490,7 +490,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 				return 0xC0203780;
 			}
 
-			forceLogDebug_printf("\t-> url: %s", url);
+			cemuLog_logDebug(LogType::Force, "\t-> url: {}", url);
 
 			if (fileName && strnlen(fileName, TaskSetting_t::kFileNameLen) == TaskSetting_t::kFileNameLen)
 			{
@@ -511,13 +511,13 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 				strncpy((char*)thisptr + 0x7D0, "rawcontent.dat", TaskSetting_t::kFileNameLen);
 			thisptr->settings[0x7EF] = '\0';
 
-			forceLogDebug_printf("\t-> filename: %s", (char*)thisptr + 0x7D0);
+			cemuLog_logDebug(LogType::Force, "\t-> filename: {}", (char*)thisptr + 0x7D0);
 
 			if (directoryName)
 			{
 				strncpy((char*)thisptr + 0x7C8, directoryName, TaskSetting_t::kDirectoryNameLen);
 				thisptr->settings[0x7CF] = '\0';
-				forceLogDebug_printf("\t-> directoryName: %s", (char*)thisptr + 0x7C8);
+				cemuLog_logDebug(LogType::Force, "\t-> directoryName: {}", (char*)thisptr + 0x7C8);
 			}
 
 			thisptr->settings[0x7C0] = newArrival;
@@ -775,7 +775,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		void export_ctor(PPCInterpreter_t* hCPU)
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
-			forceLogDebug_printf("nn_boss_Task_ctor(0x%08x)", thisptr.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_ctor(0x{:08x})", thisptr.GetMPTR());
 			ctor(thisptr.GetPtr());
 			osLib_returnFromFunction(hCPU, thisptr.GetMPTR());
 		}
@@ -824,7 +824,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		void export_StopScheduling(PPCInterpreter_t* hCPU)
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
-			forceLogDebug_printf("nn_boss_Task_StopScheduling(0x%08x)", thisptr.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_StopScheduling(0x{:08x})", thisptr.GetMPTR());
 
 			bossPrepareRequest();
 			bossRequest->requestCode = IOSU_NN_BOSS_TASK_STOP_SCHEDULING;
@@ -900,7 +900,7 @@ bossBufferVector->buffer = (uint8*)bossRequest;
 		void export_Unregister(PPCInterpreter_t* hCPU)
 		{
 			ppcDefineParamMEMPTR(thisptr, Task_t, 0);
-			forceLogDebug_printf("nn_boss_Task_Unregister(0x%08x)", thisptr.GetMPTR());
+			cemuLog_logDebug(LogType::Force, "nn_boss_Task_Unregister(0x{:08x})", thisptr.GetMPTR());
 
 			bossPrepareRequest();
 			bossRequest->requestCode = IOSU_NN_BOSS_TASK_UNREGISTER;
@@ -1468,7 +1468,7 @@ void nnBossNsDataExport_initialize(PPCInterpreter_t* hCPU)
 
 	nsData->readIndex = 0;
 
-	forceLogDebug_printf("nnBossNsDataExport_initialize: %s", nsData->name);
+	cemuLog_logDebug(LogType::Force, "nnBossNsDataExport_initialize: {}", nsData->name);
 	
 	osLib_returnFromFunction(hCPU, 0x200080);
 }

--- a/src/Cafe/OS/libs/nn_ccr/nn_ccr.cpp
+++ b/src/Cafe/OS/libs/nn_ccr/nn_ccr.cpp
@@ -5,7 +5,7 @@ namespace nn::ccr
 {
 	sint32 CCRSysCaffeineBootCheck()
 	{
-		forceLogDebug_printf("CCRSysCaffeineBootCheck()");
+		cemuLog_logDebug(LogType::Force, "CCRSysCaffeineBootCheck()");
 		return -1;
 	}
 

--- a/src/Cafe/OS/libs/nn_cmpt/nn_cmpt.cpp
+++ b/src/Cafe/OS/libs/nn_cmpt/nn_cmpt.cpp
@@ -5,7 +5,7 @@ namespace nn::cmpt
 {
 	uint32 CMPTAcctGetPcConf(uint32be* pcConf)
 	{
-		forceLogDebug_printf("CMPTAcctGetPcConf() - todo");
+		cemuLog_logDebug(LogType::Force, "CMPTAcctGetPcConf() - todo");
 		pcConf[0] = 0;
 		pcConf[1] = 0;
 		pcConf[2] = 0;

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -116,7 +116,7 @@ namespace nn
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_IS_ONLINE;
 			__depr__IOS_Ioctlv(IOS_DEVICE_FPD, IOSU_FPD_REQUEST_CEMU, 1, 1, fpdBufferVector);
-			forceLogDebug_printf("nn_fp.IsOnline() -> %d", fpdRequest->resultU32.u32);
+			cemuLog_logDebug(LogType::Force, "nn_fp.IsOnline() -> {}", fpdRequest->resultU32.u32);
 
 			osLib_returnFromFunction(hCPU, fpdRequest->resultU32.u32);
 		}
@@ -267,7 +267,7 @@ namespace nn
 
 		void export_GetMyAccountId(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetMyAccountId(0x%08x)", hCPU->gpr[3]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetMyAccountId(0x{:08x})", hCPU->gpr[3]);
 			ppcDefineParamTypePtr(accountId, uint8, 0);
 
 			fpdPrepareRequest();
@@ -280,7 +280,7 @@ namespace nn
 
 		void export_GetMyScreenName(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetMyScreenName(0x%08x)", hCPU->gpr[3]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetMyScreenName(0x{:08x})", hCPU->gpr[3]);
 			ppcDefineParamTypePtr(screenname, uint16be, 0);
 
 			screenname[0] = '\0';
@@ -301,7 +301,7 @@ namespace nn
 
 		void export_GetMyPreference(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetMyPreference(0x%08x) - placeholder", hCPU->gpr[3]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetMyPreference(0x{:08x}) - placeholder", hCPU->gpr[3]);
 			ppcDefineParamTypePtr(pref, fpPerference_t, 0);
 
 			pref->showOnline = 1;
@@ -315,7 +315,7 @@ namespace nn
 
 		void export_GetMyMii(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetMyMii(0x%08x)", hCPU->gpr[3]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetMyMii(0x{:08x})", hCPU->gpr[3]);
 			ppcDefineParamTypePtr(fflData, FFLData_t, 0);
 
 			fpdPrepareRequest();

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -40,13 +40,13 @@ namespace nn
 
 		void export_IsInitialized(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.IsInitialized");
+			cemuLog_logDebug(LogType::Force, "Called nn_fp.IsInitialized");
 			osLib_returnFromFunction(hCPU, g_fp.isInitialized ? 1 : 0);
 		}
 
 		void export_Initialize(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.Initialize");
+			cemuLog_logDebug(LogType::Force, "Called nn_fp.Initialize");
 
 			Initialize();
 
@@ -55,7 +55,7 @@ namespace nn
 
 		void export_InitializeAdmin(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.InitializeAdmin");
+			cemuLog_logDebug(LogType::Force, "Called nn_fp.InitializeAdmin");
 			Initialize();
 			g_fp.isAdminMode = true;
 			osLib_returnFromFunction(hCPU, 0);

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -63,7 +63,7 @@ namespace nn
 
 		void export_IsInitializedAdmin(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.IsInitializedAdmin()");
+			cemuLog_logDebug(LogType::Force, "nn_fp.IsInitializedAdmin()");
 			osLib_returnFromFunction(hCPU, g_fp.isInitialized ? 1 : 0);
 		}
 
@@ -106,13 +106,13 @@ namespace nn
 		void export_HasLoggedIn(PPCInterpreter_t* hCPU)
 		{
 			// Sonic All Star Racing needs this
-			forceLogDebug_printf("nn_fp.HasLoggedIn()");
+			cemuLog_logDebug(LogType::Force, "nn_fp.HasLoggedIn()");
 			osLib_returnFromFunction(hCPU, 1);
 		}
 
 		void export_IsOnline(PPCInterpreter_t* hCPU)
 		{
-			//forceLogDebug_printf("nn_fp.IsOnline();\n");
+			//cemuLog_logDebug(LogType::Force, "nn_fp.IsOnline();");
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_IS_ONLINE;
 			__depr__IOS_Ioctlv(IOS_DEVICE_FPD, IOSU_FPD_REQUEST_CEMU, 1, 1, fpdBufferVector);
@@ -128,7 +128,7 @@ namespace nn
 			ppcDefineParamU32(startIndex, 2);
 			ppcDefineParamU32(maxCount, 3);
 
-			forceLogDebug_printf("nn_fp.GetFriendList(...)");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendList(...)");
 			//debug_printf("nn_fp.GetFriendList(0x%08x, 0x%08x, %d, %d)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_GET_FRIEND_LIST;
@@ -152,7 +152,7 @@ namespace nn
 			ppcDefineParamU32(startIndex, 2);
 			ppcDefineParamU32(maxCount, 3);
 
-			forceLogDebug_printf("nn_fp.GetFriendRequestList(...)");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendRequestList(...)");
 			//debug_printf("nn_fp.GetFriendList(0x%08x, 0x%08x, %d, %d)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_GET_FRIENDREQUEST_LIST;
@@ -175,7 +175,7 @@ namespace nn
 			ppcDefineParamU32(startIndex, 2);
 			ppcDefineParamU32(maxCount, 3);
 
-			forceLogDebug_printf("nn_fp.GetFriendListAll(...)");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendListAll(...)");
 
 			//debug_printf("nn_fp.GetFriendListAll(0x%08x, 0x%08x, %d, %d)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 			fpdPrepareRequest();
@@ -198,7 +198,7 @@ namespace nn
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
 
-			forceLogDebug_printf("nn_fp.GetFriendListEx(...)");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendListEx(...)");
 
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_GET_FRIEND_LIST_EX;
@@ -218,7 +218,7 @@ namespace nn
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
 
-			forceLogDebug_printf("nn_fp.GetFriendRequestListEx(...)");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendRequestListEx(...)");
 
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_GET_FRIENDREQUEST_LIST_EX;
@@ -254,7 +254,7 @@ namespace nn
 
 		void export_GetMyPrincipalId(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetMyPrincipalId()");
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetMyPrincipalId()");
 
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_GET_MY_PRINCIPAL_ID;
@@ -508,7 +508,7 @@ namespace nn
 
 		void export_IsPreferenceValid(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.IsPreferenceValid()");
+			cemuLog_logDebug(LogType::Force, "nn_fp.IsPreferenceValid()");
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_IS_PREFERENCE_VALID;
 			__depr__IOS_Ioctlv(IOS_DEVICE_FPD, IOSU_FPD_REQUEST_CEMU, 1, 1, fpdBufferVector);
@@ -567,7 +567,7 @@ namespace nn
 			ppcDefineParamMPTR(funcMPTR, 3);
 			ppcDefineParamMPTR(customParam, 4);
 
-			forceLogDebug_printf("GetRequestBlockSettingAsync(...) - todo");
+			cemuLog_logDebug(LogType::Force, "GetRequestBlockSettingAsync(...) - todo");
 
 			for (uint32 i = 0; i < pidCount; i++)
 				settingList[i] = 0;
@@ -608,7 +608,7 @@ namespace nn
 
 		void export_DeleteFriendFlagsAsync(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.DeleteFriendFlagsAsync(...) - todo");
+			cemuLog_logDebug(LogType::Force, "nn_fp.DeleteFriendFlagsAsync(...) - todo");
 			ppcDefineParamU32(uknR3, 0); // example value: pointer
 			ppcDefineParamU32(uknR4, 1); // example value: 1
 			ppcDefineParamU32(uknR5, 2); // example value: 1

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -73,7 +73,7 @@ namespace nn
 			ppcDefineParamMPTR(funcMPTR, 1);
 			ppcDefineParamMPTR(customParam, 2);
 
-			forceLogDebug_printf("nn_fp.SetNotificationHandler(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.SetNotificationHandler(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 
 			fpdPrepareRequest();
 			fpdRequest->requestCode = iosu::fpd::IOSU_FPD_SET_NOTIFICATION_HANDLER;
@@ -328,7 +328,7 @@ namespace nn
 
 		void export_GetFriendAccountId(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetFriendAccountId(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendAccountId(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamMEMPTR(accountIds, char, 0);
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
@@ -346,7 +346,7 @@ namespace nn
 		void export_GetFriendScreenName(PPCInterpreter_t* hCPU)
 		{
 			// GetFriendScreenName__Q2_2nn2fpFPA11_wPCUiUibPUc
-			forceLogDebug_printf("nn_fp.GetFriendScreenName(0x%08x,0x%08x,0x%08x,%d,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendScreenName(0x{:08x},0x{:08x},0x{:08x},{},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
 			ppcDefineParamMEMPTR(nameList, uint16be, 0);
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
@@ -367,7 +367,7 @@ namespace nn
 
 		void export_GetFriendMii(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetFriendMii(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendMii(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamMEMPTR(miiList, FFLData_t, 0);
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
@@ -384,7 +384,7 @@ namespace nn
 
 		void export_GetFriendPresence(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetFriendPresence(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendPresence(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamMEMPTR(presenceList, uint8, 0);
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
@@ -401,7 +401,7 @@ namespace nn
 
 		void export_GetFriendRelationship(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.GetFriendRelationship(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.GetFriendRelationship(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamMEMPTR(relationshipList, uint8, 0);
 			ppcDefineParamMEMPTR(pidList, uint32be, 1);
 			ppcDefineParamU32(count, 2);
@@ -481,7 +481,7 @@ namespace nn
 
 		void export_CheckSettingStatusAsync(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.CheckSettingStatusAsync(0x%08x,0x%08x,0x%08x) - placeholder", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.CheckSettingStatusAsync(0x{:08x},0x{:08x},0x{:08x}) - placeholder", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamTypePtr(uknR3, uint8, 0);
 			ppcDefineParamMPTR(funcMPTR, 1);
 			ppcDefineParamU32(customParam, 2);
@@ -518,7 +518,7 @@ namespace nn
 
 		void export_UpdatePreferenceAsync(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.UpdatePreferenceAsync(0x%08x,0x%08x,0x%08x) - placeholder", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.UpdatePreferenceAsync(0x{:08x},0x{:08x},0x{:08x}) - placeholder", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamTypePtr(uknR3, uint8, 0);
 			ppcDefineParamMPTR(funcMPTR, 1);
 			ppcDefineParamU32(customParam, 2);
@@ -545,7 +545,7 @@ namespace nn
 
 		void export_UpdateGameMode(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("nn_fp.UpdateGameMode(0x%08x,0x%08x,%d)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+			cemuLog_logDebug(LogType::Force, "nn_fp.UpdateGameMode(0x{:08x},0x{:08x},{})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 			ppcDefineParamMEMPTR(gameMode, iosu::fpd::gameMode_t, 0);
 			ppcDefineParamMEMPTR(gameModeMessage, uint16be, 1);
 			ppcDefineParamU32(uknR5, 2);

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -89,7 +89,7 @@ namespace nn
 		{
 			ppcDefineParamMPTR(funcPtr, 0);
 			ppcDefineParamMPTR(custom, 1);
-			forceLogDebug_printf("nn_fp.LoginAsync(0x%08x,0x%08x)", funcPtr, custom);
+			cemuLog_logDebug(LogType::Force, "nn_fp.LoginAsync(0x{:08x},0x{:08x})", funcPtr, custom);
 			if (g_fp.isInitialized == false)
 			{
 				osLib_returnFromFunction(hCPU, 0xC0C00580);

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -40,13 +40,13 @@ namespace nn
 
 		void export_IsInitialized(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.IsInitialized LR %08x", hCPU->spr.LR);
+			forceLogDebug_printf("Called nn_fp.IsInitialized");
 			osLib_returnFromFunction(hCPU, g_fp.isInitialized ? 1 : 0);
 		}
 
 		void export_Initialize(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.Initialize LR %08x", hCPU->spr.LR);
+			forceLogDebug_printf("Called nn_fp.Initialize");
 
 			Initialize();
 
@@ -55,7 +55,7 @@ namespace nn
 
 		void export_InitializeAdmin(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Called nn_fp.InitializeAdmin LR %08x", hCPU->spr.LR);
+			forceLogDebug_printf("Called nn_fp.InitializeAdmin");
 			Initialize();
 			g_fp.isAdminMode = true;
 			osLib_returnFromFunction(hCPU, 0);

--- a/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
+++ b/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
@@ -108,7 +108,7 @@ namespace nn
 			SHA256((const unsigned char*)iconOutput, sizeof(nnIdbeIconDataV0_t), calculatedSHA256);
 			if (memcmp(calculatedSHA256, decryptedSHA256, SHA256_DIGEST_LENGTH) != 0)
 			{
-				forceLogDebug_printf("Idbe icon has incorrect sha256 hash");
+				cemuLog_logDebug(LogType::Force, "Idbe icon has incorrect sha256 hash");
 				return false;
 			}
 			return true;
@@ -141,14 +141,14 @@ namespace nn
 			ppcDefineParamTypePtr(input, nnIdbeEncryptedIcon_t, 1);
 			ppcDefineParamU32(platformMode, 2);
 
-			forceLogDebug_printf("nn_idbe.DecryptIconFile(...)");
+			cemuLog_logDebug(LogType::Force, "nn_idbe.DecryptIconFile(...)");
 
 			if (decryptIcon(input, output))
 			{
 				osLib_returnFromFunction(hCPU, 1);
 				return;
 			}
-			forceLogDebug_printf("Unable to decrypt idbe icon file, using default icon");
+			cemuLog_logDebug(LogType::Force, "Unable to decrypt idbe icon file, using default icon");
 
 			// return default icon
 			TGAHeader* tgaHeader = (TGAHeader*)(output->GetTGAData());

--- a/src/Cafe/OS/libs/nn_ndm/nn_ndm.cpp
+++ b/src/Cafe/OS/libs/nn_ndm/nn_ndm.cpp
@@ -10,7 +10,7 @@ namespace nn
 			// parameters:
 			// r3	pointer to status integer (out)
 			// r4	daemon name (integer)
-			forceLogDebug_printf("nn_ndm.GetDaemonStatus(...) - hack\n");
+			cemuLog_logDebug(LogType::Force, "nn_ndm.GetDaemonStatus(...) - hack");
 			// status codes:
 			// 1 - running? Download Manager (scope.rpx) expects this to return 1 (or zero). Otherwise it will display downloads as disabled
 			memory_writeU32(hCPU->gpr[3], 1);

--- a/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
+++ b/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
@@ -453,7 +453,7 @@ void nnNfpExport_GetNfpCommonInfo(PPCInterpreter_t* hCPU)
 		assert_dbg();
 	memset(commonInfo, 0x00, sizeof(nfpCommonData_t));
 
-	forceLogDebug_printf("GetNfpCommonInfo(0x%08x)");
+	cemuLog_logDebug(LogType::Force, "GetNfpCommonInfo(0x{:08x})");
 
 	commonInfo->writeCount[0] = nfp_data.amiiboNFCData.writeCounter[0];
 	commonInfo->writeCount[1] = nfp_data.amiiboNFCData.writeCounter[1];

--- a/src/Cafe/OS/libs/nn_nim/nn_nim.cpp
+++ b/src/Cafe/OS/libs/nn_nim/nn_nim.cpp
@@ -19,7 +19,7 @@ namespace nn
 
 		void export_NeedsNetworkUpdate(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("NeedsNetworkUpdate() - placeholder");
+			cemuLog_logDebug(LogType::Force, "NeedsNetworkUpdate() - placeholder");
 			ppcDefineParamTypePtr(needsUpdate, uint8, 0);
 
 			*needsUpdate = 0;
@@ -40,7 +40,7 @@ namespace nn
 
 		void export_GetUpdatePackageProgress(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("GetUpdatePackageProgress() - placeholder");
+			cemuLog_logDebug(LogType::Force, "GetUpdatePackageProgress() - placeholder");
 			ppcDefineParamTypePtr(updatePackageProgress, updatePackageProgress_t, 0);
 			// status of system update download
 			// values are unknown
@@ -53,7 +53,7 @@ namespace nn
 
 		void export_NeedsNotifyToUsers(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("NeedsNotifyToUsers() - placeholder");
+			cemuLog_logDebug(LogType::Force, "NeedsNotifyToUsers() - placeholder");
 			ppcDefineParamTypePtr(updatePackageProgress, updatePackageProgress_t, 0);
 
 			osLib_returnFromFunction(hCPU, 0);
@@ -61,7 +61,7 @@ namespace nn
 
 		void export_GetNumTitlePackages(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("GetNumTitlePackages() - placeholder");
+			cemuLog_logDebug(LogType::Force, "GetNumTitlePackages() - placeholder");
 
 			nimPrepareRequest();
 
@@ -79,7 +79,7 @@ namespace nn
 
 		void export_ListTitlePackagesStatically(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("ListTitlePackagesStatically() - placeholder");
+			cemuLog_logDebug(LogType::Force, "ListTitlePackagesStatically() - placeholder");
 			ppcDefineParamTypePtr(titleIdList, uint64, 0);
 			ppcDefineParamS32(maxCount, 1);
 
@@ -96,7 +96,7 @@ namespace nn
 
 		void export_GetTitlePackageInfos(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("GetTitlePackageInfos() - placeholder");
+			cemuLog_logDebug(LogType::Force, "GetTitlePackageInfos() - placeholder");
 			ppcDefineParamTypePtr(titlePackageInfo, iosu::nim::titlePackageInfo_t, 0);
 			ppcDefineParamTypePtr(titleIdList, uint64, 1);
 			ppcDefineParamU32(count, 2);
@@ -115,7 +115,7 @@ namespace nn
 
 		void export_NeedsNotifyToUsersTitlePackage(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("NeedsNotifyToUsers() - placeholder");
+			cemuLog_logDebug(LogType::Force, "NeedsNotifyToUsers() - placeholder");
 			ppcDefineParamTypePtr(titlePackageInfo, iosu::nim::titlePackageInfo_t, 0);
 
 			osLib_returnFromFunction(hCPU, 0);
@@ -125,7 +125,7 @@ namespace nn
 
 		void export_GetIconDatabaseEntries(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("GetIconDatabaseEntries() - placeholder");
+			cemuLog_logDebug(LogType::Force, "GetIconDatabaseEntries() - placeholder");
 			ppcDefineParamTypePtr(iconDatabaseEntries, IDBE_DATA, 0);
 			ppcDefineParamTypePtr(titleIdList, uint64, 1);
 			ppcDefineParamS32(count, 2);
@@ -150,7 +150,7 @@ namespace nn
 
 		void export_QuerySchedulerStatus(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("QuerySchedulerStatus() - placeholder");
+			cemuLog_logDebug(LogType::Force, "QuerySchedulerStatus() - placeholder");
 
 			// scheduler status seems to a be a 32bit value?
 			// scope.rpx only checks the second byte and if it matches 0x01 then the scheduler is considered paused/stopped (displays that downloads are inactive)
@@ -172,7 +172,7 @@ namespace nn
 
 		void export_ConstructResultError(PPCInterpreter_t* hCPU)
 		{
-			forceLogDebug_printf("Construct__Q3_2nn3nim11ResultErrorFQ2_2nn6Resulti() - placeholder");
+			cemuLog_logDebug(LogType::Force, "Construct__Q3_2nn3nim11ResultErrorFQ2_2nn6Resulti() - placeholder");
 			ppcDefineParamTypePtr(resultError, nimResultError_t, 0);
 			ppcDefineParamU32BEPtr(nimErrorCodePtr, 1);
 			ppcDefineParamU32(uknParam, 2);
@@ -187,7 +187,7 @@ namespace nn
 		{
 			ppcDefineParamU32BEPtr(country, 0);
 
-			forceLogDebug_printf("GetECommerceInfrastructureCountry - todo");
+			cemuLog_logDebug(LogType::Force, "GetECommerceInfrastructureCountry - todo");
 
 			*country = 0;
 
@@ -219,7 +219,7 @@ namespace nn
 			ppcDefineParamU32(regionOrLanguage, 4);
 			ppcDefineParamU32(uknR8, 5); // title type?
 
-			forceLogDebug_printf("MakeTitlePackageTaskConfigAutoUsingBgInstallPolicy - placeholder");
+			cemuLog_logDebug(LogType::Force, "MakeTitlePackageTaskConfigAutoUsingBgInstallPolicy - placeholder");
 
 			titlePackageTastConfig->titleIdHigh = (uint32)(titleId >> 32);
 			titlePackageTastConfig->titleIdLow = (uint32)(titleId & 0xFFFFFFFF);
@@ -246,7 +246,7 @@ namespace nn
 			ppcDefineParamPtr(titlePackageTastConfig, TitlePackageTaskConfig_t, 1);
 
 			// get install size of currently installed title, otherwise return -1 as size
-			forceLogDebug_printf("CalculateTitleInstallSize - todo\n");
+			cemuLog_logDebug(LogType::Force, "CalculateTitleInstallSize - todo");
 
 			*installSize = 0xFFFFFFFFFFFFFFFF;
 

--- a/src/Cafe/OS/libs/nn_temp/nn_temp.cpp
+++ b/src/Cafe/OS/libs/nn_temp/nn_temp.cpp
@@ -6,7 +6,7 @@ namespace nn::temp
 
 	void nnTempExport_TEMPCreateAndInitTempDir(PPCInterpreter_t* hCPU)
 	{
-		forceLogDebug_printf("TEMPCreateAndInitTempDir(...) - placeholder");
+		cemuLog_logDebug(LogType::Force, "TEMPCreateAndInitTempDir(...) - placeholder");
 
 		// create random temp id
 		memory_writeU64(hCPU->gpr[5], tempIdGenerator);

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -290,7 +290,7 @@ namespace nsyshid
 	{
 		ppcDefineParamTypePtr(hidClient, HIDClient_t, 0);
 		ppcDefineParamMPTR(callbackFuncMPTR, 1);
-		forceLogDebug_printf("nsyshid.HIDAddClient(0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDAddClient(0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 		hidClient->callbackFunc = callbackFuncMPTR;
 		attachClientToList(hidClient);
 		initDeviceList();
@@ -424,7 +424,7 @@ namespace nsyshid
 		{
 			sprintf(debugOutput + i * 3, "%02x ", data[i]);
 		}
-		forceLogDebug_printf("[%s] Data: %s", prefix.c_str(), debugOutput);
+		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
 	}
 
 	void doHIDTransferCallback(MPTR callbackFuncMPTR, MPTR callbackParamMPTR, uint32 hidHandle, uint32 errorCode, MPTR buffer, sint32 length)
@@ -598,7 +598,7 @@ namespace nsyshid
 				transferLength = 0;
 			else
 				transferLength = bt - 1;
-			forceLogDebug_printf("HidRead Result received immediately (error 0x%08x) Length 0x%08x", GetLastError(), transferLength);
+			cemuLog_logDebug(LogType::Force, "HidRead Result received immediately (error 0x{:08x}) Length 0x{:08x}", GetLastError(), transferLength);
 		}
 		else
 		{

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -309,7 +309,7 @@ namespace nsyshid
 	void export_HIDDelClient(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamTypePtr(hidClient, HIDClient_t, 0);
-		forceLogDebug_printf("nsyshid.HIDDelClient(0x%08x)", hCPU->gpr[3]);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDDelClient(0x{:08x})", hCPU->gpr[3]);
 	
 		// todo
 		// do detach callbacks
@@ -519,7 +519,7 @@ namespace nsyshid
 				assert_dbg();
 		}
 		free(reportData);
-		forceLogDebug_printf("_hidSetReportSync end. returnCode: %d", returnCode);
+		cemuLog_logDebug(LogType::Force, "_hidSetReportSync end. returnCode: {}", returnCode);
 		coreinit_resumeThread(osThread, 1000);
 		return returnCode;
 	}
@@ -589,7 +589,7 @@ namespace nsyshid
 
 		_debugPrintHex("HID_READ_BEFORE", data, maxLength);
 
-		forceLogDebug_printf("HidRead Begin (Length 0x%08x)", maxLength);
+		cemuLog_logDebug(LogType::Force, "HidRead Begin (Length 0x{:08x})", maxLength);
 		BOOL readResult = ReadFile(hidDeviceInfo->hFile, tempBuffer, maxLength + 1, &bt, &ovlp);
 		if (readResult != FALSE)
 		{
@@ -603,12 +603,12 @@ namespace nsyshid
 		else
 		{
 			// wait for result
-			forceLogDebug_printf("HidRead WaitForResult (error 0x%08x)", GetLastError());
+			cemuLog_logDebug(LogType::Force, "HidRead WaitForResult (error 0x{:08x})", GetLastError());
 			// async hid read is never supposed to return unless there is an response? Lego Dimensions stops HIDRead calls as soon as one of them fails with a non-zero error (which includes time out)
 			DWORD r = WaitForSingleObject(ovlp.hEvent, 2000*100);
 			if (r == WAIT_TIMEOUT)
 			{
-				forceLogDebug_printf("HidRead internal timeout (error 0x%08x)", GetLastError());
+				cemuLog_logDebug(LogType::Force, "HidRead internal timeout (error 0x{:08x})", GetLastError());
 				// return -108 in case of timeout
 				free(tempBuffer);
 				CloseHandle(ovlp.hEvent);
@@ -622,7 +622,7 @@ namespace nsyshid
 				transferLength = 0;
 			else
 				transferLength = bt - 1;
-			forceLogDebug_printf("HidRead WaitComplete Length: 0x%08x", transferLength);
+			cemuLog_logDebug(LogType::Force, "HidRead WaitComplete Length: 0x{:08x}", transferLength);
 		}
 		sint32 returnCode = 0;
 		if (bt != 0)
@@ -635,7 +635,7 @@ namespace nsyshid
 			{
 				sprintf(debugOutput + i * 3, "%02x ", tempBuffer[1 + i]);
 			}
-			forceLogDebug_printf("HIDRead data: %s", debugOutput);
+			cemuLog_logDebug(LogType::Force, "HIDRead data: {}", debugOutput);
 
 			returnCode = transferLength;
 		}
@@ -710,7 +710,7 @@ namespace nsyshid
 		memcpy(tempBuffer + 1, data, maxLength);
 		tempBuffer[0] = 0; // report byte?
 
-		forceLogDebug_printf("HidWrite Begin (Length 0x%08x)", maxLength);
+		cemuLog_logDebug(LogType::Force, "HidWrite Begin (Length 0x{:08x})", maxLength);
 		BOOL WriteResult = WriteFile(hidDeviceInfo->hFile, tempBuffer, maxLength + 1, &bt, &ovlp);
 		if (WriteResult != FALSE)
 		{
@@ -720,7 +720,7 @@ namespace nsyshid
 		else
 		{
 			// wait for result
-			forceLogDebug_printf("HidWrite WaitForResult (error 0x%08x)", GetLastError());
+			cemuLog_logDebug(LogType::Force, "HidWrite WaitForResult (error 0x{:08x})", GetLastError());
 			// todo - check for error type
 			DWORD r = WaitForSingleObject(ovlp.hEvent, 2000);
 			if (r == WAIT_TIMEOUT)

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -440,7 +440,7 @@ namespace nsyshid
 		ppcDefineParamU32(duration, 3); // r6
 		ppcDefineParamMPTR(callbackFuncMPTR, 4); // r7
 		ppcDefineParamMPTR(callbackParamMPTR, 5); // r8
-		forceLogDebug_printf("nsyshid.HIDSetIdle(...)");
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetIdle(...)");
 
 		// todo
 		if (callbackFuncMPTR)
@@ -461,7 +461,7 @@ namespace nsyshid
 		ppcDefineParamU32(protocol, 2); // r5
 		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
 		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
-		forceLogDebug_printf("nsyshid.HIDSetProtocol(...)");
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetProtocol(...)");
 		
 		if (callbackFuncMPTR)
 		{
@@ -501,7 +501,7 @@ namespace nsyshid
 	// handler for synchronous HIDSetReport transfers
 	sint32 _hidSetReportSync(HIDDeviceInfo_t* hidDeviceInfo, uint8* reportData, sint32 length, uint8* originalData, sint32 originalLength, OSThread_t* osThread)
 	{
-		//forceLogDebug_printf("_hidSetReportSync begin");
+		//cemuLog_logDebug(LogType::Force, "_hidSetReportSync begin");
 		_debugPrintHex("_hidSetReportSync Begin", reportData, length);
 		sint32 retryCount = 0;
 		sint32 returnCode = 0;
@@ -616,7 +616,7 @@ namespace nsyshid
 			}
 
 
-			forceLogDebug_printf("HidRead WaitHalfComplete");
+			cemuLog_logDebug(LogType::Force, "HidRead WaitHalfComplete");
 			GetOverlappedResult(hidDeviceInfo->hFile, &ovlp, &bt, false);
 			if (bt == 0)
 				transferLength = 0;
@@ -725,7 +725,7 @@ namespace nsyshid
 			DWORD r = WaitForSingleObject(ovlp.hEvent, 2000);
 			if (r == WAIT_TIMEOUT)
 			{
-				forceLogDebug_printf("HidWrite internal timeout");
+				cemuLog_logDebug(LogType::Force, "HidWrite internal timeout");
 				// return -108 in case of timeout
 				free(tempBuffer);
 				CloseHandle(ovlp.hEvent);
@@ -733,9 +733,9 @@ namespace nsyshid
 			}
 
 
-			forceLogDebug_printf("HidWrite WaitHalfComplete");
+			cemuLog_logDebug(LogType::Force, "HidWrite WaitHalfComplete");
 			GetOverlappedResult(hidDeviceInfo->hFile, &ovlp, &bt, false);
-			forceLogDebug_printf("HidWrite WaitComplete");
+			cemuLog_logDebug(LogType::Force, "HidWrite WaitComplete");
 		}
 		sint32 returnCode = 0;
 		if (bt != 0)

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -533,7 +533,7 @@ namespace nsyshid
 		ppcDefineParamU32(dataLength, 4); // r7
 		ppcDefineParamMPTR(callbackFuncMPTR, 5); // r8
 		ppcDefineParamMPTR(callbackParamMPTR, 6); // r9
-		forceLogDebug_printf("nsyshid.HIDSetReport(%d,0x%02x,0x%02x,...)", hidHandle, reportRelatedUkn, reportId);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetReport({},0x{:02x},0x{:02x},...)", hidHandle, reportRelatedUkn, reportId);
 
 		_debugPrintHex("HIDSetReport", data, dataLength);
 
@@ -771,7 +771,7 @@ namespace nsyshid
 		ppcDefineParamU32(maxLength, 2); // r5
 		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
 		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
-		forceLogDebug_printf("nsyshid.HIDWrite(0x%x,0x%08x,0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDWrite(0x{:x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
 
 		HIDDeviceInfo_t* hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle, true);
 		if (hidDeviceInfo == nullptr)
@@ -804,7 +804,7 @@ namespace nsyshid
 		ppcDefineParamU32(errorCode, 0);
 		ppcDefineParamTypePtr(ukn0, uint32be, 1);
 		ppcDefineParamTypePtr(ukn1, uint32be, 2);
-		forceLogDebug_printf("nsyshid.HIDDecodeError(0x%08x,0x%08x,0x%08x)", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDDecodeError(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 
 		// todo
 		*ukn0 = 0x3FF;

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -672,7 +672,7 @@ namespace nsyshid
 		ppcDefineParamU32(maxLength, 2); // r5
 		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
 		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
-		forceLogDebug_printf("nsyshid.HIDRead(0x%x,0x%08x,0x%08x,0x%08x,0x%08x) LR %08x", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7], hCPU->spr.LR);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDRead(0x{:x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
 
 		HIDDeviceInfo_t* hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle, true);
 		if (hidDeviceInfo == nullptr)

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -715,7 +715,7 @@ namespace nsyshid
 		if (WriteResult != FALSE)
 		{
 			// sometimes we get the result immediately
-			forceLogDebug_printf("HidWrite Result received immediately (error 0x%08x) Length 0x%08x", GetLastError());
+			cemuLog_logDebug(LogType::Force, "HidWrite Result received immediately (error 0x{:08x}) Length 0x{:08x}", GetLastError());
 		}
 		else
 		{

--- a/src/Cafe/OS/libs/nsyskbd/nsyskbd.cpp
+++ b/src/Cafe/OS/libs/nsyskbd/nsyskbd.cpp
@@ -8,7 +8,7 @@ namespace nsyskbd
 		static bool loggedError = false;
 		if (loggedError == false)
 		{
-			forceLogDebug_printf("KBDGetChannelStatus() placeholder");
+			cemuLog_logDebug(LogType::Force, "KBDGetChannelStatus() placeholder");
 			loggedError = true;
 		}
 		*status = 1; // disconnected

--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -236,7 +236,7 @@ WUSOCKET nsysnet_createVirtualSocket(sint32 family, sint32 type, sint32 protocol
 	sint32 s = _getFreeSocketHandle();
 	if (s == 0)
 	{
-		forceLogDebug_printf("Ran out of socket handles");
+		cemuLog_logDebug(LogType::Force, "Ran out of socket handles");
 		cemu_assert(false);
 	}
 	virtualSocket_t* vs = (virtualSocket_t*)malloc(sizeof(virtualSocket_t));
@@ -262,13 +262,13 @@ WUSOCKET nsysnet_createVirtualSocket(sint32 family, sint32 type, sint32 protocol
 
 WUSOCKET nsysnet_createVirtualSocketFromExistingSocket(SOCKET existingSocket)
 {
-	forceLogDebug_printf("nsysnet_createVirtualSocketFromExistingSocket - incomplete");
+	cemuLog_logDebug(LogType::Force, "nsysnet_createVirtualSocketFromExistingSocket - incomplete");
 
 
 	sint32 s = _getFreeSocketHandle();
 	if (s == 0)
 	{
-		forceLogDebug_printf("Ran out of socket handles");
+		cemuLog_logDebug(LogType::Force, "Ran out of socket handles");
 		cemu_assert(false);
 	}
 	virtualSocket_t* vs = (virtualSocket_t*)malloc(sizeof(virtualSocket_t));
@@ -358,7 +358,7 @@ void nsysnetExport_socket(PPCInterpreter_t* hCPU)
 	// check family param
 	if (family != WU_AF_INET)
 	{
-		forceLogDebug_printf("socket(): Unsupported family");
+		cemuLog_logDebug(LogType::Force, "socket(): Unsupported family");
 		// todo - error code
 		osLib_returnFromFunction(hCPU, -1);
 		return;
@@ -366,7 +366,7 @@ void nsysnetExport_socket(PPCInterpreter_t* hCPU)
 	// check type param
 	if (type != WU_SOCK_STREAM && type != WU_SOCK_DGRAM)
 	{
-		forceLogDebug_printf("socket(): Unsupported family");
+		cemuLog_logDebug(LogType::Force, "socket(): Unsupported family");
 		// todo - error code
 		osLib_returnFromFunction(hCPU, -1);
 		return;
@@ -374,7 +374,7 @@ void nsysnetExport_socket(PPCInterpreter_t* hCPU)
 
 	if (protocol != WU_IPPROTO_TCP && protocol != WU_IPPROTO_UDP && protocol != WU_IPPROTO_IP)
 	{
-		forceLogDebug_printf("socket(): Unsupported protocol");
+		cemuLog_logDebug(LogType::Force, "socket(): Unsupported protocol");
 		// todo - error code
 		osLib_returnFromFunction(hCPU, -1);
 		return;
@@ -570,7 +570,7 @@ void nsysnetExport_setsockopt(PPCInterpreter_t* hCPU)
 			}
 			else if( optname == 0x4 )
 			{
-				forceLogDebug_printf("setsockopt with unsupported opname 4 for IPPROTO_IP");
+				cemuLog_logDebug(LogType::Force, "setsockopt with unsupported opname 4 for IPPROTO_IP");
 			}
 			else
 				assert_dbg();
@@ -1138,7 +1138,7 @@ void nsysnetExport_select(PPCInterpreter_t* hCPU)
 		r = select(hostnfds + 1, readfds ? &_readfds : NULL, writefds ? &_writefds : NULL, exceptfds ? &_exceptfds : NULL, &tv);
 		if (r < 0)
 		{
-			forceLogDebug_printf("select() failed");
+			cemuLog_logDebug(LogType::Force, "select() failed");
 			// timeout
 			_translateError(r, GETLASTERR);
 			//_setSockError(WU_SO_SUCCESS);

--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -1943,7 +1943,7 @@ namespace nsysnet
 
 		uint32 nsslHandle = (uint32)g_nsslInternalStates.size() - 1;
 
-		forceLogDebug_printf("NSSLCreateContext(0x%x) -> 0x%x", version, nsslHandle);
+		cemuLog_logDebug(LogType::Force, "NSSLCreateContext(0x{:x}) -> 0x{:x}", version, nsslHandle);
 
 		osLib_returnFromFunction(hCPU, nsslHandle);
 	}
@@ -1952,7 +1952,7 @@ namespace nsysnet
 	{
 		ppcDefineParamU32(nsslHandle, 0);
 		ppcDefineParamU32(clientPKI, 1);
-		forceLogDebug_printf("NSSLSetClientPKI(0x%x, 0x%x)", nsslHandle, clientPKI);
+		cemuLog_logDebug(LogType::Force, "NSSLSetClientPKI(0x{:x}, 0x{:x})", nsslHandle, clientPKI);
 
 		if (g_nsslInternalStates.size() <= nsslHandle || g_nsslInternalStates[nsslHandle].destroyed)
 		{
@@ -1968,7 +1968,7 @@ namespace nsysnet
 	{
 		ppcDefineParamU32(nsslHandle, 0);
 		ppcDefineParamU32(serverPKI, 1);
-		forceLogDebug_printf("NSSLAddServerPKI(0x%x, 0x%x)", nsslHandle, serverPKI);
+		cemuLog_logDebug(LogType::Force, "NSSLAddServerPKI(0x{:x}, 0x{:x})", nsslHandle, serverPKI);
 
 		if (g_nsslInternalStates.size() <= nsslHandle || g_nsslInternalStates[nsslHandle].destroyed)
 		{

--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -1987,7 +1987,7 @@ namespace nsysnet
 		ppcDefineParamS32(certLen, 2);
 		ppcDefineParamS32(certType, 3);
 
-		forceLogDebug_printf("NSSLAddServerPKIExternal(0x%x, 0x%08x, 0x%x, %d)", nsslHandle, certData.GetMPTR(), certLen, certType);
+		cemuLog_logDebug(LogType::Force, "NSSLAddServerPKIExternal(0x{:x}, 0x{:08x}, 0x{:x}, {})", nsslHandle, certData.GetMPTR(), certLen, certType);
 		if (g_nsslInternalStates.size() <= nsslHandle || g_nsslInternalStates[nsslHandle].destroyed)
 		{
 			osLib_returnFromFunction(hCPU, NSSL_INVALID_CTX);
@@ -2005,7 +2005,7 @@ namespace nsysnet
 		ppcDefineParamU32(groupMask, 1);
 		ppcDefineParamMEMPTR(validCountOut, sint32, 2);
 		ppcDefineParamMEMPTR(invalidCountOut, sint32, 3);
-		forceLogDebug_printf("NSSLAddServerPKIGroups(0x%x, 0x%x, 0x%08x, 0x%08x)", nsslHandle, groupMask, validCountOut.GetMPTR(), invalidCountOut.GetMPTR());
+		cemuLog_logDebug(LogType::Force, "NSSLAddServerPKIGroups(0x{:x}, 0x{:x}, 0x{:08x}, 0x{:08x})", nsslHandle, groupMask, validCountOut.GetMPTR(), invalidCountOut.GetMPTR());
 
 		if (g_nsslInternalStates.size() <= nsslHandle || g_nsslInternalStates[nsslHandle].destroyed)
 		{

--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -543,7 +543,7 @@ void nsysnetExport_setsockopt(PPCInterpreter_t* hCPU)
 			}
 			else
 			{
-				forceLogDebug_printf("setsockopt(): Unsupported optname 0x%08x", optname);
+				cemuLog_logDebug(LogType::Force, "setsockopt(): Unsupported optname 0x{:08x}", optname);
 			}
 		}
 		else if (level == WU_IPPROTO_TCP)
@@ -1566,7 +1566,7 @@ void nsysnetExport_recvfrom(PPCInterpreter_t* hCPU)
 				wsaError = GETLASTERR;
 				if (r < 0)
 					cemu_assert_debug(false);
-				forceLogDebug_printf("recvfrom returned %d bytes", r);
+				cemuLog_logDebug(LogType::Force, "recvfrom returned {} bytes", r);
 				*fromLen = fromLenHost;
 				fromAddr->sa_family = _swapEndianU16(fromAddrHost.sa_family);
 				memcpy(fromAddr->sa_data, fromAddrHost.sa_data, 14);
@@ -2039,7 +2039,7 @@ namespace nsysnet
 	void export_NSSLDestroyContext(PPCInterpreter_t* hCPU)
 	{
 		ppcDefineParamU32(nsslHandle, 0);
-		forceLogDebug_printf("NSSLDestroyContext(0x%x)", nsslHandle);
+		cemuLog_logDebug(LogType::Force, "NSSLDestroyContext(0x{:x})", nsslHandle);
 
 		if (g_nsslInternalStates.size() <= nsslHandle || g_nsslInternalStates[nsslHandle].destroyed)
 		{

--- a/src/Cafe/OS/libs/snd_core/ax_aux.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_aux.cpp
@@ -287,7 +287,7 @@ namespace snd_core
 		}
 		else
 		{
-			forceLogDebug_printf("sndcore2.AXSetAuxReturnVolume() - unsupported device %d", device);
+			cemuLog_logDebug(LogType::Force, "sndcore2.AXSetAuxReturnVolume() - unsupported device {}", device);
 		}
 		return 0;
 	}

--- a/src/Cafe/OS/libs/snd_core/ax_exports.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_exports.cpp
@@ -77,7 +77,7 @@ namespace snd_core
 
 	void AXQuit()
 	{
-		forceLogDebug_printf("AXQuit called from 0x%08x", ppcInterpreterCurrentInstance->spr.LR);
+		cemuLog_logDebug(LogType::Force, "AXQuit called from 0x{:08x}", ppcInterpreterCurrentInstance->spr.LR);
 		// clean up
 		AXResetCallbacks();
 		AXVoiceList_ResetFreeVoiceList();

--- a/src/Cafe/OS/libs/snd_core/ax_ist.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_ist.cpp
@@ -1012,7 +1012,7 @@ namespace snd_core
 			OSReceiveMessage(__AXIstThreadMsgQueue.GetPtr(), msg.GetPointer(), OS_MESSAGE_BLOCK);
 			if (msg.GetPointer()->message == 2)
 			{
-				forceLogDebug_printf("Shut down of AX thread requested");
+				cemuLog_logDebug(LogType::Force, "Shut down of AX thread requested");
 				coreinit::OSExitThread(0);
 				break;
 			}

--- a/src/Cafe/OS/libs/snd_core/ax_mix.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_mix.cpp
@@ -695,7 +695,7 @@ namespace snd_core
 #ifdef CEMU_DEBUG_ASSERT
 		if (internalShadowCopy->biquad.on != 0x0200)
 		{
-			forceLogDebug_printf("AX_ApplyBiquad() with incorrect biquad.on value 0x%04x", _swapEndianU16(internalShadowCopy->biquad.on));
+			cemuLog_logDebug(LogType::Force, "AX_ApplyBiquad() with incorrect biquad.on value 0x{:04x}", _swapEndianU16(internalShadowCopy->biquad.on));
 		}
 #endif
 

--- a/src/Cafe/OS/libs/snd_core/ax_voice.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_voice.cpp
@@ -365,7 +365,7 @@ namespace snd_core
 				// get last voice in chain
 				while (voiceItr->next)
 					voiceItr = voiceItr->next.GetPtr();
-				forceLogDebug_printf("Dropped voice %d", (uint32)voiceItr->index);
+				cemuLog_logDebug(LogType::Force, "Dropped voice {}", (uint32)voiceItr->index);
 				// drop voice
 				if (voiceItr->playbackState != 0)
 				{

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -93,7 +93,7 @@ swkbdInternalState_t* swkbdInternalState = NULL;
 
 void swkbdExport_SwkbdCreate(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("swkbd.SwkbdCreate(0x%08x,0x%08x,0x%08x,0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
+	cemuLog_logDebug(LogType::Force, "swkbd.SwkbdCreate(0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6]);
 	if( swkbdInternalState == NULL )
 	{
 		MPTR swkbdInternalStateMPTR = coreinit_allocFromSysArea(sizeof(swkbdInternalState_t), 4);

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -204,7 +204,7 @@ static_assert(offsetof(swkbdAppearArg_t, cursorIndex) == 0xC4, "appearArg.cursor
 void swkbdExport_SwkbdAppearInputForm(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(appearArg, swkbdAppearArg_t, 0);
-	forceLogDebug_printf("SwkbdAppearInputForm__3RplFRCQ3_2nn5swkbd9AppearArg LR: %08x\n", hCPU->spr.LR);
+	forceLogDebug_printf("SwkbdAppearInputForm__3RplFRCQ3_2nn5swkbd9AppearArg\n");
 	swkbdInternalState->formStringLength = 0;
 	swkbdInternalState->isActive = true;
 	swkbdInternalState->decideButtonWasPressed = false;
@@ -241,7 +241,7 @@ void swkbdExport_SwkbdAppearInputForm(PPCInterpreter_t* hCPU)
 void swkbdExport_SwkbdAppearKeyboard(PPCInterpreter_t* hCPU)
 {
 	// todo: Figure out what the difference between AppearInputForm and AppearKeyboard is?
-	forceLogDebug_printf("SwkbdAppearKeyboard__3RplFRCQ3_2nn5swkbd11KeyboardArg LR: %08x\n", hCPU->spr.LR);
+	forceLogDebug_printf("SwkbdAppearKeyboard__3RplFRCQ3_2nn5swkbd11KeyboardArg\n");
 	SwkbdKeyboardArg_t* keyboardArg = (SwkbdKeyboardArg_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 
 	uint32 argPtr = hCPU->gpr[3];
@@ -310,7 +310,7 @@ static_assert(sizeof(SwkbdDrawStringInfo_t) != 0x19, "SwkbdDrawStringInfo_t has 
 
 void swkbdExport_SwkbdGetDrawStringInfo(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SwkbdGetDrawStringInfo(0x%08x) - stub LR: %08x", hCPU->gpr[3], hCPU->spr.LR);
+	forceLogDebug_printf("SwkbdGetDrawStringInfo(0x%08x)", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(drawStringInfo, SwkbdDrawStringInfo_t, 0);
 
 	drawStringInfo->ukn00 = -1;
@@ -326,7 +326,7 @@ void swkbdExport_SwkbdGetDrawStringInfo(PPCInterpreter_t* hCPU)
 
 void swkbdExport_SwkbdInitLearnDic(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SwkbdInitLearnDic(0x%08x) - stub LR: %08x", hCPU->gpr[3], hCPU->spr.LR);
+	forceLogDebug_printf("SwkbdInitLearnDic(0x%08x)", hCPU->gpr[3]);
 	// todo
 
 	// this has to fail (at least once?) or MH3U will not boot

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -204,7 +204,7 @@ static_assert(offsetof(swkbdAppearArg_t, cursorIndex) == 0xC4, "appearArg.cursor
 void swkbdExport_SwkbdAppearInputForm(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(appearArg, swkbdAppearArg_t, 0);
-	forceLogDebug_printf("SwkbdAppearInputForm__3RplFRCQ3_2nn5swkbd9AppearArg\n");
+	cemuLog_logDebug(LogType::Force, "SwkbdAppearInputForm__3RplFRCQ3_2nn5swkbd9AppearArg");
 	swkbdInternalState->formStringLength = 0;
 	swkbdInternalState->isActive = true;
 	swkbdInternalState->decideButtonWasPressed = false;
@@ -241,7 +241,7 @@ void swkbdExport_SwkbdAppearInputForm(PPCInterpreter_t* hCPU)
 void swkbdExport_SwkbdAppearKeyboard(PPCInterpreter_t* hCPU)
 {
 	// todo: Figure out what the difference between AppearInputForm and AppearKeyboard is?
-	forceLogDebug_printf("SwkbdAppearKeyboard__3RplFRCQ3_2nn5swkbd11KeyboardArg\n");
+	cemuLog_logDebug(LogType::Force, "SwkbdAppearKeyboard__3RplFRCQ3_2nn5swkbd11KeyboardArg");
 	SwkbdKeyboardArg_t* keyboardArg = (SwkbdKeyboardArg_t*)memory_getPointerFromVirtualOffset(hCPU->gpr[3]);
 
 	uint32 argPtr = hCPU->gpr[3];
@@ -310,7 +310,7 @@ static_assert(sizeof(SwkbdDrawStringInfo_t) != 0x19, "SwkbdDrawStringInfo_t has 
 
 void swkbdExport_SwkbdGetDrawStringInfo(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SwkbdGetDrawStringInfo(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "SwkbdGetDrawStringInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(drawStringInfo, SwkbdDrawStringInfo_t, 0);
 
 	drawStringInfo->ukn00 = -1;
@@ -326,7 +326,7 @@ void swkbdExport_SwkbdGetDrawStringInfo(PPCInterpreter_t* hCPU)
 
 void swkbdExport_SwkbdInitLearnDic(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SwkbdInitLearnDic(0x%08x)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "SwkbdInitLearnDic(0x{:08x})", hCPU->gpr[3]);
 	// todo
 
 	// this has to fail (at least once?) or MH3U will not boot

--- a/src/Cafe/OS/libs/sysapp/sysapp.cpp
+++ b/src/Cafe/OS/libs/sysapp/sysapp.cpp
@@ -469,7 +469,7 @@ void sysappExport__SYSGetEShopArgs(PPCInterpreter_t* hCPU)
 void sysappExport_SYSGetUPIDFromTitleID(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamU64(titleId, 0);
-	forceLogDebug_printf("SYSGetUPIDFromTitleID(0x%08x%08x)", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_logDebug(LogType::Force, "SYSGetUPIDFromTitleID(0x{:08x}{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
 	uint32 titleIdHigh = (titleId >> 32);
 	uint32 titleIdLow = (uint32)(titleId & 0xFFFFFFFF);
 	if ((titleIdHigh & 0xFFFF0000) != 0x50000)

--- a/src/Cafe/OS/libs/sysapp/sysapp.cpp
+++ b/src/Cafe/OS/libs/sysapp/sysapp.cpp
@@ -571,7 +571,7 @@ void sysappExport__SYSGetLauncherArgs(PPCInterpreter_t* hCPU)
 
 void sysappExport_SYSGetStandardResult(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SYSGetStandardResult(0x%08x,0x%08x,0x%08x)\n", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_logDebug(LogType::Force, "SYSGetStandardResult(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	memset(memory_getPointerFromVirtualOffset(hCPU->gpr[3]), 0, 4);
 
 	osLib_returnFromFunction(hCPU, 0);

--- a/src/Cafe/OS/libs/sysapp/sysapp.cpp
+++ b/src/Cafe/OS/libs/sysapp/sysapp.cpp
@@ -417,7 +417,7 @@ uint64 _SYSGetSystemApplicationTitleId(sint32 index)
 void sysappExport__SYSGetSystemApplicationTitleId(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamU32(systemApplicationId, 0);
-	forceLogDebug_printf("_SYSGetSystemApplicationTitleId(0x%d)", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "_SYSGetSystemApplicationTitleId(0x{})", hCPU->gpr[3]);
 
 	uint64 titleId = _SYSGetSystemApplicationTitleId(systemApplicationId);
 	osLib_returnFromFunction64(hCPU, titleId);
@@ -559,7 +559,7 @@ static_assert(sizeof(SysLauncherArgs28) == 0x28);
 
 void sysappExport__SYSGetLauncherArgs(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("_SYSGetLauncherArgs(0x%08x) - todo\n", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "_SYSGetLauncherArgs(0x{:08x}) - todo", hCPU->gpr[3]);
 
 	// todo: Handle OS library version. Older versions used a different struct (only 0x18 bytes?)
 	//ppcDefineParamStructPtr(launcherArgs, SysLauncherArgs, 0);

--- a/src/Cafe/OS/libs/sysapp/sysapp.cpp
+++ b/src/Cafe/OS/libs/sysapp/sysapp.cpp
@@ -417,7 +417,7 @@ uint64 _SYSGetSystemApplicationTitleId(sint32 index)
 void sysappExport__SYSGetSystemApplicationTitleId(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamU32(systemApplicationId, 0);
-	cemuLog_logDebug(LogType::Force, "_SYSGetSystemApplicationTitleId(0x{})", hCPU->gpr[3]);
+	cemuLog_logDebug(LogType::Force, "_SYSGetSystemApplicationTitleId(0x{:x})", hCPU->gpr[3]);
 
 	uint64 titleId = _SYSGetSystemApplicationTitleId(systemApplicationId);
 	osLib_returnFromFunction64(hCPU, titleId);

--- a/src/Cafe/OS/libs/sysapp/sysapp.cpp
+++ b/src/Cafe/OS/libs/sysapp/sysapp.cpp
@@ -460,7 +460,7 @@ void sysappExport__SYSReturnToCallerWithStandardResult(PPCInterpreter_t* hCPU)
 void sysappExport__SYSGetEShopArgs(PPCInterpreter_t* hCPU)
 {
 	ppcDefineParamStructPtr(args, eshopArguments_t, 0);
-	forceLogDebug_printf("_SYSGetEShopArgs() - placeholder");
+	cemuLog_logDebug(LogType::Force, "_SYSGetEShopArgs() - placeholder");
 	memset(args, 0, sizeof(eshopArguments_t));
 
 	osLib_returnFromFunction(hCPU, 0);
@@ -537,7 +537,7 @@ void sysappExport_SYSGetUPIDFromTitleID(PPCInterpreter_t* hCPU)
 
 void sysappExport_SYSGetVodArgs(PPCInterpreter_t* hCPU)
 {
-	forceLogDebug_printf("SYSGetVodArgs() - todo");
+	cemuLog_logDebug(LogType::Force, "SYSGetVodArgs() - todo");
 	osLib_returnFromFunction(hCPU, 1);
 }
 

--- a/src/Cemu/napi/napi_idbe.cpp
+++ b/src/Cemu/napi/napi_idbe.cpp
@@ -97,7 +97,7 @@ namespace NAPI
 			titleId == 0x000500301001520A)
 		{
 			// friend list has no icon, just fail immediately
-			forceLogDebug_printf("Requesting IDBE for Friend List. Return none instead");
+			cemuLog_logDebug(LogType::Force, "Requesting IDBE for Friend List. Return none instead");
 			return std::nullopt;
 		}
 

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -185,7 +185,7 @@ void nexFriends_protocolNotification_processRequest(nexServiceRequest_t* request
 			request->nex->sendRequestResponse(request, 0, nullptr, 0);
 			return;
 		}
-		forceLogDebug_printf("NN_NOTIFICATION methodId %d type %02x pid %08x", request->methodId, notificationType, pid);
+		cemuLog_logDebug(LogType::Force, "NN_NOTIFICATION methodId {} type {:02x} pid {:08x}", request->methodId, notificationType, pid);
 		nexFriends->processServerNotification(notificationType, pid, &request->data);
 		request->nex->sendRequestResponse(request, 0, nullptr, 0);
 		return;

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -168,7 +168,7 @@ void NexFriends::processServerNotification(uint32 notificationType, uint32 pid, 
 	}
 	else if (true)
 	{
-		forceLogDebug_printf("Unsupported friend server notification type 0x%02x", notificationType);
+		cemuLog_logDebug(LogType::Force, "Unsupported friend server notification type 0x{:02x}", notificationType);
 	}
 }
 

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -260,7 +260,7 @@ void NexFriends::initiateLogin()
 	previousState.list_friendReqOutgoing.resize(0);
 	this->hasData = false;
 	// start login attempt
-	forceLogDebug_printf("Attempt to log into friend server...");
+	cemuLog_logDebug(LogType::Force, "Attempt to log into friend server...");
 	std::thread t(&NexFriends::doAsyncLogin, this);
 	t.detach();
 }

--- a/src/Cemu/nex/prudp.cpp
+++ b/src/Cemu/nex/prudp.cpp
@@ -719,7 +719,7 @@ void prudpClient::handleIncomingPacket(prudpIncomingPacket* incomingPacket)
 			if (it->sequenceId == incomingPacket->sequenceId)
 			{
 				// already queued (should check other values too, like packet type?)
-				forceLogDebug_printf("Duplicate PRUDP packet received");
+				cemuLog_logDebug(LogType::Force, "Duplicate PRUDP packet received");
 				delete incomingPacket;
 				return;
 			}

--- a/src/audio/CubebAPI.cpp
+++ b/src/audio/CubebAPI.cpp
@@ -122,7 +122,7 @@ bool CubebAPI::FeedBlock(sint16* data)
 	std::unique_lock lock(m_mutex);
 	if (m_buffer.capacity() <= m_buffer.size() + m_bytesPerBlock)
 	{
-		forceLogDebug_printf("dropped direct sound block since too many buffers are queued");
+		cemuLog_logDebug(LogType::Force, "dropped direct sound block since too many buffers are queued");
 		return false;
 	}
 

--- a/src/audio/CubebInputAPI.cpp
+++ b/src/audio/CubebInputAPI.cpp
@@ -38,7 +38,7 @@ long CubebInputAPI::data_cb(cubeb_stream* stream, void* user, const void* inputb
 	std::unique_lock lock(thisptr->m_mutex);
 	if (thisptr->m_buffer.capacity() <= thisptr->m_buffer.size() + size)
 	{
-		forceLogDebug_printf("dropped input sound block since too many buffers are queued");
+		cemuLog_logDebug(LogType::Force, "dropped input sound block since too many buffers are queued");
 		return nframes;
 	}
 

--- a/src/audio/DirectSoundAPI.cpp
+++ b/src/audio/DirectSoundAPI.cpp
@@ -124,7 +124,7 @@ void DirectSoundAPI::AudioThread()
 				std::unique_lock lock(m_mutex);
 				if (m_buffer.empty())
 				{
-					//forceLogDebug_printf("DirectSound: writing silence");
+					//cemuLog_logDebug(LogType::Force, "DirectSound: writing silence");
 
 					// we got no data, just write silence
 					memset(ptr1, 0x00, bytes1);
@@ -189,7 +189,7 @@ bool DirectSoundAPI::FeedBlock(sint16* data)
 	std::unique_lock lock(m_mutex);
 	if (m_buffer.size() > kBlockCount)
 	{
-		forceLogDebug_printf("dropped direct sound block since too many buffers are queued");
+		cemuLog_logDebug(LogType::Force, "dropped direct sound block since too many buffers are queued");
 		return false;
 	}
 

--- a/src/audio/XAudio27API.cpp
+++ b/src/audio/XAudio27API.cpp
@@ -205,7 +205,7 @@ bool XAudio27API::FeedBlock(sint16* data)
 
 		if (m_blocks_queued >= kBlockCount)
 		{
-			forceLogDebug_printf("dropped xaudio2 block since too many buffers are queued");
+			cemuLog_logDebug(LogType::Force, "dropped xaudio2 block since too many buffers are queued");
 			return false;
 		}
 	}

--- a/src/audio/XAudio2API.cpp
+++ b/src/audio/XAudio2API.cpp
@@ -276,7 +276,7 @@ bool XAudio2API::FeedBlock(sint16* data)
 
 		if (m_blocks_queued >= kBlockCount)
 		{
-			forceLogDebug_printf("dropped xaudio2 block since too many buffers are queued");
+			cemuLog_logDebug(LogType::Force, "dropped xaudio2 block since too many buffers are queued");
 			return false;
 		}
 	}

--- a/src/gui/GameUpdateWindow.cpp
+++ b/src/gui/GameUpdateWindow.cpp
@@ -307,7 +307,7 @@ void GameUpdateWindow::OnClose(wxCloseEvent& event)
 			}
 			catch (const std::exception& ex)
 			{
-				forceLogDebug_printf("can't restore update backup: %s",ex.what());
+				cemuLog_logDebug(LogType::Force, "can't restore update backup: {}",ex.what());
 			}
 		}
 		else
@@ -320,7 +320,7 @@ void GameUpdateWindow::OnClose(wxCloseEvent& event)
 			}
 			catch (const std::exception& ex)
 			{
-				forceLogDebug_printf("can't delete update backup: %s",ex.what());
+				cemuLog_logDebug(LogType::Force, "can't delete update backup: {}",ex.what());
 			}
 		}
 		

--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -543,7 +543,7 @@ void wxDownloadManagerList::UpdateTitleStatusDepr(TitleEntryData_t* obj, const w
 		}
 	}
 
-	forceLogDebug_printf("cant update title status of %llx", data.titleId);
+	cemuLog_logDebug(LogType::Force, "cant update title status of {:x}", data.titleId);
 }
 
 int wxDownloadManagerList::AddImage(const wxImage& image) const

--- a/src/gui/input/panels/InputPanel.cpp
+++ b/src/gui/input/panels/InputPanel.cpp
@@ -92,7 +92,7 @@ void InputPanel::on_timer(const EmulatedControllerPtr& emulated_controller, cons
 			if (id >= kButtonAxisStart)
 			{
 				if (controller->get_axis_value(id) < 0.33f) {
-					forceLogDebug_printf("skipping since value too low %f", controller->get_axis_value(id));
+					cemuLog_logDebug(LogType::Force, "skipping since value too low {}", controller->get_axis_value(id));
 					s_was_idle = true;
 					return;
 				}

--- a/src/input/emulated/VPADController.cpp
+++ b/src/input/emulated/VPADController.cpp
@@ -408,7 +408,7 @@ bool VPADController::push_rumble(uint8* pattern, uint8 length)
 	std::scoped_lock lock(m_rumble_mutex);
 	if (m_rumble_queue.size() >= 5)
 	{
-		forceLogDebug_printf("too many cmds");
+		cemuLog_logDebug(LogType::Force, "too many cmds");
 		return false;
 	}
 

--- a/src/input/motion/Mahony.h
+++ b/src/input/motion/Mahony.h
@@ -33,7 +33,7 @@ public:
 		if (fabs(gv.z) < 0.015f)
 			gv.z = 0.0f;
 
-		// forceLogDebug_printf("[IMU Quat] time %7.4lf | %7.2lf %7.2lf %7.2lf %7.2lf | gyro( - bias) %7.4lf %7.4lf %7.4lf | acc %7.2lf %7.2lf %7.2lf | GyroBias %7.4lf %7.4lf %7.4lf", deltaTime, m_imuQ.x, m_imuQ.y, m_imuQ.z, m_imuQ.w, gv.x, gv.y, gv.z, ax, ay, az, m_gyroBias[0], m_gyroBias[1], m_gyroBias[2]);
+		// cemuLog_logDebug(LogType::Force, "[IMU Quat] time {:7.4} | {:7.2} {:7.2} {:7.2} {:7.2} | gyro( - bias) {:7.4} {:7.4} {:7.4} | acc {:7.2} {:7.2} {:7.2} | GyroBias {:7.4} {:7.4} {:7.4}", deltaTime, m_imuQ.x, m_imuQ.y, m_imuQ.z, m_imuQ.w, gv.x, gv.y, gv.z, ax, ay, az, m_gyroBias[0], m_gyroBias[1], m_gyroBias[2]);
 
 		if (fabs(av.x) > 0.000001f || fabs(av.y) > 0.000001f || fabs(av.z) > 0.000001f)
 		{


### PR DESCRIPTION
Converts all instances of the `forceLogDebug_printf()` logging method with the newer `cemuLog_logDebug(LogType::Force, ...)`.

Part of #703