### PR TITLE
Fix Hermite bicubic mistake

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -111,7 +111,7 @@ vec3 BicubicHermiteTexture(vec2 uv, vec4 texelSize)
 	vec2 frac = fract(pixel);	
     pixel = floor(pixel) / texelSize.zw - vec2(texelSize.xy/2.0);
 	
-	vec4 doubleSize = texelSize*texelSize;
+	vec4 doubleSize = texelSize*2.0;
 
 	vec3 C00 = texture(textureSrc, pixel + vec2(-texelSize.x ,-texelSize.y)).rgb;
     vec3 C10 = texture(textureSrc, pixel + vec2( 0.0        ,-texelSize.y)).rgb;


### PR DESCRIPTION
It seems like there's a mistake in the Hermite bicubic filtering implementation. My change is based on the reference sources, and it also seems to make more sense, I don't see how squaring the inverse texture size would make sense. I don't think this change was on purpose, as the variable was called `doubleSize`, not `squaredSize`.

Sources:
https://www.shadertoy.com/view/MllSzX
https://www.shadertoy.com/view/XdGXWt