### PR TITLE
Coreinit: Implement several FSA functions and fix some bugs

### DIFF
--- a/src/Cafe/Filesystem/fsc.cpp
+++ b/src/Cafe/Filesystem/fsc.cpp
@@ -378,6 +378,7 @@ FSCVirtualFile* fsc_open(const char* path, FSC_ACCESS_FLAG accessFlags, sint32* 
 				{
 					// return first found file
 					cemu_assert_debug(HAS_FLAG(accessFlags, FSC_ACCESS_FLAG::OPEN_FILE));
+					fscVirtualFile->m_isAppend = HAS_FLAG(accessFlags, FSC_ACCESS_FLAG::IS_APPEND);
 					fscLeave();
 					return fscVirtualFile;
 				}				
@@ -598,6 +599,9 @@ uint32 fsc_writeFile(FSCVirtualFile* fscFile, void* buffer, uint32 size)
 		fscLeave();
 		return 0;
 	}
+	if (fscFile->m_isAppend)
+		fsc_setFileSeek(fscFile, fsc_getFileSize(fscFile));
+
 	uint32 fscStatus = fscFile->fscWriteData(buffer, size);
 	fscLeave();
 	return fscStatus;

--- a/src/Cafe/Filesystem/fsc.cpp
+++ b/src/Cafe/Filesystem/fsc.cpp
@@ -302,6 +302,15 @@ public:
 		return true;
 	}
 
+	bool fscRewindDir() override
+	{
+		if (!dirIterator)
+			return true;
+
+		dirIterator->index  = 0;
+		return true;
+	}
+
 	void addUniqueDirEntry(const FSCDirEntry& dirEntry)
 	{
 		// skip if already in list

--- a/src/Cafe/Filesystem/fsc.h
+++ b/src/Cafe/Filesystem/fsc.h
@@ -152,6 +152,12 @@ struct FSCVirtualFile
 		return false;
 	}
 
+	virtual bool fscRewindDir()
+	{
+		cemu_assert_unimplemented();
+		return false;
+	}
+
 	FSCDirIteratorState* dirIterator{};
 
 	bool m_isAppend{ false };

--- a/src/Cafe/Filesystem/fsc.h
+++ b/src/Cafe/Filesystem/fsc.h
@@ -24,7 +24,10 @@ enum class FSC_ACCESS_FLAG : uint8
 	// which types can be opened
 	// invalid operation if neither is set
 	OPEN_DIR = (1 << 4), 
-	OPEN_FILE = (1 << 5)
+	OPEN_FILE = (1 << 5),
+
+	// Writing seeks to the end of the file if set
+	IS_APPEND = (1 << 6)
 };
 DEFINE_ENUM_FLAG_OPERATORS(FSC_ACCESS_FLAG);
 
@@ -150,6 +153,8 @@ struct FSCVirtualFile
 	}
 
 	FSCDirIteratorState* dirIterator{};
+
+	bool m_isAppend{ false };
 };
 
 #define FSC_PRIORITY_BASE				(0)

--- a/src/Cafe/IOSU/fsa/fsa_types.h
+++ b/src/Cafe/IOSU/fsa/fsa_types.h
@@ -17,9 +17,11 @@ enum class FS_RESULT : sint32 // aka FSStatus
 
 enum class FSA_RESULT : sint32 // aka FSError/FSAStatus
 {
-	SUCCESS = 0,
-	END_DIR = -0x30000 - 0x04,
-	END_FILE = -0x30000 - 0x05,
+	OK = 0,
+	NOT_INIT = -0x30000 - 0x01,
+	END_OF_DIRECTORY = -0x30000 - 0x04,
+	END_OF_FILE = -0x30000 - 0x05,
+	MAX_CLIENTS = -0x30000 - 0x12,
 	MAX_FILES = -0x30000 - 0x13,
 	MAX_DIRS = -0x30000 - 0x14,
 	ALREADY_EXISTS = -0x30000 - 0x16,
@@ -34,6 +36,7 @@ enum class FSA_RESULT : sint32 // aka FSError/FSAStatus
 	INVALID_DIR_HANDLE = -0x30000 - 0x27,
 	NOT_FILE = -0x30000 - 0x28,
 	NOT_DIR = -0x30000 - 0x29,
+	OUT_OF_RESOURCES = -0x30000 - 0x2C,
 	FATAL_ERROR = -0x30000 - 0x400,
 };
 

--- a/src/Cafe/IOSU/fsa/fsa_types.h
+++ b/src/Cafe/IOSU/fsa/fsa_types.h
@@ -86,6 +86,7 @@ enum class FSFlag : uint32
 {
 	NONE = 0,
 	IS_DIR = 0x80000000,
+	IS_FILE = 0x01000000,
 };
 DEFINE_ENUM_FLAG_OPERATORS(FSFlag);
 

--- a/src/Cafe/IOSU/fsa/fsa_types.h
+++ b/src/Cafe/IOSU/fsa/fsa_types.h
@@ -49,6 +49,7 @@ enum class FSA_CMD_OPERATION_TYPE : uint32
 	RENAME = 0x9,
 	OPENDIR = 0xA,
 	READDIR = 0xB,
+	REWINDDIR = 0xC,
 	CLOSEDIR = 0xD,
 	OPENFILE = 0xE,
 	READ = 0xF,
@@ -58,6 +59,7 @@ enum class FSA_CMD_OPERATION_TYPE : uint32
 	ISEOF = 0x13,
 	GETSTATFILE = 0x14,
 	CLOSEFILE = 0x15,
+	FLUSHFILE = 0x17,
 	QUERYINFO = 0x18,
 	APPENDFILE = 0x19,
 	TRUNCATEFILE = 0x1A,
@@ -114,8 +116,18 @@ struct FSDirEntry_t
 
 static_assert(sizeof(FSDirEntry_t) == 0xE4);
 
+struct FSADeviceInfo_t
+{
+	uint8 ukn0[0x8];
+	uint64be deviceSizeInSectors;
+	uint32be deviceSectorSize;
+	uint8 ukn014[0x14];
+};
+static_assert(sizeof(FSADeviceInfo_t) == 0x28);
+
 #pragma pack()
 
 // query types for QueryInfo
 #define FSA_QUERY_TYPE_FREESPACE 0
+#define FSA_QUERY_TYPE_DEVICE_INFO 4
 #define FSA_QUERY_TYPE_STAT 5

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -229,10 +229,9 @@ namespace iosu
 				accessModifier = FSC_ACCESS_FLAG::READ_PERMISSION;
 			else if (strcmp(accessModifierStr, "r+") == 0)
 			{
-				// r+ will create a new file if it doesn't exist
 				// the cursor will be set to the beginning of the file
 				// allows read and write access
-				accessModifier = FSC_ACCESS_FLAG::READ_PERMISSION | FSC_ACCESS_FLAG::WRITE_PERMISSION | FSC_ACCESS_FLAG::FILE_ALLOW_CREATE; // create if non exists, read, write
+				accessModifier = FSC_ACCESS_FLAG::READ_PERMISSION | FSC_ACCESS_FLAG::WRITE_PERMISSION; // read, write
 			}
 			else if (strcmp(accessModifierStr, "w") == 0)
 			{

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -252,10 +252,12 @@ namespace iosu
 			}
 			else if (strcmp(accessModifierStr, "a+") == 0)
 			{
-				cemu_assert_debug(false); // a+ is kind of special. Writing always happens at the end but the read cursor can dynamically move
-				// but Cafe OS might not support this. Needs investigation.
-				// this also used to be FILE_ALWAYS_CREATE in 1.26.2 and before
-				accessModifier = FSC_ACCESS_FLAG::READ_PERMISSION | FSC_ACCESS_FLAG::WRITE_PERMISSION | FSC_ACCESS_FLAG::FILE_ALLOW_CREATE;
+				accessModifier = FSC_ACCESS_FLAG::READ_PERMISSION | FSC_ACCESS_FLAG::WRITE_PERMISSION | FSC_ACCESS_FLAG::FILE_ALLOW_CREATE | FSC_ACCESS_FLAG::IS_APPEND;
+				isAppend = true;
+			}
+			else if (strcmp(accessModifierStr, "a") == 0)
+			{
+				accessModifier = FSC_ACCESS_FLAG::WRITE_PERMISSION | FSC_ACCESS_FLAG::FILE_ALLOW_CREATE | FSC_ACCESS_FLAG::IS_APPEND;
 				isAppend = true;
 			}
 			else

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -548,6 +548,7 @@ namespace iosu
 			}
 			else if (fscDirEntry.isFile)
 			{
+				statFlag |= FSFlag::IS_FILE;
 				dirEntryOut->stat.size = fscDirEntry.fileSize;
 			}
 			dirEntryOut->stat.flag = statFlag;

--- a/src/Cafe/IOSU/fsa/iosu_fsa.h
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.h
@@ -115,6 +115,7 @@ namespace iosu
 		};
 		static_assert(sizeof(FSARequest) == 0x520);
 
+#pragma pack(1)
 		struct FSAResponse
 		{
 			uint32be ukn0;
@@ -162,7 +163,8 @@ namespace iosu
 				} cmdQueryInfo;
 			};
 		};
-		// static_assert(sizeof(FSAResponse) == 0x293);
+		static_assert(sizeof(FSAResponse) == 0x293);
+#pragma pack()
 
 		struct FSAShimBuffer
 		{
@@ -189,7 +191,7 @@ namespace iosu
 			uint32 ukn0930;
 			uint32 ukn0934;
 		};
-		// static_assert(sizeof(FSAShimBuffer) == 0x938); // exact size of this is not known
+		static_assert(sizeof(FSAShimBuffer) == 0x938); // exact size of this is not known
 
 		void Initialize();
 		void Shutdown();

--- a/src/Cafe/IOSU/fsa/iosu_fsa.h
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.h
@@ -111,6 +111,20 @@ namespace iosu
 				{
 					uint32be fileHandle;
 				} cmdIsEof;
+				struct
+				{
+					uint32be dirHandle;
+				} cmdRewindDir;
+				struct
+				{
+					uint32be fileHandle;
+				} cmdFlushFile;
+				struct
+				{
+					uint8 path[FSA_CMD_PATH_MAX_LENGTH];
+					uint32be mode1;
+					uint32be mode2;
+				} cmdChangeMode;
 			};
 		};
 		static_assert(sizeof(FSARequest) == 0x520);
@@ -159,6 +173,10 @@ namespace iosu
 						{
 							FSStat_t stat;
 						} queryStat;
+						struct
+						{
+							FSADeviceInfo_t info;
+						} queryDeviceInfo;
 					};
 				} cmdQueryInfo;
 			};

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -586,12 +586,12 @@ namespace coreinit
 		}
 		switch (err)
 		{
-		case FSA_RESULT::SUCCESS:
+		case FSA_RESULT::OK:
 		{
 			return FS_RESULT::SUCCESS;
 		}
-		case FSA_RESULT::END_DIR:
-		case FSA_RESULT::END_FILE:
+		case FSA_RESULT::END_OF_DIRECTORY:
+		case FSA_RESULT::END_OF_FILE:
 		{
 			return FS_RESULT::END_ITERATION;
 		}
@@ -627,6 +627,9 @@ namespace coreinit
 		case FSA_RESULT::INVALID_PATH:
 		case FSA_RESULT::INVALID_BUFFER:
 		case FSA_RESULT::INVALID_ALIGNMENT:
+		case FSA_RESULT::NOT_INIT:
+		case FSA_RESULT::MAX_CLIENTS:
+		case FSA_RESULT::OUT_OF_RESOURCES:
 		case FSA_RESULT::FATAL_ERROR:
 		{
 			return FS_RESULT::FATAL_ERROR;
@@ -863,7 +866,7 @@ namespace coreinit
 
 		fsaShimBuffer->response.cmdOpenFile.fileHandleOutput = 0xFFFFFFFF;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSOpenFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, char* mode, FSFileHandleDepr_t* outFileHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -901,7 +904,7 @@ namespace coreinit
 		fsCmdBlockBody->returnValues.cmdOpenFile.handlePtr = &outFileHandle->fileHandle;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_OpenFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, path, mode, createMode, openFlag, preallocSize);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -926,7 +929,8 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::CLOSEFILE;
 		fsaShimBuffer->request.cmdCloseFile.fileHandle = fileHandle;
-		return FSA_RESULT::SUCCESS;
+
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSCloseFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -934,7 +938,7 @@ namespace coreinit
 		_FSCmdIntro();
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_CloseFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -980,7 +984,7 @@ namespace coreinit
 		fsaShimBuffer->request.cmdReadFile.fileHandle = fileHandle;
 		fsaShimBuffer->request.cmdReadFile.flag = flag;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	SysAllocator<uint8, 128, 64> _tempFSSpace;
@@ -1009,7 +1013,7 @@ namespace coreinit
 			flag &= ~FSA_CMD_FLAG_SET_POS;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_ReadFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, dest, size, count, filePos, fileHandle, flag);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1076,7 +1080,7 @@ namespace coreinit
 		fsaShimBuffer->request.cmdWriteFile.fileHandle = fileHandle;
 		fsaShimBuffer->request.cmdWriteFile.flag = flag;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 __FSWriteFileWithPosAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, void* dest, uint32 size, uint32 count, bool useFilePos, uint32 filePos, uint32 fileHandle, uint32 flag, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1103,7 +1107,7 @@ namespace coreinit
 			flag &= ~FSA_CMD_FLAG_SET_POS;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_WriteFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, dest, size, count, filePos, fileHandle, flag);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1146,14 +1150,14 @@ namespace coreinit
 		fsaShimBuffer->request.cmdSetPosFile.fileHandle = fileHandle;
 		fsaShimBuffer->request.cmdSetPosFile.filePos = filePos;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::SETPOS;
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSSetPosFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 filePos, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
 		FSA_RESULT prepareResult = __FSPrepareCmd_SetPosFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle, filePos);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
 		return (FSStatus)FS_RESULT::SUCCESS;
@@ -1176,7 +1180,7 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->request.cmdGetPosFile.fileHandle = fileHandle;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::GETPOS;
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSGetPosFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32be* returnedFilePos, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1185,7 +1189,7 @@ namespace coreinit
 		_FSCmdIntro();
 		fsCmdBlockBody->returnValues.cmdGetPosFile.filePosPtr = returnedFilePos;
 		FSA_RESULT prepareResult = __FSPrepareCmd_GetPosFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
 		return (FSStatus)FS_RESULT::SUCCESS;
@@ -1224,7 +1228,7 @@ namespace coreinit
 
 		fsaShimBuffer->response.cmdOpenDir.dirHandleOutput = -1;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSOpenDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, FSDirHandlePtr dirHandleOut, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1233,7 +1237,7 @@ namespace coreinit
 		cemu_assert(dirHandleOut && path);
 		fsCmdBlockBody->returnValues.cmdOpenDir.handlePtr = dirHandleOut.GetMPTR();
 		FSA_RESULT prepareResult = __FSPrepareCmd_OpenDir(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, path);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
 		return (FSStatus)FS_RESULT::SUCCESS;
@@ -1255,14 +1259,14 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::READDIR;
 		fsaShimBuffer->request.cmdReadDir.dirHandle = dirHandle;
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSReadDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, FSDirEntry_t* dirEntryOut, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
 		FSA_RESULT prepareResult = __FSPrepareCmd_ReadDir(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, dirHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 		fsCmdBlockBody->returnValues.cmdReadDir.dirEntryPtr = dirEntryOut;
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1285,14 +1289,14 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::CLOSEDIR;
 		fsaShimBuffer->request.cmdCloseDir.dirHandle = dirHandle;
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSCloseDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
 		FSA_RESULT prepareResult = __FSPrepareCmd_CloseDir(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, dirHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1320,14 +1324,14 @@ namespace coreinit
 		fsaShimBuffer->request.cmdAppendFile.size = count;
 		fsaShimBuffer->request.cmdAppendFile.uknParam = uknParam;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSAppendFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 size, uint32 count, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
 		FSA_RESULT prepareResult = __FSPrepareCmd_AppendFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle, size, count, 0);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1352,14 +1356,14 @@ namespace coreinit
 
 		fsaShimBuffer->request.cmdTruncateFile.fileHandle = fileHandle;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSTruncateFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSFileHandle2 fileHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
 		FSA_RESULT prepareResult = __FSPrepareCmd_TruncateFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1410,7 +1414,7 @@ namespace coreinit
 		}
 		fsaShimBuffer->request.cmdRename.dstPath[stringLen] = '\0';
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSRenameAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* srcPath, char* dstPath, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1423,7 +1427,7 @@ namespace coreinit
 			return -0x400;
 		}
 		FSA_RESULT prepareResult = __FSPrepareCmd_Rename(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, srcPath, dstPath);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1461,7 +1465,7 @@ namespace coreinit
 		}
 		fsaShimBuffer->request.cmdRemove.path[pathLen] = '\0';
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSRemoveAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint8* filePath, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1474,7 +1478,7 @@ namespace coreinit
 			return -0x400;
 		}
 		FSA_RESULT prepareResult = __FSPrepareCmd_Remove(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, filePath);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1513,7 +1517,7 @@ namespace coreinit
 		fsaShimBuffer->request.cmdMakeDir.path[pathLen] = '\0';
 		fsaShimBuffer->request.cmdMakeDir.uknParam = uknVal660;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSMakeDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, const uint8* dirPath, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1526,7 +1530,7 @@ namespace coreinit
 			return -0x400;
 		}
 		FSA_RESULT prepareResult = __FSPrepareCmd_MakeDir(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, dirPath, 0x660);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1563,7 +1567,7 @@ namespace coreinit
 
 		fsaShimBuffer->request.cmdChangeDir.path[pathLen] = '\0';
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSChangeDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1575,7 +1579,7 @@ namespace coreinit
 			return -0x400;
 		}
 		FSA_RESULT prepareResult = __FSPrepareCmd_ChangeDir(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, (uint8*)path);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1599,7 +1603,7 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::GETCWD;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSGetCwdAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* dirPathOut, sint32 dirPathMaxLen, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1610,7 +1614,7 @@ namespace coreinit
 		fsCmdBlockBody->returnValues.cmdGetCwd.transferSize = dirPathMaxLen;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_GetCwd(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1647,7 +1651,7 @@ namespace coreinit
 			fsaShimBuffer->request.cmdFlushQuota.path[i] = path[i];
 		fsaShimBuffer->request.cmdFlushQuota.path[pathLen] = '\0';
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSFlushQuotaAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1655,7 +1659,7 @@ namespace coreinit
 		_FSCmdIntro();
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_FlushQuota(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, path);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1697,7 +1701,7 @@ namespace coreinit
 		fsaShimBuffer->request.cmdQueryInfo.query[stringLen] = '\0';
 		fsaShimBuffer->request.cmdQueryInfo.queryType = queryType;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 __FSQueryInfoAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint8* queryString, uint32 queryType, void* queryResult, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1707,7 +1711,7 @@ namespace coreinit
 		fsCmdBlockBody->returnValues.cmdQueryInfo.queryResultPtr = queryResult;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_QueryInfo(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, queryString, queryType);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1738,7 +1742,7 @@ namespace coreinit
 		fsaShimBuffer->ipcReqType = 0;
 		fsaShimBuffer->request.cmdGetStatFile.fileHandle = fileHandle;
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::GETSTATFILE;
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSGetStatFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSFileHandle2 fileHandle, FSStat_t* statOut, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1748,7 +1752,7 @@ namespace coreinit
 		fsCmdBlockBody->returnValues.cmdStatFile.resultPtr = statOut;
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_GetStatFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle, statOut);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));
@@ -1789,7 +1793,7 @@ namespace coreinit
 
 		fsaShimBuffer->request.cmdIsEof.fileHandle = fileHandle;
 
-		return FSA_RESULT::SUCCESS;
+		return FSA_RESULT::OK;
 	}
 
 	sint32 FSIsEofAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
@@ -1798,7 +1802,7 @@ namespace coreinit
 		_FSCmdIntro();
 
 		FSA_RESULT prepareResult = __FSPrepareCmd_IsEof(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle);
-		if (prepareResult != FSA_RESULT::SUCCESS)
+		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
 		__FSQueueCmd(&fsClientBody->fsCmdQueue, fsCmdBlockBody, RPLLoader_MakePPCCallable(export___FSQueueDefaultFinishFunc));

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -2455,27 +2455,27 @@ namespace coreinit
 		return FSAGetInfoByQuery(client, path, FSA_QUERY_TYPE_FREESPACE, outSize);
 	}
 
-	auto s_fsaStr_OK = SysAllocatorString("FSA_STATUS_OK");
-	auto s_fsaStr_NOT_INIT = SysAllocatorString("FSA_STATUS_NOT_INIT");
-	auto s_fsaStr_END_OF_DIRECTORY = SysAllocatorString("FSA_STATUS_END_OF_DIRECTORY");
-	auto s_fsaStr_END_OF_FILE = SysAllocatorString("FSA_STATUS_END_OF_FILE");
-	auto s_fsaStr_MAX_CLIENTS = SysAllocatorString("FSA_STATUS_MAX_CLIENTS");
-	auto s_fsaStr_MAX_FILES = SysAllocatorString("FSA_STATUS_MAX_FILES");
-	auto s_fsaStr_MAX_DIRS = SysAllocatorString("FSA_STATUS_MAX_DIRS");
-	auto s_fsaStr_ALREADY_EXISTS = SysAllocatorString("FSA_STATUS_ALREADY_EXISTS");
-	auto s_fsaStr_NOT_FOUND = SysAllocatorString("FSA_STATUS_NOT_FOUND");
-	auto s_fsaStr_PERMISSION_ERROR = SysAllocatorString("FSA_STATUS_PERMISSION_ERROR");
-	auto s_fsaStr_INVALID_PARAM = SysAllocatorString("FSA_STATUS_INVALID_PARAM");
-	auto s_fsaStr_INVALID_PATH = SysAllocatorString("FSA_STATUS_INVALID_PATH");
-	auto s_fsaStr_INVALID_BUFFER = SysAllocatorString("FSA_STATUS_INVALID_BUFFER");
-	auto s_fsaStr_INVALID_ALIGNMENT = SysAllocatorString("FSA_STATUS_INVALID_ALIGNMENT");
-	auto s_fsaStr_INVALID_CLIENT_HANDLE = SysAllocatorString("FSA_STATUS_INVALID_CLIENT_HANDLE");
-	auto s_fsaStr_INVALID_FILE_HANDLE = SysAllocatorString("FSA_STATUS_INVALID_FILE_HANDLE");
-	auto s_fsaStr_INVALID_DIR_HANDLE = SysAllocatorString("FSA_STATUS_INVALID_DIR_HANDLE");
-	auto s_fsaStr_NOT_FILE = SysAllocatorString("FSA_STATUS_NOT_FILE");
-	auto s_fsaStr_NOT_DIR = SysAllocatorString("FSA_STATUS_NOT_DIR");
-	auto s_fsaStr_OUT_OF_RESOURCES = SysAllocatorString("FSA_STATUS_OUT_OF_RESOURCES");
-	auto s_fsaStr_UNKNOWN = SysAllocatorString("FSA_STATUS_???");
+	SysAllocator s_fsaStr_OK("FSA_STATUS_OK");
+	SysAllocator s_fsaStr_NOT_INIT("FSA_STATUS_NOT_INIT");
+	SysAllocator s_fsaStr_END_OF_DIRECTORY("FSA_STATUS_END_OF_DIRECTORY");
+	SysAllocator s_fsaStr_END_OF_FILE("FSA_STATUS_END_OF_FILE");
+	SysAllocator s_fsaStr_MAX_CLIENTS("FSA_STATUS_MAX_CLIENTS");
+	SysAllocator s_fsaStr_MAX_FILES("FSA_STATUS_MAX_FILES");
+	SysAllocator s_fsaStr_MAX_DIRS("FSA_STATUS_MAX_DIRS");
+	SysAllocator s_fsaStr_ALREADY_EXISTS("FSA_STATUS_ALREADY_EXISTS");
+	SysAllocator s_fsaStr_NOT_FOUND("FSA_STATUS_NOT_FOUND");
+	SysAllocator s_fsaStr_PERMISSION_ERROR("FSA_STATUS_PERMISSION_ERROR");
+	SysAllocator s_fsaStr_INVALID_PARAM("FSA_STATUS_INVALID_PARAM");
+	SysAllocator s_fsaStr_INVALID_PATH("FSA_STATUS_INVALID_PATH");
+	SysAllocator s_fsaStr_INVALID_BUFFER("FSA_STATUS_INVALID_BUFFER");
+	SysAllocator s_fsaStr_INVALID_ALIGNMENT("FSA_STATUS_INVALID_ALIGNMENT");
+	SysAllocator s_fsaStr_INVALID_CLIENT_HANDLE("FSA_STATUS_INVALID_CLIENT_HANDLE");
+	SysAllocator s_fsaStr_INVALID_FILE_HANDLE("FSA_STATUS_INVALID_FILE_HANDLE");
+	SysAllocator s_fsaStr_INVALID_DIR_HANDLE("FSA_STATUS_INVALID_DIR_HANDLE");
+	SysAllocator s_fsaStr_NOT_FILE("FSA_STATUS_NOT_FILE");
+	SysAllocator s_fsaStr_NOT_DIR("FSA_STATUS_NOT_DIR");
+	SysAllocator s_fsaStr_OUT_OF_RESOURCES("FSA_STATUS_OUT_OF_RESOURCES");
+	SysAllocator s_fsaStr_UNKNOWN("FSA_STATUS_???");
 
 	const char* FSAGetStatusStr(FSA_RESULT status)
 	{

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.h
@@ -12,6 +12,8 @@ typedef struct
 
 typedef MEMPTR<betype<FSDirHandle2>> FSDirHandlePtr;
 
+typedef uint32 FSAClientHandle;
+
 typedef struct
 {
 	MEMPTR<void> userCallback;

--- a/src/Cafe/OS/libs/coreinit/coreinit_IPCBuf.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_IPCBuf.cpp
@@ -1,40 +1,9 @@
 #include "Cafe/OS/common/OSCommon.h"
 #include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
+#include "coreinit_IPCBuf.h"
 
 namespace coreinit
 {
-
-	struct FIFOEntry_t
-	{
-		MEMPTR<uint8> p;
-	};
-
-	struct IPCFifo_t
-	{
-		uint32be writeIndex;
-		uint32be readIndex;
-		uint32be availableEntries; // number of available entries
-		uint32be entryCount;
-		MEMPTR<FIFOEntry_t> entryArray;
-	};
-
-	struct IPCBufPool_t
-	{
-		/* +0x00 */ uint32be		magic;
-		/* +0x04 */	MEMPTR<void>	fullBufferPtr;
-		/* +0x08 */ uint32be		fullBufferSize;
-		/* +0x0C */ uint32be		uknFromParamR7; // boolean?
-		/* +0x10 */ uint32be		ukn10; // set to zero on init
-		/* +0x14 */ uint32be		entrySize1;
-		/* +0x18 */ uint32be		entrySize2; // set to same value as entrySize1
-		/* +0x1C */ uint32be		entryCount; // actual number of used entries
-		/* +0x20 */	MEMPTR<uint8>	entryStartPtr;
-		/* +0x24 */ uint32be		entryCountMul4;
-		/* +0x28 */ IPCFifo_t		fifo;
-		/* +0x3C */ coreinit::OSMutex mutex;
-		// full size is 0x68
-	};
-
 	void FIFOInit(IPCFifo_t* fifo, uint32 entryCount, void* entryArray)
 	{
 		fifo->entryCount = entryCount;
@@ -89,8 +58,6 @@ namespace coreinit
 		uint64 v = ((uint64)addr) & ~(uint64)(alignment - 1);
 		return (uint8*)v;
 	}
-
-	static_assert(sizeof(IPCBufPool_t) == 0x68);
 
 	IPCBufPool_t* IPCBufPoolCreate(uint8* bufferArea, uint32 bufferSize, uint32 entrySize, uint32be* entryCountOutput, uint32 uknR7)
 	{

--- a/src/Cafe/OS/libs/coreinit/coreinit_IPCBuf.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_IPCBuf.h
@@ -2,5 +2,43 @@
 
 namespace coreinit
 {
+	struct FIFOEntry_t
+	{
+		MEMPTR<uint8> p;
+	};
+
+	struct IPCFifo_t
+	{
+		uint32be writeIndex;
+		uint32be readIndex;
+		uint32be availableEntries; // number of available entries
+		uint32be entryCount;
+		MEMPTR<FIFOEntry_t> entryArray;
+	};
+
+	struct IPCBufPool_t
+	{
+		/* +0x00 */ uint32be magic;
+		/* +0x04 */ MEMPTR<void> fullBufferPtr;
+		/* +0x08 */ uint32be fullBufferSize;
+		/* +0x0C */ uint32be uknFromParamR7; // boolean?
+		/* +0x10 */ uint32be ukn10;			 // set to zero on init
+		/* +0x14 */ uint32be entrySize1;
+		/* +0x18 */ uint32be entrySize2;	 // set to same value as entrySize1
+		/* +0x1C */ uint32be entryCount;	 // actual number of used entries
+		/* +0x20 */ MEMPTR<uint8> entryStartPtr;
+		/* +0x24 */ uint32be entryCountMul4;
+		/* +0x28 */ IPCFifo_t fifo;
+		/* +0x3C */ coreinit::OSMutex mutex;
+		/* +0x68 */ uint32 ukn68;
+		// full size is 0x6C
+	};
+
+	static_assert(sizeof(IPCBufPool_t) == 0x6C);
+
+	uint8* IPCBufPoolAllocate(IPCBufPool_t* ipcBufPool, uint32 size);
+	IPCBufPool_t* IPCBufPoolCreate(uint8* bufferArea, uint32 bufferSize, uint32 entrySize, uint32be* entryCountOutput, uint32 uknR7);
+	sint32 IPCBufPoolFree(IPCBufPool_t* ipcBufPool, uint8* entry);
+
 	void InitializeIPCBuf();
-}
+} // namespace coreinit

--- a/src/Common/SysAllocator.h
+++ b/src/Common/SysAllocator.h
@@ -49,6 +49,13 @@ public:
 			m_tempData.insert(m_tempData.end(), count - l.size(), T());
 	}
 
+	template <size_t N>
+	SysAllocator(const char(&str)[N])
+	{
+		m_tempData.reserve(count);
+		m_tempData.insert(m_tempData.begin(), str, str + N);
+	}
+
 	constexpr uint32 GetCount() const
 	{
 		return count;
@@ -135,6 +142,9 @@ private:
 	std::vector<T> m_tempData;
 };
 
+template <size_t N>
+SysAllocator(const char(&str)[N]) -> SysAllocator<char, N>;
+
 template<typename T>
 class SysAllocator<T, 1> : public SysAllocatorBase
 {
@@ -197,9 +207,3 @@ private:
 	MEMPTR<T> m_sysMem;
 	T m_tempData;
 };
-
-template <size_t N>
-SysAllocator<char, N> SysAllocatorString(const char(&str)[N])
-{
-	return std::initializer_list<char> (str, str + N - 1 );
-}

--- a/src/Common/SysAllocator.h
+++ b/src/Common/SysAllocator.h
@@ -197,3 +197,9 @@ private:
 	MEMPTR<T> m_sysMem;
 	T m_tempData;
 };
+
+template <size_t N>
+SysAllocator<char, N> SysAllocatorString(const char(&str)[N])
+{
+	return std::initializer_list<char> (str, str + N - 1 );
+}


### PR DESCRIPTION
This pull requests implements all FSA functions which are used by the FSA devoptab of [wut 1.3.0](https://github.com/devkitPro/wut) or higher.

Changes:
- [FS: add support for "a" and "a+" filemodes](https://github.com/cemu-project/Cemu/commit/4749314c91cea75fb859ccc3bb748e6987d825b2)
- [FS: Update "r+" filemode to not create non-existing files](https://github.com/cemu-project/Cemu/commit/2db76487a6614d84afdbd0d21f56a249b392c868)
- [FS: Implement support for various FSA* functions](https://github.com/cemu-project/Cemu/commit/8ccc1c04a33705a3bafa4759d9a110af58733634)
- [FS: Set FSFlag::IS_FILE flag for files to match console behaviour](https://github.com/cemu-project/Cemu/pull/844/commits/6d29c6f62a42c84a026b8f155ba1f02f2fa19712)
- [FS: Implement FSRewindDir(Async) and FSFlushFile(Async)](https://github.com/cemu-project/Cemu/pull/844/commits/7daf7bff17bc532947a0670d09e831c4e56229b2)