### PR TITLE
FS: Fix FSGetMountSource and FSAppendFile implementation (Fixes SD access in SSBU)

### DIFF
--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -611,14 +611,13 @@ namespace iosu
 
 		FSA_RESULT FSAProcessCmd_appendFile(FSAClient* client, FSAShimBuffer* shimBuffer)
 		{
-			uint32 fileHandle = shimBuffer->request.cmdAppendFile.fileHandle;
-			FSCVirtualFile* fscFile = sFileHandleTable.GetByHandle(fileHandle);
+			FSCVirtualFile* fscFile = sFileHandleTable.GetByHandle(shimBuffer->request.cmdAppendFile.fileHandle);
 			if (!fscFile)
 				return FSA_RESULT::INVALID_FILE_HANDLE;
 #ifdef CEMU_DEBUG_ASSERT
 			cemuLog_log(LogType::Force, "FSAProcessCmd_appendFile(): size 0x{:08x} count 0x{:08x} (todo)\n", shimBuffer->request.cmdAppendFile.size, shimBuffer->request.cmdAppendFile.count);
 #endif
-			return (FSA_RESULT)(shimBuffer->request.cmdAppendFile.size * shimBuffer->request.cmdAppendFile.count);
+			return (FSA_RESULT)(shimBuffer->request.cmdAppendFile.count.value());
 		}
 
 		FSA_RESULT FSAProcessCmd_truncateFile(FSAClient* client, FSAShimBuffer* shimBuffer)

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -1406,7 +1406,7 @@ namespace coreinit
 		return __FSProcessAsyncResult(fsClient, fsCmdBlock, fsAsyncRet, errorMask);
 	}
 
-	FSA_RESULT __FSPrepareCmd_AppendFile(iosu::fsa::FSAShimBuffer* fsaShimBuffer, IOSDevHandle fsaHandle, uint32 fileHandle, uint32 size, uint32 count, uint32 uknParam)
+	FSA_RESULT __FSPrepareCmd_AppendFile(iosu::fsa::FSAShimBuffer* fsaShimBuffer, IOSDevHandle fsaHandle, uint32 size, uint32 count, uint32 fileHandle, uint32 uknParam)
 	{
 		if (fsaShimBuffer == nullptr)
 			return FSA_RESULT::INVALID_BUFFER;
@@ -1415,17 +1415,17 @@ namespace coreinit
 		fsaShimBuffer->operationType = (uint32)FSA_CMD_OPERATION_TYPE::APPENDFILE;
 
 		fsaShimBuffer->request.cmdAppendFile.fileHandle = fileHandle;
-		fsaShimBuffer->request.cmdAppendFile.count = size;
-		fsaShimBuffer->request.cmdAppendFile.size = count;
+		fsaShimBuffer->request.cmdAppendFile.count = count;
+		fsaShimBuffer->request.cmdAppendFile.size = size;
 		fsaShimBuffer->request.cmdAppendFile.uknParam = uknParam;
 
 		return FSA_RESULT::OK;
 	}
 
-	sint32 FSAppendFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 size, uint32 count, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
+	sint32 FSAppendFileAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 size, uint32 count, uint32 fileHandle, uint32 errorMask, FSAsyncParamsNew_t* fsAsyncParams)
 	{
 		_FSCmdIntro();
-		FSA_RESULT prepareResult = __FSPrepareCmd_AppendFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, fileHandle, size, count, 0);
+		FSA_RESULT prepareResult = __FSPrepareCmd_AppendFile(&fsCmdBlockBody->fsaShimBuffer, fsClientBody->iosuFSAHandle, size, count, fileHandle, 0);
 		if (prepareResult != FSA_RESULT::OK)
 			return (FSStatus)_FSAStatusToFSStatus(prepareResult);
 
@@ -1433,11 +1433,11 @@ namespace coreinit
 		return (FSStatus)FS_RESULT::SUCCESS;
 	}
 
-	sint32 FSAppendFile(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 fileHandle, uint32 size, uint32 count, uint32 errorMask)
+	sint32 FSAppendFile(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint32 size, uint32 count, uint32 fileHandle,  uint32 errorMask)
 	{
 		StackAllocator<FSAsyncParamsNew_t> asyncParams;
 		__FSAsyncToSyncInit(fsClient, fsCmdBlock, asyncParams);
-		sint32 fsAsyncRet = FSAppendFileAsync(fsClient, fsCmdBlock, fileHandle, size, count, errorMask, asyncParams.GetPointer());
+		sint32 fsAsyncRet = FSAppendFileAsync(fsClient, fsCmdBlock, size, count, fileHandle, errorMask, asyncParams.GetPointer());
 		return __FSProcessAsyncResult(fsClient, fsCmdBlock, fsAsyncRet, errorMask);
 	}
 


### PR DESCRIPTION
This PR fixes SD Access in Super Smash Bros. To fix this, two things need to be fixed:

- The FSGetMountSource implementation was simplified to return more accurate values
- Fix FSAppendFile parameters, return values and shim preparation (yes, this was totally broken before)

This PR still doesn't implement `FSAppendFile` properly, but afaik this only "reserves" space on the filesystem without actually affecting/touching the files.