### PR TITLE
update KPADGetUnifiedWpadStatus to print ppc pointers

### DIFF
--- a/src/Cafe/OS/libs/padscore/padscore.cpp
+++ b/src/Cafe/OS/libs/padscore/padscore.cpp
@@ -287,7 +287,7 @@ void padscoreExport_KPADGetUnifiedWpadStatus(PPCInterpreter_t* hCPU)
 	ppcDefineParamPtr(status, KPADUnifiedWpadStatus_t, 1);
 	ppcDefineParamU32(count, 2);
 
-	cemuLog_log(LogType::InputAPI, "KPADGetUnifiedWpadStatus({}, 0x{:x}, 0x{:x})", channel, fmt::ptr(status), count);
+	cemuLog_log(LogType::InputAPI, "KPADGetUnifiedWpadStatus({}, 0x{:08x}, 0x{:x})", channel, MEMPTR<void>(status).GetMPTR(), count);
 
 	if (channel < InputManager::kMaxWPADControllers)
 	{


### PR DESCRIPTION
..., and as a side effect, fixes the crash occuring due to a casting mismatch that would cause an exception within fmt when logging Input.

Closes #874 