### PR TITLE
Expose logging systems and remove deprecated logging system

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -211,7 +211,7 @@ void InfoLog_TitleLoaded()
 	fs::path effectiveSavePath = getTitleSavePath();
 	std::error_code ec;
 	const bool saveDirExists = fs::exists(effectiveSavePath, ec);
-	cemuLog_force("Save path:   {}{}", _pathToUtf8(effectiveSavePath), saveDirExists ? "" : " (not present)");
+	cemuLog_log(LogType::Force, "Save path:   {}{}", _pathToUtf8(effectiveSavePath), saveDirExists ? "" : " (not present)");
 
 	// log shader cache name
 	cemuLog_log(LogType::Force, "Shader cache file: shaderCache/transferable/{:016x}.bin", titleId);

--- a/src/Cafe/Filesystem/fsc.cpp
+++ b/src/Cafe/Filesystem/fsc.cpp
@@ -541,7 +541,7 @@ void fsc_setFileLength(FSCVirtualFile* fscFile, uint32 newEndOffset)
 	uint32 fileSize = fsc_getFileSize(fscFile);
 	if (!fsc_isWritable(fscFile))
 	{
-		cemuLog_force("TruncateFile called on read-only file");
+		cemuLog_log(LogType::Force, "TruncateFile called on read-only file");
 	}
 	else
 	{

--- a/src/Cafe/Filesystem/fscDeviceHostFS.cpp
+++ b/src/Cafe/Filesystem/fscDeviceHostFS.cpp
@@ -113,7 +113,7 @@ void FSCVirtualFile_Host::fscSetFileLength(uint64 endOffset)
 	m_fileSize = m_seek;
 	m_fs->SetPosition(m_seek);
 	if (!r)
-		cemuLog_force("fscSetFileLength: Failed to set size to 0x{:x}", endOffset);
+		cemuLog_log(LogType::Force, "fscSetFileLength: Failed to set size to 0x{:x}", endOffset);
 }
 
 bool FSCVirtualFile_Host::fscDirNext(FSCDirEntry* dirEntry)
@@ -127,7 +127,7 @@ bool FSCVirtualFile_Host::fscDirNext(FSCDirEntry* dirEntry)
 		m_dirIterator.reset(new fs::directory_iterator(*m_path));
 		if (!m_dirIterator)
 		{
-			cemuLog_force("Failed to iterate directory: {}", _pathToUtf8(*m_path));
+			cemuLog_log(LogType::Force, "Failed to iterate directory: {}", _pathToUtf8(*m_path));
 			return false;
 		}
 	}
@@ -175,14 +175,14 @@ FSCVirtualFile* FSCVirtualFile_Host::OpenFile(const fs::path& path, FSC_ACCESS_F
 				cemu_assert_debug(writeAccessRequested);
 				fs = FileStream::createFile2(path);
 				if (!fs)
-					cemuLog_force("FSC: File create failed for {}", _pathToUtf8(path));
+					cemuLog_log(LogType::Force, "FSC: File create failed for {}", _pathToUtf8(path));
 			}
 		}
 		else if (HAS_FLAG(accessFlags, FSC_ACCESS_FLAG::FILE_ALWAYS_CREATE))
 		{
 			fs = FileStream::createFile2(path);
 			if (!fs)
-				cemuLog_force("FSC: File create failed for {}", _pathToUtf8(path));
+				cemuLog_log(LogType::Force, "FSC: File create failed for {}", _pathToUtf8(path));
 		}
 		else
 		{
@@ -235,14 +235,14 @@ public:
 		if (fs::exists(dirPath))
 		{
 			if (!fs::is_directory(dirPath))
-				cemuLog_force("CreateDir: {} already exists but is not a directory", path);
+				cemuLog_log(LogType::Force, "CreateDir: {} already exists but is not a directory", path);
 			*fscStatus = FSC_STATUS_ALREADY_EXISTS;
 			return false;
 		}
 		std::error_code ec;
 		bool r = fs::create_directories(dirPath, ec);
 		if (!r)
-			cemuLog_force("CreateDir: Failed to create {}", path);
+			cemuLog_log(LogType::Force, "CreateDir: Failed to create {}", path);
 		*fscStatus = FSC_STATUS_OK;
 		return true;
 	}

--- a/src/Cafe/GameProfile/GameProfile.cpp
+++ b/src/Cafe/GameProfile/GameProfile.cpp
@@ -43,7 +43,7 @@ bool gameProfile_loadBooleanOption(IniParser* iniParser, char* optionName, gameP
 		return true;
 	}
 	else
-		cemuLog_force("Unknown value '{}' for option '{}' in game profile", *option_value, optionName);
+		cemuLog_log(LogType::Force, "Unknown value '{}' for option '{}' in game profile", *option_value, optionName);
 	return false;
 }
 
@@ -64,7 +64,7 @@ bool gameProfile_loadBooleanOption2(IniParser& iniParser, const char* optionName
 		return true;
 	}
 	else
-		cemuLog_force("Unknown value '{}' for option '{}' in game profile", *option_value, optionName);
+		cemuLog_log(LogType::Force, "Unknown value '{}' for option '{}' in game profile", *option_value, optionName);
 	return false;
 }
 
@@ -94,7 +94,7 @@ bool gameProfile_loadIntegerOption(IniParser* iniParser, const char* optionName,
 	sint32 val = StringHelpers::ToInt(*option_value, defaultValue);
 	if (val < minVal || val > maxVal)
 	{
-		cemuLog_force("Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
+		cemuLog_log(LogType::Force, "Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
 		option->value = defaultValue;
 		return false;
 	}
@@ -116,7 +116,7 @@ bool gameProfile_loadIntegerOption(IniParser& iniParser, const char* optionName,
 		T val = ConvertString<T>(*option_value);
 		if (val < minVal || val > maxVal)
 		{
-			cemuLog_force("Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
+			cemuLog_log(LogType::Force, "Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
 			return false;
 		}
 
@@ -125,7 +125,7 @@ bool gameProfile_loadIntegerOption(IniParser& iniParser, const char* optionName,
 	}
 	catch(std::exception&)
 	{
-		cemuLog_force("Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
+		cemuLog_log(LogType::Force, "Value '{}' is out of range for option '{}' in game profile", *option_value, optionName);
 		return false;
 	}	
 }
@@ -175,7 +175,7 @@ void gameProfile_load()
 	ppcThreadQuantum = g_current_game_profile->GetThreadQuantum();
 
 	if (ppcThreadQuantum != GameProfile::kThreadQuantumDefault)
-		cemuLog_force("Thread quantum set to {}", ppcThreadQuantum);
+		cemuLog_log(LogType::Force, "Thread quantum set to {}", ppcThreadQuantum);
 }
 
 bool GameProfile::Load(uint64_t title_id)
@@ -283,7 +283,7 @@ void GameProfile::Save(uint64_t title_id)
 	FileStream* fs = FileStream::createFile2(gameProfilePath);
 	if (!fs)
 	{
-		cemuLog_force("Failed to write game profile");
+		cemuLog_log(LogType::Force, "Failed to write game profile");
 		return;
 	}
 

--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -32,12 +32,12 @@ void GraphicPack2::LoadGraphicPack(fs::path graphicPackPath)
 
 	if (!iniParser.NextSection())
 	{
-		cemuLog_force("{}: Does not contain any sections", _pathToUtf8(rulesPath));
+		cemuLog_log(LogType::Force, "{}: Does not contain any sections", _pathToUtf8(rulesPath));
 		return;
 	}
 	if (!boost::iequals(iniParser.GetCurrentSectionName(), "Definition"))
 	{
-		cemuLog_force("{}: [Definition] must be the first section", _pathToUtf8(rulesPath));
+		cemuLog_log(LogType::Force, "{}: [Definition] must be the first section", _pathToUtf8(rulesPath));
 		return;
 	}
 
@@ -48,7 +48,7 @@ void GraphicPack2::LoadGraphicPack(fs::path graphicPackPath)
 		auto [ptr, ec] = std::from_chars(option_version->data(), option_version->data() + option_version->size(), versionNum);
 		if (ec != std::errc{})
 		{
-			cemuLog_force("{}: Unable to parse version", _pathToUtf8(rulesPath));
+			cemuLog_log(LogType::Force, "{}: Unable to parse version", _pathToUtf8(rulesPath));
 			return;
 		}
 
@@ -58,7 +58,7 @@ void GraphicPack2::LoadGraphicPack(fs::path graphicPackPath)
 			return;
 		}
 	}
-	cemuLog_force("{}: Outdated graphic pack", _pathToUtf8(rulesPath));
+	cemuLog_log(LogType::Force, "{}: Outdated graphic pack", _pathToUtf8(rulesPath));
 }
 
 void GraphicPack2::LoadAll()
@@ -265,7 +265,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 	m_version = StringHelpers::ToInt(*option_version, -1);
 	if (m_version < 0)
 	{
-		cemuLog_force(L"{}: Invalid version", m_filename);
+		cemuLog_log(LogType::Force, L"{}: Invalid version", m_filename);
 		throw std::exception();
 	}
 
@@ -277,7 +277,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 		else if (boost::iequals(*option_rendererFilter, "opengl"))
 			m_renderer_api = RendererAPI::OpenGL;
 		else
-			cemuLog_force("Unknown value '{}' for rendererFilter option", *option_rendererFilter);
+			cemuLog_log(LogType::Force, "Unknown value '{}' for rendererFilter option", *option_rendererFilter);
 	}
 
 	auto option_defaultEnabled = rules.FindOption("default");
@@ -301,14 +301,14 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 		else if (boost::iequals(*option_vendorFilter, "apple"))
 			m_gfx_vendor = GfxVendor::Apple;
 		else
-			cemuLog_force("Unknown value '{}' for vendorFilter", *option_vendorFilter);
+			cemuLog_log(LogType::Force, "Unknown value '{}' for vendorFilter", *option_vendorFilter);
 	}
 
 	auto option_path = rules.FindOption("path");
 	if (!option_path)
 	{
 		auto gp_name_log = rules.FindOption("name");
-		cemuLog_force("[Definition] section from '{}' graphic pack must contain option: path", gp_name_log.has_value() ? *gp_name_log : "Unknown");
+		cemuLog_log(LogType::Force, "[Definition] section from '{}' graphic pack must contain option: path", gp_name_log.has_value() ? *gp_name_log : "Unknown");
 		throw std::exception();
 	}
 	m_path = *option_path;
@@ -348,7 +348,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 			const auto preset_name = rules.FindOption("name");
 			if (!preset_name)
 			{
-				cemuLog_force("Graphic pack \"{}\": Preset in line {} skipped because it has no name option defined", m_name, rules.GetCurrentSectionLineNumber());
+				cemuLog_log(LogType::Force, "Graphic pack \"{}\": Preset in line {} skipped because it has no name option defined", m_name, rules.GetCurrentSectionLineNumber());
 				continue;
 			}
 			
@@ -372,7 +372,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 			}
 			catch (const std::exception & ex)
 			{
-				cemuLog_force("Graphic pack \"{}\": Can't parse preset \"{}\": {}", m_name, *preset_name, ex.what());
+				cemuLog_log(LogType::Force, "Graphic pack \"{}\": Can't parse preset \"{}\": {}", m_name, *preset_name, ex.what());
 			}
 		}
 		else if (boost::iequals(currentSectionName, "RAM"))
@@ -386,7 +386,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 				{
 					if (m_version <= 5)
 					{
-						cemuLog_force("Graphic pack \"{}\": [RAM] options are only available for graphic pack version 6 or higher", m_name, optionNameBuf);
+						cemuLog_log(LogType::Force, "Graphic pack \"{}\": [RAM] options are only available for graphic pack version 6 or higher", m_name, optionNameBuf);
 						throw std::exception();
 					}
 
@@ -396,12 +396,12 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 					{
 						if (addrEnd <= addrStart)
 						{
-							cemuLog_force("Graphic pack \"{}\": start address (0x{:08x}) must be greater than end address (0x{:08x}) for {}", m_name, addrStart, addrEnd, optionNameBuf);
+							cemuLog_log(LogType::Force, "Graphic pack \"{}\": start address (0x{:08x}) must be greater than end address (0x{:08x}) for {}", m_name, addrStart, addrEnd, optionNameBuf);
 							throw std::exception();
 						}
 						else if ((addrStart & 0xFFF) != 0 || (addrEnd & 0xFFF) != 0)
 						{
-							cemuLog_force("Graphic pack \"{}\": addresses for %s are not aligned to 0x1000", m_name, optionNameBuf);
+							cemuLog_log(LogType::Force, "Graphic pack \"{}\": addresses for %s are not aligned to 0x1000", m_name, optionNameBuf);
 							throw std::exception();
 						}
 						else
@@ -411,7 +411,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 					}
 					else
 					{
-						cemuLog_force("Graphic pack \"{}\": has invalid syntax for option {}", m_name, optionNameBuf);
+						cemuLog_log(LogType::Force, "Graphic pack \"{}\": has invalid syntax for option {}", m_name, optionNameBuf);
 						throw std::exception();
 					}
 				}
@@ -434,7 +434,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 				const auto it = m_preset_vars.find(kv.first);
 				if (it == m_preset_vars.cend())
 				{
-					cemuLog_force("Graphic pack: \"{}\" contains preset variables which are not defined in the default section", m_name);
+					cemuLog_log(LogType::Force, "Graphic pack: \"{}\" contains preset variables which are not defined in the default section", m_name);
 					throw std::exception();
 				}
 
@@ -472,7 +472,7 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 				auto& p2 = kv.second[i + 1];
 				if (p1->variables.size() != p2->variables.size())
 				{
-					cemuLog_force("Graphic pack: \"{}\" contains inconsistent preset variables", m_name);
+					cemuLog_log(LogType::Force, "Graphic pack: \"{}\" contains inconsistent preset variables", m_name);
 					throw std::exception();
 				}
 
@@ -480,14 +480,14 @@ GraphicPack2::GraphicPack2(std::wstring filename, IniParser& rules)
 				std::set<std::string> keys2(get_keys(p2->variables).begin(), get_keys(p2->variables).end());
 				if (keys1 != keys2)
 				{
-					cemuLog_force("Graphic pack: \"{}\" contains inconsistent preset variables", m_name);
+					cemuLog_log(LogType::Force, "Graphic pack: \"{}\" contains inconsistent preset variables", m_name);
 					throw std::exception();
 				}
 
 				if(p1->is_default)
 				{
 					if(has_default)
-						cemuLog_force("Graphic pack: \"{}\" has more than one preset with the default key set for the same category \"{}\"", m_name, p1->name);
+						cemuLog_log(LogType::Force, "Graphic pack: \"{}\" has more than one preset with the default key set for the same category \"{}\"", m_name, p1->name);
 					p1->active = true;
 					has_default = true;
 				}

--- a/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
@@ -33,7 +33,7 @@ void PatchErrorHandler::printError(class PatchGroup* patchGroup, sint32 lineNumb
 	cemuLog_writeLineToLog(msg, true, true);
 	m_anyErrorTriggered = true;
 
-	if (cafeLog_isLoggingFlagEnabled(LOG_TYPE_PATCHES))
+	if (cemuLog_isLoggingEnabled(LogType::Patches))
 		errorMessages.emplace_back(msg);
 }
 
@@ -51,7 +51,7 @@ void PatchErrorHandler::showStageErrorMessageBox()
 	{
 		cemu_assert_debug(false); // graphic pack should always be set
 	}
-	if (cafeLog_isLoggingFlagEnabled(LOG_TYPE_PATCHES))
+	if (cemuLog_isLoggingEnabled(LogType::Patches))
 	{
 		errorMsg.append("\n \nDetails:\n");
 		for (auto& itr : errorMessages)

--- a/src/Cafe/GraphicPack/GraphicPack2PatchesApply.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2PatchesApply.cpp
@@ -738,7 +738,7 @@ void GraphicPack2::UndoPatchGroups(std::vector<PatchGroup*>& groups, const RPLMo
 
 void GraphicPack2::NotifyModuleLoaded(const RPLModule* rpl)
 {
-	cemuLog_force("Loaded module \'{}\' with checksum 0x{:08x}", rpl->moduleName2, rpl->patchCRC);
+	cemuLog_log(LogType::Force, "Loaded module \'{}\' with checksum 0x{:08x}", rpl->moduleName2, rpl->patchCRC);
 
 	std::lock_guard<std::recursive_mutex> lock(mtx_patches);
 	list_modules.emplace_back(rpl);

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
@@ -132,7 +132,7 @@ PPCRecFunction_t* PPCRecompiler_recompileFunction(PPCFunctionBoundaryTracker::PP
 {
 	if (range.startAddress >= PPC_REC_CODE_AREA_END)
 	{
-		cemuLog_force("Attempting to recompile function outside of allowed code area");
+		cemuLog_log(LogType::Force, "Attempting to recompile function outside of allowed code area");
 		return nullptr;
 	}
 

--- a/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteCommandProcessor.cpp
@@ -470,7 +470,7 @@ LatteCMDPtr LatteCP_itMemWrite(LatteCMDPtr cmd, uint32 nWords)
 	MPTR valuePhysAddr = (word0 & ~3);
 	if (valuePhysAddr == 0)
 	{
-		cemuLog_force("GPU: Invalid itMemWrite to null pointer");
+		cemuLog_log(LogType::Force, "GPU: Invalid itMemWrite to null pointer");
 		return cmd;
 	}
 	uint32be* memPtr = (uint32be*)memory_getPointerFromPhysicalOffset(valuePhysAddr);

--- a/src/Cafe/HW/Latte/Core/LatteTexture.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTexture.cpp
@@ -374,7 +374,7 @@ void LatteTexture_CopySlice(LatteTexture* srcTexture, sint32 srcSlice, sint32 sr
 		sint32 effectiveHeight_src = srcTexture->overwriteInfo.hasResolutionOverwrite ? srcTexture->overwriteInfo.height : srcTexture->height;
 		sint32 effectiveWidth_dst = dstTexture->overwriteInfo.hasResolutionOverwrite ? dstTexture->overwriteInfo.width : dstTexture->width;
 		sint32 effectiveHeight_dst = dstTexture->overwriteInfo.hasResolutionOverwrite ? dstTexture->overwriteInfo.height : dstTexture->height;
-		if (cafeLog_isLoggingFlagEnabled(LOG_TYPE_TEXTURE_CACHE))
+		if (cemuLog_isLoggingEnabled(LogType::TextureCache))
 		{
 			cemuLog_log(LogType::Force, "_copySlice(): Unable to sync textures with mismatching scale ratio (due to texture rule)");
 			float ratioWidth_src = (float)effectiveWidth_src / (float)srcTexture->width;

--- a/src/Cafe/HW/Latte/Core/LatteThread.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteThread.cpp
@@ -163,7 +163,7 @@ int Latte_ThreadEntry()
 	sLatteThreadFinishedInit = true;
 
 	// register debug handler
-	if (cafeLog_isLoggingFlagEnabled(LOG_TYPE_OPENGL))
+	if (cemuLog_isLoggingEnabled(LogType::OpenGLLogging))
 		g_renderer->EnableDebugMode();
 
 	// wait till a game is started

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -253,7 +253,7 @@ void LoadOpenGLImports()
 void OpenGLRenderer::Initialize()
 {
 	Renderer::Initialize();
-	auto lock = cafeLog_acquire();
+	auto lock = cemuLog_acquire();
 	cemuLog_log(LogType::Force, "------- Init OpenGL graphics backend -------");
 
 	GLCanvas_MakeCurrent(false);

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRendererCore.cpp
@@ -1042,7 +1042,7 @@ void OpenGLRenderer::draw_genericDrawHandler(uint32 baseVertex, uint32 baseInsta
 		LatteTextureView* rt_depth = LatteMRT::GetDepthAttachment();
 		if (!rt_depth || !rt_color)
 		{
-			cemuLog_force("GPU7 special state 5 used but render target not setup correctly");
+			cemuLog_log(LogType::Force, "GPU7 special state 5 used but render target not setup correctly");
 			return;
 		}
 		surfaceCopy_copySurfaceWithFormatConversion(rt_depth->baseTexture, rt_depth->firstMip, rt_depth->firstSlice, rt_color->baseTexture, rt_color->firstMip, rt_color->firstSlice, rt_depth->baseTexture->width, rt_depth->baseTexture->height);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -18,7 +18,7 @@ void SwapchainInfoVk::Create(VkPhysicalDevice physicalDevice, VkDevice logicalDe
 	if(details.capabilities.maxImageCount > 0)
 		image_count = std::min(image_count, details.capabilities.maxImageCount);
 	if(image_count < 2)
-		cemuLog_force("Vulkan: Swapchain image count less than 2 may cause problems");
+		cemuLog_log(LogType::Force, "Vulkan: Swapchain image count less than 2 may cause problems");
 
 	VkSwapchainCreateInfoKHR create_info = CreateSwapchainCreateInfo(surface, details, m_surfaceFormat, image_count, m_actualExtent);
 	create_info.oldSwapchain = nullptr;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -311,7 +311,7 @@ VulkanRenderer::VulkanRenderer()
 
 	cemuLog_log(LogType::Force, "------- Init Vulkan graphics backend -------");
 
-	const bool useValidationLayer = cafeLog_isLoggingFlagEnabled(LOG_TYPE_VULKAN_VALIDATION);
+	const bool useValidationLayer = cemuLog_isLoggingEnabled(LogType::VulkanValidation);
 	if (useValidationLayer)
 		cemuLog_log(LogType::Force, "Validation layer is enabled");
 
@@ -1194,7 +1194,7 @@ std::vector<const char*> VulkanRenderer::CheckInstanceExtensionSupport(FeatureCo
 	#elif BOOST_OS_MACOS
 	requiredInstanceExtensions.emplace_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
 	#endif
-	if (cafeLog_isLoggingFlagEnabled(LOG_TYPE_VULKAN_VALIDATION))
+	if (cemuLog_isLoggingEnabled(LogType::VulkanValidation))
 		requiredInstanceExtensions.emplace_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
 
 	// make sure all required extensions are supported

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -531,7 +531,7 @@ VulkanRenderer::VulkanRenderer()
 	swapchain_createDescriptorSetLayout();
 
 	// extension info
-	// cemuLog_force("VK_KHR_dynamic_rendering: {}", m_featureControl.deviceExtensions.dynamic_rendering?"supported":"not supported");
+	// cemuLog_log(LogType::Force, "VK_KHR_dynamic_rendering: {}", m_featureControl.deviceExtensions.dynamic_rendering?"supported":"not supported");
 
 	void* bufferPtr;
 	// init ringbuffer for uniform vars
@@ -3596,7 +3596,7 @@ void VulkanRenderer::bufferCache_init(const sint32 bufferSize)
 		m_useHostMemoryForCache = memoryManager->CreateBufferFromHostMemory(memory_getPointerFromVirtualOffset(m_importedMemBaseAddress), hostAllocationSize, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0, m_importedMem, m_importedMemMemory);
 		if (!m_useHostMemoryForCache)
 		{
-			cemuLog_force("Unable to import host memory to Vulkan buffer. Use default cache system instead");
+			cemuLog_log(LogType::Force, "Unable to import host memory to Vulkan buffer. Use default cache system instead");
 		}
 	}
 	if(!m_useHostMemoryForCache)

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -607,7 +607,7 @@ namespace iosu
 			if (!fscFile)
 				return (FSStatus)FS_RESULT::ERR_PLACEHOLDER;
 #ifdef CEMU_DEBUG_ASSERT
-			cemuLog_force("FSAProcessCmd_appendFile(): size 0x{:08x} count 0x{:08x} (todo)\n", _swapEndianU32(cmd->cmdAppendFile.size), _swapEndianU32(cmd->cmdAppendFile.count));
+			cemuLog_log(LogType::Force, "FSAProcessCmd_appendFile(): size 0x{:08x} count 0x{:08x} (todo)\n", _swapEndianU32(cmd->cmdAppendFile.size), _swapEndianU32(cmd->cmdAppendFile.count));
 #endif
 			return _swapEndianU32(cmd->cmdAppendFile.size) * _swapEndianU32(cmd->cmdAppendFile.count);
 		}

--- a/src/Cafe/IOSU/legacy/iosu_act.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_act.cpp
@@ -113,7 +113,7 @@ void iosuAct_loadAccounts()
 	//	}
 	//}
 
-	cemuLog_force(L"IOSU_ACT: using account {} in first slot", first_acc.GetMiiName());
+	cemuLog_log(LogType::Force, L"IOSU_ACT: using account {} in first slot", first_acc.GetMiiName());
 	
 	_actAccountDataInitialized = true;
 }

--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -367,7 +367,7 @@ namespace iosu
 	bool parse_xml_content(Task& task)
 	{
 		tinyxml2::XMLDocument doc;
-		//cafeLog_writeLineToLog((char*)task.result_buffer.data());
+		//cemuLog_log(LogType::Force, (char*)task.result_buffer.data());
 		if (doc.Parse((const char*)task.result_buffer.data(), task.processed_length) != tinyxml2::XML_SUCCESS)
 			return false;
 

--- a/src/Cafe/IOSU/legacy/iosu_crypto.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.cpp
@@ -326,12 +326,12 @@ bool iosuCrypto_loadCertificate(uint32 id, std::wstring_view mlcSubpath, std::ws
 		pkeyData = FileStream::LoadIntoMemory(pkeyPath);
 		if (!pkeyData || pkeyData->empty())
 		{
-			cemuLog_force("Unable to load private key file {}", pkeyPath.generic_string());
+			cemuLog_log(LogType::Force, "Unable to load private key file {}", pkeyPath.generic_string());
 			return false;
 		}
 		else if ((pkeyData->size() % 16) != 0)
 		{
-			cemuLog_force("Private key file has invalid length. Possibly corrupted? File: {}", pkeyPath.generic_string());
+			cemuLog_log(LogType::Force, "Private key file has invalid length. Possibly corrupted? File: {}", pkeyPath.generic_string());
 			return false;
 		}
 	}

--- a/src/Cafe/IOSU/legacy/iosu_nim.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_nim.cpp
@@ -58,7 +58,7 @@ namespace iosu
 				return false;
 			if (versionListVersionResult.fqdnURL.size() >= 256)
 			{
-				cemuLog_force("NIM: fqdn URL too long");
+				cemuLog_log(LogType::Force, "NIM: fqdn URL too long");
 				return false;
 			}
 			g_nim.latestVersion = (sint32)versionListVersionResult.version;

--- a/src/Cafe/OS/libs/coreinit/coreinit_Synchronization.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Synchronization.cpp
@@ -254,7 +254,7 @@ namespace coreinit
 			else
 			{
 				if (failedAttempts >= 0x800)
-					cemuLog_force("Detected long-term contested OSLockMutex");
+					cemuLog_log(LogType::Force, "Detected long-term contested OSLockMutex");
 				currentThread->waitingForMutex = mutex;
 				mutex->threadQueue.queueAndWait(currentThread);
 				currentThread->waitingForMutex = nullptr;

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -407,7 +407,7 @@ namespace coreinit
 		// release held synchronization primitives
 		if (!threadBE->mutexQueue.isEmpty())
 		{
-			cemuLog_force("OSExitThread: Thread is holding mutexes");
+			cemuLog_log(LogType::Force, "OSExitThread: Thread is holding mutexes");
 			while (true)
 			{
 				OSMutex* mutex = threadBE->mutexQueue.getFirst();
@@ -415,7 +415,7 @@ namespace coreinit
 					break;
 				if (mutex->owner != threadBE)
 				{
-					cemuLog_force("OSExitThread: Thread is holding mutex which it doesn't own");
+					cemuLog_log(LogType::Force, "OSExitThread: Thread is holding mutex which it doesn't own");
 					threadBE->mutexQueue.removeMutex(mutex);
 					continue;
 				}

--- a/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
+++ b/src/Cafe/OS/libs/h264_avc/H264Dec.cpp
@@ -355,7 +355,7 @@ namespace H264
 				uint32 numByteConsumed = 0;
 				if (!DetermineBufferSizes(data, length, numByteConsumed))
 				{
-					cemuLog_force("H264: Unable to determine picture size. Ignoring decode input");
+					cemuLog_log(LogType::Force, "H264: Unable to determine picture size. Ignoring decode input");
 					decodeResult.frameReady = false;
 					return;
 				}
@@ -397,7 +397,7 @@ namespace H264
 			}
 			else if (status != 0)
 			{
-				cemuLog_force("H264: Failed to decode frame (error 0x{:08x})", status);
+				cemuLog_log(LogType::Force, "H264: Failed to decode frame (error 0x{:08x})", status);
 				decodeResult.frameReady = false;
 				return;
 			}
@@ -901,7 +901,7 @@ namespace H264
 		}
 		else
 		{
-			cemuLog_force("h264Export_H264DECSetParam(): Unsupported parameterId 0x{:08x}\n", paramId);
+			cemuLog_log(LogType::Force, "h264Export_H264DECSetParam(): Unsupported parameterId 0x{:08x}\n", paramId);
 			cemu_assert_unimplemented();
 		}
 		return H264DEC_STATUS::SUCCESS;

--- a/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
+++ b/src/Cafe/OS/libs/nn_idbe/nn_idbe.cpp
@@ -46,7 +46,7 @@ namespace nn
 			if (idbeData.size() != sizeof(nnIdbeEncryptedIcon_t))
 			{
 				// icon does not exist or has the wrong size
-				cemuLog_force("IDBE: Failed to retrieve icon for title {:016x}", titleId);
+				cemuLog_log(LogType::Force, "IDBE: Failed to retrieve icon for title {:016x}", titleId);
 				memset(iconOut, 0, sizeof(nnIdbeEncryptedIcon_t));
 				coreinit_resumeThread(thread);
 				return;

--- a/src/Cafe/OS/libs/snd_user/snd_user.cpp
+++ b/src/Cafe/OS/libs/snd_user/snd_user.cpp
@@ -1069,8 +1069,8 @@ namespace snd
 		{
 			if (gUnsupportedSoundEffectWarning)
 				return;
-			cemuLog_force("The currently running title is trying to utilize an unsupported audio effect");
-			cemuLog_force("To emulate these correctly, place snd_user.rpl and snduser2.rpl from the original Wii U firmware in /cafeLibs/ folder");
+			cemuLog_log(LogType::Force, "The currently running title is trying to utilize an unsupported audio effect");
+			cemuLog_log(LogType::Force, "To emulate these correctly, place snd_user.rpl and snduser2.rpl from the original Wii U firmware in /cafeLibs/ folder");
 			gUnsupportedSoundEffectWarning = true;
 		}
 
@@ -1104,17 +1104,17 @@ namespace snd
 
 		void AXFXReverbHiInit(AXFXReverbHiData* param)
 		{
-			cemuLog_force("AXFXReverbHiInit - stub");
+			cemuLog_log(LogType::Force, "AXFXReverbHiInit - stub");
 		}
 
 		void AXFXReverbHiSettings(AXFXReverbHiData* param)
 		{
-			cemuLog_force("AXFXReverbHiSettings - stub");
+			cemuLog_log(LogType::Force, "AXFXReverbHiSettings - stub");
 		}
 
 		void AXFXReverbHiShutdown(AXFXReverbHiData* param)
 		{
-			cemuLog_force("AXFXReverbHiShutdown - stub");
+			cemuLog_log(LogType::Force, "AXFXReverbHiShutdown - stub");
 		}
 
 		void AXFXReverbHiCallback(AUXCBSAMPLEDATA* auxSamples, AXFXReverbHiData* reverbHi)
@@ -1133,7 +1133,7 @@ namespace snd
 
 		void AXFXMultiChReverbInit(AXFXMultiChReverbData* param, int ukn2, int ukn3)
 		{
-			cemuLog_force("AXFXMultiChReverbInit (Stubbed)");
+			cemuLog_log(LogType::Force, "AXFXMultiChReverbInit (Stubbed)");
 		}
 
 		void AXFXMultiChReverbSettingsUpdate(AXFXMultiChReverbData* param)

--- a/src/Cemu/Logging/CemuLogging.cpp
+++ b/src/Cemu/Logging/CemuLogging.cpp
@@ -33,18 +33,25 @@ struct _LogContext
 
 const std::map<LogType, std::string> g_logging_window_mapping
 {
+	{LogType::UnsupportedAPI, "Unsupported API calls"},
+	{LogType::CoreinitLogging, "Coreinit Logging"},
 	{LogType::CoreinitFile, "Coreinit File-Access"},
-	{LogType::GX2, "GX2"},
 	{LogType::ThreadSync, "Coreinit Thread-Synchronization"},
+	{LogType::CoreinitMem, "Coreinit Memory"},
+	{LogType::CoreinitMP, "Coreinit MP"},
+	{LogType::CoreinitThread, "Coreinit Thread"},
+	{LogType::nn_nfp, "nn::nfp"},
+	{LogType::GX2, "GX2"},
 	{LogType::SoundAPI, "Audio"},
 	{LogType::InputAPI, "Input"},
 	{LogType::Socket, "Socket"},
 	{LogType::Save, "Save"},
-	{LogType::CoreinitMem, "Coreinit Memory"},
 	{LogType::H264, "H264"},
-	{LogType::OpenGLLogging, "OpenGL"},
-	{LogType::TextureCache, "Texture Cache"},
-	{LogType::nn_nfp, "NFP"},
+	{LogType::Patches, "Graphic pack patches"},
+	{LogType::TextureCache, "Texture cache"},
+	{LogType::TextureReadback, "Texture readback"},
+	{LogType::OpenGLLogging, "OpenGL debug output"},
+	{LogType::VulkanValidation, "Vulkan validation layer"},
 };
 
 uint64 cemuLog_getFlag(LogType type)

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -121,20 +121,3 @@ void cemuLog_setFlag(LogType type, bool enabled);
 fs::path cemuLog_GetLogFilePath();
 void cemuLog_createLogFile(bool triggeredByCrash);
 [[nodiscard]] std::unique_lock<std::recursive_mutex> cemuLog_acquire(); // used for logging multiple lines at once
-
-// force log. Redundant -> replace with _log(LogType::Force, ...) call
-inline bool cemuLog_force(std::string_view msg)
-{
-	return cemuLog_log(LogType::Force, msg);
-}
-
-inline bool cemuLog_force(std::wstring_view msg)
-{
-	return cemuLog_log(LogType::Force, msg);
-}
-
-template<typename TFmt, typename ... TArgs>
-void cemuLog_force(TFmt format, TArgs&&... args)
-{
-	cemuLog_log(LogType::Force, format, std::forward<TArgs>(args)...);
-}

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -116,40 +116,11 @@ bool cemuLog_logDebug(LogType type, TFmt format, TArgs&&... args)
 bool cemuLog_advancedPPCLoggingEnabled();
 
 uint64 cemuLog_getFlag(LogType type);
-void cafeLog_setLoggingFlagEnable(sint32 loggingType, bool isEnable);
-bool cafeLog_isLoggingFlagEnabled(sint32 loggingType);
+void cemuLog_setFlag(LogType type, bool enabled);
 
 fs::path cemuLog_GetLogFilePath();
 void cemuLog_createLogFile(bool triggeredByCrash);
-
-[[nodiscard]] std::unique_lock<std::recursive_mutex> cafeLog_acquire();
-
-// legacy methods
-void cafeLog_log(uint32 type, const char* format, ...);
-void cafeLog_logW(uint32 type, const wchar_t* format, ...);
-void cafeLog_logLine(uint32 type, const char* line);
-
-// legacy log types, deprecated. Use LogType instead
-#define LOG_TYPE_FORCE				(0) // this logging type is always on
-#define LOG_TYPE_FILE				(1)
-#define LOG_TYPE_GX2				(2)
-#define LOG_TYPE_UNSUPPORTED_API	(3)
-#define LOG_TYPE_THREADSYNC			(4)
-#define LOG_TYPE_SNDAPI				(5) // any audio related API
-#define LOG_TYPE_INPUT				(6) // any input related API
-#define LOG_TYPE_SOCKET				(7) // anything from nn_sysnet
-#define LOG_TYPE_SAVE				(8) // anything from nn_save
-#define LOG_TYPE_COREINIT_MEM		(9)	// coreinit memory functions
-#define LOG_TYPE_H264				(10)
-#define LOG_TYPE_OPENGL				(11) // OpenGL debug logging
-#define LOG_TYPE_TEXTURE_CACHE		(12) // texture cache warnings and info
-#define LOG_TYPE_VULKAN_VALIDATION	(13) // Vulkan validation layer
-#define LOG_TYPE_NFP				(14) // nn_nfp (Amiibo) API
-#define LOG_TYPE_PATCHES			(15) // logging for graphic pack patches
-#define LOG_TYPE_COREINIT_MP		(16)
-#define LOG_TYPE_COREINIT_THREAD	(17)
-#define LOG_TYPE_COREINIT_LOGGING	(18)
-#define LOG_TYPE_LAST				(64) // set to 64 so we can easily add more log types in the future without destroying settings file compatibility
+[[nodiscard]] std::unique_lock<std::recursive_mutex> cemuLog_acquire(); // used for logging multiple lines at once
 
 // force log. Redundant -> replace with _log(LogType::Force, ...) call
 inline bool cemuLog_force(std::string_view msg)
@@ -167,22 +138,3 @@ void cemuLog_force(TFmt format, TArgs&&... args)
 {
 	cemuLog_log(LogType::Force, format, std::forward<TArgs>(args)...);
 }
-
-// these are deprecated. Superseded by cemuLog_log(type, ...)
-#define forceLog_printf(...)		cafeLog_log(LOG_TYPE_FORCE, __VA_ARGS__);
-#define gx2Log_printf(...)			if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_GX2) ) cafeLog_log(LOG_TYPE_GX2, __VA_ARGS__);
-#define coreinitMemLog_printf(...)	if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_COREINIT_MEM) ) cafeLog_log(LOG_TYPE_COREINIT_MEM, __VA_ARGS__);
-#define sndApiLog_printf(...)		if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_SNDAPI) ) cafeLog_log(LOG_TYPE_SNDAPI, __VA_ARGS__);
-#define socketLog_printf(...)		if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_SOCKET) ) cafeLog_log(LOG_TYPE_SOCKET, __VA_ARGS__);
-#define inputLog_printf(...)		if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_INPUT) ) cafeLog_log(LOG_TYPE_INPUT, __VA_ARGS__);
-#define saveLog_printf(...)			if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_SAVE) ) cafeLog_log(LOG_TYPE_SAVE, __VA_ARGS__);
-#define nfpLog_printf(...)			if( cafeLog_isLoggingFlagEnabled(LOG_TYPE_NFP) ) cafeLog_log(LOG_TYPE_NFP, __VA_ARGS__);
-
-#ifdef CEMU_DEBUG_ASSERT
-#define forceLogDebug_printf(...)		cafeLog_log(LOG_TYPE_FORCE, __VA_ARGS__);
-
- // use this for temporary debug logging. Will trigger compilation error in release builds
-#define forceLogRemoveMe_printf(...)	cafeLog_log(LOG_TYPE_FORCE, __VA_ARGS__);
-#else
-#define forceLogDebug_printf(...)	;
-#endif

--- a/src/Cemu/napi/napi_act.cpp
+++ b/src/Cemu/napi/napi_act.cpp
@@ -40,16 +40,16 @@ namespace NAPI
 				sint32 errorCode = StringHelpers::ToInt(errorCodeStr);
 				if (errorCode == 0)
 				{
-					cemuLog_force("Account response with unexpected error code 0");
+					cemuLog_log(LogType::Force, "Account response with unexpected error code 0");
 					result.apiError = NAPI_RESULT::XML_ERROR;
 				}
 				else
 				{
 					result.apiError = NAPI_RESULT::SERVICE_ERROR;
 					result.serviceError = (ACT_ERROR_CODE)errorCode;
-					cemuLog_force("Account response with error code {}", errorCode);
+					cemuLog_log(LogType::Force, "Account response with error code {}", errorCode);
 					if(!errorCodeMsg.empty())
-						cemuLog_force("Message from server: {}", errorCodeMsg);
+						cemuLog_log(LogType::Force, "Message from server: {}", errorCodeMsg);
 				}
 			}
 			else
@@ -212,7 +212,7 @@ namespace NAPI
 		result.apiError = NAPI_RESULT::SUCCESS;
 
 		if (result.token.empty())
-			cemuLog_force("OAuth20/token is empty");
+			cemuLog_log(LogType::Force, "OAuth20/token is empty");
 		sint64 expiration = StringHelpers::ToInt64(expires_in);
 		expiration = std::max(expiration - 30LL, 0LL); // subtract a few seconds to compensate for the web request delay
 
@@ -283,7 +283,7 @@ namespace NAPI
 		ACTOauthToken oauthToken = ACT_GetOauthToken_WithCache(authInfo, titleId, titleVersion);
 		if (!oauthToken.isValid())
 		{
-			cemuLog_force("ACT_GetNexToken(): Failed to retrieve OAuth token");
+			cemuLog_log(LogType::Force, "ACT_GetNexToken(): Failed to retrieve OAuth token");
 			if (oauthToken.apiError == NAPI_RESULT::SERVICE_ERROR)
 			{
 				result.apiError = NAPI_RESULT::SERVICE_ERROR;
@@ -348,7 +348,7 @@ namespace NAPI
 		pugi::xml_node tokenNode = doc.child("nex_token");
 		if (!tokenNode)
 		{
-			cemuLog_force("Response does not contain NexToken node");
+			cemuLog_log(LogType::Force, "Response does not contain NexToken node");
 			result.apiError = NAPI_RESULT::XML_ERROR;
 			return result;
 		}
@@ -360,11 +360,11 @@ namespace NAPI
 
 		std::memset(&result.nexToken, 0, sizeof(result.nexToken));
 		if (host.size() > 15)
-			cemuLog_force("NexToken response: host field too long");
+			cemuLog_log(LogType::Force, "NexToken response: host field too long");
 		if (nex_password.size() > 64)
-			cemuLog_force("NexToken response: nex_password field too long");
+			cemuLog_log(LogType::Force, "NexToken response: nex_password field too long");
 		if (token.size() > 512)
-			cemuLog_force("NexToken response: token field too long");
+			cemuLog_log(LogType::Force, "NexToken response: token field too long");
 		for (size_t i = 0; i < std::min(host.size(), (size_t)15); i++)
 			result.nexToken.host[i] = host[i];
 		for (size_t i = 0; i < std::min(nex_password.size(), (size_t)64); i++)
@@ -435,7 +435,7 @@ namespace NAPI
 		ACTOauthToken oauthToken = ACT_GetOauthToken_WithCache(authInfo, titleId, titleVersion);
 		if (!oauthToken.isValid())
 		{
-			cemuLog_force("ACT_GetIndependentToken(): Failed to retrieve OAuth token");
+			cemuLog_log(LogType::Force, "ACT_GetIndependentToken(): Failed to retrieve OAuth token");
 			if (oauthToken.apiError == NAPI_RESULT::SERVICE_ERROR)
 			{
 				result.apiError = NAPI_RESULT::SERVICE_ERROR;
@@ -484,7 +484,7 @@ namespace NAPI
 		pugi::xml_node tokenNode = doc.child("service_token");
 		if (!tokenNode)
 		{
-			cemuLog_force("Response does not contain service_token node");
+			cemuLog_log(LogType::Force, "Response does not contain service_token node");
 			result.apiError = NAPI_RESULT::XML_ERROR;
 			return result;
 		}
@@ -506,7 +506,7 @@ namespace NAPI
 		ACTOauthToken oauthToken = ACT_GetOauthToken_WithCache(authInfo, 0x0005001010001C00, 0);
 		if (!oauthToken.isValid())
 		{
-			cemuLog_force("ACT_ACTConvertNnidToPrincipalId(): Failed to retrieve OAuth token");
+			cemuLog_log(LogType::Force, "ACT_ACTConvertNnidToPrincipalId(): Failed to retrieve OAuth token");
 			if (oauthToken.apiError == NAPI_RESULT::SERVICE_ERROR)
 			{
 				result.apiError = NAPI_RESULT::SERVICE_ERROR;
@@ -558,14 +558,14 @@ namespace NAPI
 		pugi::xml_node tokenNode = doc.child("mapped_ids");
 		if (!tokenNode)
 		{
-			cemuLog_force("Response does not contain mapped_ids node");
+			cemuLog_log(LogType::Force, "Response does not contain mapped_ids node");
 			result.apiError = NAPI_RESULT::XML_ERROR;
 			return result;
 		}
 		tokenNode = tokenNode.child("mapped_id");
 		if (!tokenNode)
 		{
-			cemuLog_force("Response does not contain mapped_id node");
+			cemuLog_log(LogType::Force, "Response does not contain mapped_id node");
 			result.apiError = NAPI_RESULT::XML_ERROR;
 			return result;
 		}
@@ -598,7 +598,7 @@ namespace NAPI
 			static bool s_showedLoginError = false;
 			if (!s_showedLoginError)
 			{
-				cemuLog_force("Account login is impossible because the cached password hash is not set");
+				cemuLog_log(LogType::Force, "Account login is impossible because the cached password hash is not set");
 				s_showedLoginError = true;
 			}
 			return false; // password hash not set

--- a/src/Cemu/napi/napi_ec.cpp
+++ b/src/Cemu/napi/napi_ec.cpp
@@ -336,7 +336,7 @@ namespace NAPI
 				result.accountStatus = NAPI_ECSGetAccountStatus_Result::AccountStatus::UNREGISTERED;
 			else
 			{
-				cemuLog_force("ECS_GetAccountStatus: Account has unknown status code {}", accountStatusStr);
+				cemuLog_log(LogType::Force, "ECS_GetAccountStatus: Account has unknown status code {}", accountStatusStr);
 			}
 		}
 		// extract service URLs

--- a/src/Cemu/napi/napi_helper.cpp
+++ b/src/Cemu/napi/napi_helper.cpp
@@ -189,7 +189,7 @@ bool CurlRequestHelper::submitRequest(bool isPost)
 	int res = curl_easy_perform(m_curl);
 	if (res != CURLE_OK)
 	{
-		cemuLog_force("CURL web request failed with error {}. Retrying...", res);
+		cemuLog_log(LogType::Force, "CURL web request failed with error {}. Retrying...", res);
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 		// retry
 		res = curl_easy_perform(m_curl);

--- a/src/Cemu/ncrypto/ncrypto.cpp
+++ b/src/Cemu/ncrypto/ncrypto.cpp
@@ -447,7 +447,7 @@ namespace NCrypto
 	{
 		if (size < sizeof(TMDFileHeaderWiiU))
 		{
-			cemuLog_force("TMD size {} below minimum size of {}", size, sizeof(TMDFileHeaderWiiU));
+			cemuLog_log(LogType::Force, "TMD size {} below minimum size of {}", size, sizeof(TMDFileHeaderWiiU));
 			return false;
 		}
 		TMDFileHeaderWiiU* header = (TMDFileHeaderWiiU*)data;
@@ -456,7 +456,7 @@ namespace NCrypto
 		size_t expectedSize = sizeof(TMDFileHeaderWiiU) + sizeof(TMDFileContentEntryWiiU) * header->numContent;
 		if (size < expectedSize)
 		{
-			cemuLog_force("TMD size {} below expected size of {}. Content count: {}", size, expectedSize, (uint16)header->numContent);
+			cemuLog_log(LogType::Force, "TMD size {} below expected size of {}. Content count: {}", size, expectedSize, (uint16)header->numContent);
 			return false;
 		}
 
@@ -806,7 +806,7 @@ namespace NCrypto
 			return "KOR";
 		else if (regionCode == CafeConsoleRegion::TWN)
 			return "TWN";
-		cemuLog_force("Unknown region code 0x{:x}", (uint32)regionCode);
+		cemuLog_log(LogType::Force, "Unknown region code 0x{:x}", (uint32)regionCode);
 		return "UKN";
 	}
 

--- a/src/audio/CubebAPI.cpp
+++ b/src/audio/CubebAPI.cpp
@@ -169,7 +169,7 @@ bool CubebAPI::InitializeStatic()
 {
 	if (cubeb_init(&s_context, "Cemu Cubeb", nullptr))
 	{
-		cemuLog_force("can't create cubeb audio api");
+		cemuLog_log(LogType::Force, "can't create cubeb audio api");
 		return false;
 	}
 	return true;

--- a/src/audio/CubebInputAPI.cpp
+++ b/src/audio/CubebInputAPI.cpp
@@ -160,7 +160,7 @@ bool CubebInputAPI::InitializeStatic()
 {
 	if (cubeb_init(&s_context, "Cemu Input Cubeb", nullptr))
 	{
-		cemuLog_force("can't create cubeb audio api");
+		cemuLog_log(LogType::Force, "can't create cubeb audio api");
 		return false;
 	}
 

--- a/src/gui/DownloadGraphicPacksWindow.cpp
+++ b/src/gui/DownloadGraphicPacksWindow.cpp
@@ -84,7 +84,7 @@ void createGraphicPackDownloadedVersionFile(const char* nameVersion)
 		file->writeString(nameVersion);
 	else
 	{
-		cemuLog_force("Failed to write graphic pack version.txt");
+		cemuLog_log(LogType::Force, "Failed to write graphic pack version.txt");
 	}
 }
 

--- a/src/gui/LoggingWindow.cpp
+++ b/src/gui/LoggingWindow.cpp
@@ -21,7 +21,7 @@ LoggingWindow::LoggingWindow(wxFrame* parent)
 
 		filter_row->Add(new wxStaticText( this, wxID_ANY, _("Filter")), 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-		wxString choices[] = {"Coreinit File-Access", "Coreinit Thread-Synchronization", "Coreinit Memory", "GX2", "Audio", "Input", "Socket", "Save", "H264", "Texture Cache", "OpenGL"};
+		wxString choices[] = {"Unsupported APIs calls", "Coreinit Logging", "Coreinit File-Access", "Coreinit Thread-Synchronization", "Coreinit Memory", "Coreinit MP", "Coreinit Thread", "nn::nfp", "GX2", "Audio", "Input", "Socket", "Save", "H264", "Graphic pack patches", "Texture cache", "Texture readback", "OpenGL debug output", "Vulkan validation layer"};
 		m_filter = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, std::size(choices), choices, 0 );
 		m_filter->Bind(wxEVT_COMBOBOX, &LoggingWindow::OnFilterChange, this);
 		m_filter->Bind(wxEVT_TEXT, &LoggingWindow::OnFilterChange, this);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2193,9 +2193,7 @@ void MainWindow::RecreateMenu()
 	debugLoggingMenu->AppendSeparator();
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::OpenGLLogging), _("&OpenGL debug output"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::OpenGLLogging));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::VulkanValidation), _("&Vulkan validation layer (slow)"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::VulkanValidation));
-#ifdef CEMU_DEBUG_ASSERT
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_ADVANCED_PPC_INFO, _("&Log PPC context for API"), wxEmptyString)->Check(cemuLog_advancedPPCLoggingEnabled());
-#endif
 	m_loggingSubmenu = debugLoggingMenu;
 	// debug->dump submenu
 	wxMenu* debugDumpMenu = new wxMenu;
@@ -2224,9 +2222,7 @@ void MainWindow::RecreateMenu()
 	audioAuxOnly->Check(ActiveSettings::AudioOutputOnlyAux());
 #endif
 
-#ifdef CEMU_DEBUG_ASSERT
 	debugMenu->Append(MAINFRAME_MENU_ID_DEBUG_VIEW_LOGGING_WINDOW, _("&Open logging window"));
-#endif
 	m_gdbstub_toggle = debugMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_TOGGLE_GDB_STUB, _("&Launch with GDB stub"), wxEmptyString);
 	m_gdbstub_toggle->Check(g_gdbstub != nullptr);
 	m_gdbstub_toggle->Enable(!m_game_launched);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1089,7 +1089,7 @@ void MainWindow::OnDebugLoggingToggleFlagGeneric(wxCommandEvent& event)
 	sint32 id = event.GetId();
 	if (id >= loggingIdBase && id < (MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 64))
 	{
-		cafeLog_setLoggingFlagEnable(id - loggingIdBase, event.IsChecked());
+		cemuLog_setFlag(static_cast<LogType>(id - loggingIdBase), event.IsChecked());
 	}
 }
 
@@ -2263,8 +2263,8 @@ void MainWindow::RecreateMenu()
 		m_nfcMenu->Enable(MAINFRAME_MENU_ID_NFC_TOUCH_NFC_FILE, true);
 		
 		// disable OpenGL logging (currently cant be toggled after OpenGL backend is initialized)
-		m_loggingSubmenu->Enable(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_OPENGL, false);
-		m_loggingSubmenu->Enable(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + LOG_TYPE_VULKAN_VALIDATION, false);
+		m_loggingSubmenu->Enable(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::OpenGLLogging), false);
+		m_loggingSubmenu->Enable(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::VulkanValidation), false);
 
 		UpdateNFCMenu();
 	}

--- a/src/gui/canvas/OpenGLCanvas.cpp
+++ b/src/gui/canvas/OpenGLCanvas.cpp
@@ -77,7 +77,7 @@ public:
 			{
 				if (eglSwapInterval(eglGetCurrentDisplay(), configValue) == EGL_FALSE)
 				{
-					cemuLog_force("Failed to set vsync using EGL");
+					cemuLog_log(LogType::Force, "Failed to set vsync using EGL");
 				}
 			}
 #else

--- a/src/input/ControllerFactory.cpp
+++ b/src/input/ControllerFactory.cpp
@@ -159,7 +159,7 @@ ControllerProviderPtr ControllerFactory::CreateControllerProvider(InputAPI::Type
 			}
 			catch (const std::bad_cast&)
 			{
-				cemuLog_force("failing to cast ControllerProviderSettings class to DSUControllerProvider");
+				cemuLog_log(LogType::Force, "failing to cast ControllerProviderSettings class to DSUControllerProvider");
 				return std::make_shared<DSUControllerProvider>();
 			}
 		}

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -21,7 +21,7 @@ InputManager::InputManager()
 		}
 		catch (const std::exception& ex)
 		{
-			cemuLog_force(ex.what());
+			cemuLog_log(LogType::Force, ex.what());
 		}
 	}
 	*/
@@ -67,7 +67,7 @@ void InputManager::load() noexcept
 		}
 		catch (const std::exception& ex)
 		{
-			cemuLog_force("can't load controller profile: {}", ex.what());
+			cemuLog_log(LogType::Force, "can't load controller profile: {}", ex.what());
 		}
 	}
 }
@@ -198,7 +198,7 @@ bool InputManager::load(size_t player_index, std::string_view filename)
 			}
 			catch (const std::exception& ex)
 			{
-				cemuLog_force("can't load controller: {}", ex.what());
+				cemuLog_log(LogType::Force, "can't load controller: {}", ex.what());
 			}
 		}
 
@@ -207,7 +207,7 @@ bool InputManager::load(size_t player_index, std::string_view filename)
 	}
 	catch (const std::exception& ex)
 	{
-		cemuLog_force("can't load config file: {}", ex.what());
+		cemuLog_log(LogType::Force, "can't load config file: {}", ex.what());
 		return false;
 	}
 }
@@ -420,7 +420,7 @@ bool InputManager::migrate_config(const fs::path& file_path)
 	}
 	catch (const std::exception& ex)
 	{
-		cemuLog_force("can't migrate config file {}: {}", file_path.string(), ex.what());
+		cemuLog_log(LogType::Force, "can't migrate config file {}: {}", file_path.string(), ex.what());
 	}
 
 	return false;
@@ -436,7 +436,7 @@ void InputManager::save() noexcept
 		}
 		catch (const std::exception& ex)
 		{
-			cemuLog_force("can't save controller profile: {}", ex.what());
+			cemuLog_log(LogType::Force, "can't save controller profile: {}", ex.what());
 		}
 	}
 }
@@ -620,7 +620,7 @@ EmulatedControllerPtr InputManager::set_controller(size_t player_index, Emulated
 	}
 	catch (const std::exception& ex)
 	{
-		cemuLog_force("Unable to set controller type {} on player index {}: {}", type, player_index, ex.what());
+		cemuLog_log(LogType::Force, "Unable to set controller type {} on player index {}: {}", type, player_index, ex.what());
 	}
 
 	return {};

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -114,7 +114,7 @@ private:
 		}
 		catch (const std::exception& ex)
 		{
-			cemuLog_force(ex.what());
+			cemuLog_log(LogType::Force, ex.what());
 		}
 	}
 };

--- a/src/input/emulated/VPADController.cpp
+++ b/src/input/emulated/VPADController.cpp
@@ -221,7 +221,7 @@ void VPADController::update_touch(VPADStatus_t& status)
 
 		m_last_touch_position = glm::ivec2{ status.tpData.x, status.tpData.y };
 
-		/*cemuLog_force("TDATA: {},{} -> {},{} -> {},{} -> {},{} -> {},{} -> {},{}",
+		/*cemuLog_log(LogType::Force, "TDATA: {},{} -> {},{} -> {},{} -> {},{} -> {},{} -> {},{}",
 			left_mouse->x, left_mouse->y,
 			(left_mouse.value() - image_pos).x, (left_mouse.value() - image_pos).y,
 			relative_mouse_pos.x, relative_mouse_pos.y,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,9 +110,9 @@ void checkForWine()
 
 void infoLog_cemuStartup()
 {
-	cemuLog_force("------- Init {} -------", BUILD_VERSION_WITH_NAME_STRING);
-	cemuLog_force("Init Wii U memory space (base: 0x{:016x})", (size_t)memory_base);
-	cemuLog_force("mlc01 path: {}", _pathToUtf8(ActiveSettings::GetMlcPath()));
+	cemuLog_log(LogType::Force, "------- Init {} -------", BUILD_VERSION_WITH_NAME_STRING);
+	cemuLog_log(LogType::Force, "Init Wii U memory space (base: 0x{:016x})", (size_t)memory_base);
+	cemuLog_log(LogType::Force, "mlc01 path: {}", _pathToUtf8(ActiveSettings::GetMlcPath()));
 	// check for wine version
 	checkForWine();
 	// CPU and RAM info

--- a/src/util/EventService.h
+++ b/src/util/EventService.h
@@ -56,7 +56,7 @@ public:
 		}
 		catch (const std::exception& ex)
 		{
-			cemuLog_force("error when signaling {}: {}", event, ex.what());
+			cemuLog_log(LogType::Force, "error when signaling {}: {}", event, ex.what());
 		}
 	}
 

--- a/src/util/IniParser/IniParser.cpp
+++ b/src/util/IniParser/IniParser.cpp
@@ -259,5 +259,5 @@ std::span<std::pair<std::string_view, std::string_view>> IniParser::GetAllOption
 void IniParser::PrintWarning(int lineNumber, std::string_view msg, std::string_view lineView)
 {
 	// INI logging is silenced
-	// cemuLog_force("File: {} Line {}: {}", m_name, lineNumber, msg);
+	// cemuLog_log(LogType::Force, "File: {} Line {}: {}", m_name, lineNumber, msg);
 }

--- a/src/util/ScreenSaver/ScreenSaver.h
+++ b/src/util/ScreenSaver/ScreenSaver.h
@@ -16,7 +16,7 @@ public:
       int initErr = SDL_InitSubSystem(SDL_INIT_VIDEO);
       if (initErr)
       {
-        cemuLog_force("Could not disable screen saver (SDL video subsystem initialization error)");
+        cemuLog_log(LogType::Force, "Could not disable screen saver (SDL video subsystem initialization error)");
       }
     }
     // Toggle SDL's screen saver inhibition
@@ -25,7 +25,7 @@ public:
       SDL_DisableScreenSaver();
       if (SDL_IsScreenSaverEnabled() == SDL_TRUE)
       {
-        cemuLog_force("Could not verify if screen saver was disabled (`SDL_IsScreenSaverEnabled()` returned SDL_TRUE)");
+        cemuLog_log(LogType::Force, "Could not verify if screen saver was disabled (`SDL_IsScreenSaverEnabled()` returned SDL_TRUE)");
       }
     }
     else
@@ -33,7 +33,7 @@ public:
       SDL_EnableScreenSaver();
       if (SDL_IsScreenSaverEnabled() == SDL_FALSE)
       {
-        cemuLog_force("Could not verify if screen saver was re-enabled (`SDL_IsScreenSaverEnabled()` returned SDL_FALSE)");
+        cemuLog_log(LogType::Force, "Could not verify if screen saver was re-enabled (`SDL_IsScreenSaverEnabled()` returned SDL_FALSE)");
       }
     }
   };

--- a/src/util/SystemInfo/SystemInfoMac.cpp
+++ b/src/util/SystemInfo/SystemInfoMac.cpp
@@ -58,5 +58,5 @@ void QueryCoreTimes(uint32 count, std::vector<ProcessorTime>& out)
 	int ret = vm_deallocate(mach_task_self(), (vm_address_t) info_array,
 						info_count * sizeof(int));
 	if (ret != KERN_SUCCESS)
-		cemuLog_force("vm_deallocate() failed");
+		cemuLog_log(LogType::Force, "vm_deallocate() failed");
 }


### PR DESCRIPTION
Here's some final changes to remove the old logging system implementation now that @why-keith finished migrating everything to the new logging system.

I also removed all the calls to `cemuLog_force` since it's considered a deprecated shorthand version of `cemuLog_log(LogType::Force, ...)`.

Since all calls are done through the new logging system, we can also expose systems that only worked with the new logging system like the advanced PPC context logging and a logging window.