### PR TITLE
Resolve domains to IPs in Friends NEX

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -181,8 +181,8 @@ namespace iosu
 				cemuLog_log(LogType::Force, "IOSU_FPD: Resolved IP for hostname {}, {}", nexTokenResult.nexToken.host, addrstr);
 
 				// start session
-				uint32 hostIp;
-				inet_pton(AF_INET, addrstr, &hostIp);
+				const uint32_t hostIp = ((struct sockaddr_in*)addrs->ai_addr)->sin_addr.s_addr;
+				freeaddrinfo(addrs);
 				g_fpd.nexFriendSession = new NexFriends(hostIp, nexTokenResult.nexToken.port, "ridfebb9", myPid, nexTokenResult.nexToken.nexPassword, nexTokenResult.nexToken.token, accountId, (uint8*)&miiData, (wchar_t*)screenName, (uint8)countryCode, g_fpd.myPresence);
 				g_fpd.nexFriendSession->setNotificationHandler(notificationHandler);
 				cemuLog_log(LogType::Force, "IOSU_FPD: Created friend server session");

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -172,7 +172,11 @@ namespace iosu
 
 				const int status = getaddrinfo(nexTokenResult.nexToken.host, NULL, &hints, &addrs);
 				if (status != 0) {
+#ifdef _WIN32
+					cemuLog_log(LogType::Force, "IOSU_FPD: Failed to resolve hostname {}, {}", nexTokenResult.nexToken.host, gai_strerrorA(status));
+#else
 					cemuLog_log(LogType::Force, "IOSU_FPD: Failed to resolve hostname {}, {}", nexTokenResult.nexToken.host, gai_strerror(status));
+#endif
 					return;
 				}
 

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -168,9 +168,7 @@ namespace iosu
 
 				// Resolve potential domain to IP address
 				struct addrinfo hints = {0}, *addrs;
-				hints.ai_family = AF_UNSPEC;
-				hints.ai_socktype = SOCK_DGRAM;
-				hints.ai_protocol = IPPROTO_UDP;
+				hints.ai_family = AF_INET;
 
 				const int status = getaddrinfo(nexTokenResult.nexToken.host, NULL, &hints, &addrs);
 				if (status != 0) {
@@ -178,15 +176,9 @@ namespace iosu
 					return;
 				}
 
-				if (addrs->ai_family != AF_INET) {
-					cemuLog_log(LogType::Force, "IOSU_FPD: Resolved IP for hostname {} not IPv4", nexTokenResult.nexToken.host);
-					return;
-				}
-
-				char addrstr[15];
-				void *ptr = &((struct sockaddr_in*)addrs->ai_addr)->sin_addr;
-				inet_ntop(addrs->ai_family, ptr, addrstr, 15);
-				cemuLog_log(LogType::Force, "IOSU_FPD: Resolved IP for hostname {}, ", nexTokenResult.nexToken.host, addrstr);
+				char addrstr[NI_MAXHOST];
+				getnameinfo(addrs->ai_addr, addrs->ai_addrlen, addrstr, sizeof addrstr, NULL, 0, NI_NUMERICHOST);
+				cemuLog_log(LogType::Force, "IOSU_FPD: Resolved IP for hostname {}, {}", nexTokenResult.nexToken.host, addrstr);
 
 				// start session
 				uint32 hostIp;

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -172,7 +172,7 @@ namespace iosu
 
 				const int status = getaddrinfo(nexTokenResult.nexToken.host, NULL, &hints, &addrs);
 				if (status != 0) {
-#ifdef _WIN32
+#if BOOST_OS_WINDOWS
 					cemuLog_log(LogType::Force, "IOSU_FPD: Failed to resolve hostname {}, {}", nexTokenResult.nexToken.host, gai_strerrorA(status));
 #else
 					cemuLog_log(LogType::Force, "IOSU_FPD: Failed to resolve hostname {}, {}", nexTokenResult.nexToken.host, gai_strerror(status));


### PR DESCRIPTION
The official Nintendo servers only ever return IP addresses for hosts in NEX, but real hardware is capable of resolving domains back to IP addresses. Custom servers like the ones at Pretendo Network make use of domains rather than IP addresses, which prevents Cemu from going online

These changes allow Cemu to resolve IPs from domains when connecting to the Friends NEX server

Tested on Ubuntu 22.04