### PR TITLE
'--title-id' parameter and desktop entry creation

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -12,7 +12,6 @@ on:
       - "*.md"
     branches:
       - main
-      - launching
 
 jobs:
   build:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -12,6 +12,7 @@ on:
       - "*.md"
     branches:
       - main
+      - launching
 
 jobs:
   build:

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -100,6 +100,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	column_width.game_time = loadColumnSize("game_time_width", DefaultColumnSize::game_time);
 	column_width.game_started = loadColumnSize("game_started_width", DefaultColumnSize::game_started);
 	column_width.region = loadColumnSize("region_width", DefaultColumnSize::region);
+    column_width.title_id = loadColumnSize("title_id", DefaultColumnSize::title_id);
 
 	recent_launch_files.clear();
 	auto launch_parser = parser.get("RecentLaunchFiles");
@@ -398,6 +399,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	gamelist.set("game_time_width", column_width.game_time);
 	gamelist.set("game_started_width", column_width.game_started);
 	gamelist.set("region_width", column_width.region);
+    gamelist.set("title_id", column_width.title_id);
 
 	auto launch_files_parser = config.set("RecentLaunchFiles");
 	for (const auto& entry : recent_launch_files)

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -340,6 +340,7 @@ namespace DefaultColumnSize {
 		game_time = 140u,
 		game_started = 160u,
 		region = 80u,
+        title_id = 160u
 	};
 };
 
@@ -427,6 +428,7 @@ struct CemuConfig
 		uint32 game_time = DefaultColumnSize::game_time;
 		uint32 game_started = DefaultColumnSize::game_started;
 		uint32 region = DefaultColumnSize::region;
+        uint32 title_id = DefaultColumnSize::title_id;
 	} column_width{};
 
 	// graphics

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -428,7 +428,7 @@ struct CemuConfig
 		uint32 game_time = DefaultColumnSize::game_time;
 		uint32 game_started = DefaultColumnSize::game_started;
 		uint32 region = DefaultColumnSize::region;
-        uint32 title_id = DefaultColumnSize::title_id;
+        uint32 title_id = 0;
 	} column_width{};
 
 	// graphics

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -60,6 +60,7 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 		("version,v", "Displays the version of Cemu")
 
 		("game,g", po::wvalue<std::wstring>(), "Path of game to launch")
+        ("title-id,t", po::value<std::string>(), "Title ID of the title to be launched (overridden by --game)")
 		("mlc,m", po::wvalue<std::wstring>(), "Custom mlc folder location")
 
 		("fullscreen,f", po::value<bool>()->implicit_value(true), "Launch games in fullscreen mode")
@@ -133,6 +134,20 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 			
 			s_load_game_file = tmp;
 		}
+        if (vm.count("title-id"))
+        {
+            auto title_param = vm["title-id"].as<std::string>();
+            try {
+
+                if (title_param.starts_with('=')){
+                    title_param.erase(title_param.begin());
+                }
+                s_load_title_id = std::stoul(title_param, nullptr, 16);
+            }
+            catch (std::invalid_argument const& e){
+                std::cerr << "Expected title_param ID as an unsigned 64-bit hexadecimal string\n";
+            }
+        }
 			
 		if (vm.count("mlc"))
 		{

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -142,9 +142,10 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
                 if (title_param.starts_with('=')){
                     title_param.erase(title_param.begin());
                 }
-                s_load_title_id = std::stoul(title_param, nullptr, 16);
+                s_load_title_id = std::stoull(title_param, nullptr, 16);
             }
-            catch (std::invalid_argument const& e){
+            catch (std::invalid_argument const& e)
+            {
                 std::cerr << "Expected title_param ID as an unsigned 64-bit hexadecimal string\n";
             }
         }

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -16,6 +16,7 @@ public:
 	static bool HandleCommandline(const std::vector<std::wstring>& args);
 
 	static std::optional<fs::path> GetLoadFile() { return s_load_game_file; }
+    static std::optional<uint64> GetLoadTitleID() {return s_load_title_id;}
 	static std::optional<fs::path> GetMLCPath() { return s_mlc_path; }
 
 	static std::optional<bool> RenderUpsideDownEnabled() { return s_render_upside_down; }
@@ -35,6 +36,7 @@ public:
 
 private:
 	inline static std::optional<fs::path> s_load_game_file{};
+    inline static std::optional<uint64> s_load_title_id{};
 	inline static std::optional<fs::path> s_mlc_path{};
 
 	inline static std::optional<bool> s_render_upside_down{};

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -259,6 +259,8 @@ int wxGameList::GetColumnDefaultWidth(int column)
 		return DefaultColumnSize::game_started;
 	case ColumnRegion:
 		return DefaultColumnSize::region;
+    case ColumnTitleID:
+        return DefaultColumnSize::title_id;
 	default:
 		return 80;
 	}
@@ -800,6 +802,9 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 			case ShowRegion:
 				config.column_width.region = menu->IsChecked(ShowRegion) ? DefaultColumnSize::region : 0;
 				break;
+            case ShowTitleId:
+                config.column_width.title_id = menu->IsChecked(ShowTitleId) ? DefaultColumnSize::title_id : 0;
+                break;
 			case ResetWidth:
 			{
 				switch (column)
@@ -824,6 +829,8 @@ void wxGameList::OnColumnRightClick(wxListEvent& event)
 				case ColumnRegion:
 					config.column_width.region = DefaultColumnSize::region;
 					break;
+                case ColumnTitleID:
+                    config.column_width.title_id = DefaultColumnSize::title_id;
 				default:
 					return;
 				}

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1226,20 +1226,20 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
 #if BOOST_OS_LINUX
     const wxString desktop_entry_name = fmt::format("{}.desktop", title_name);
     wxFileDialog entry_dialog(this, _("Choose desktop entry location"), "~/.local/share/applications", desktop_entry_name,
-                              "Desktop files (*.desktop)|*.desktop", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);
+                              "Desktop file (*.desktop)|*.desktop", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);
 #elif BOOST_OS_WINDOWS
     PWSTR user_shortcut_folder;
     SHGetKnownFolderPath(FOLDERID_Programs, 0, NULL, &user_shortcut_folder);
     const wxString shortcut_name = fmt::format("{}.lnk", title_name);
     wxFileDialog entry_dialog(this, _("Choose shortcut location"), _pathToUtf8(user_shortcut_folder), shortcut_name,
-                              "Desktop files (*.lnk)|*.lnk", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);
+                              "Shortcut (*.lnk)|*.lnk", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);
 #endif
     const auto result = entry_dialog.ShowModal();
     if (result == wxID_CANCEL)
         return;
     const auto output_path = entry_dialog.GetPath();
 
-
+#if BOOST_OS_LINUX
     std::optional<fs::path> icon_path;
     // Obtain and convert icon
     {
@@ -1264,7 +1264,6 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
             pngHandler.SaveFile(&image, png_file, false);
         }
     }
-#if BOOST_OS_LINUX
     const auto desktop_entry_string =
             fmt::format("[Desktop Entry]\n"
                         "Name={}\n"
@@ -1283,7 +1282,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
     std::ofstream output_stream(output_path);
     if (!output_stream.good())
     {
-        wxString errorMsg = fmt::format("Failed to save desktop entry to {}", output_path.utf8_string());
+        const wxString errorMsg = fmt::format("Failed to save desktop entry to {}", output_path.utf8_string());
         wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
         return;
     }

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -727,7 +727,8 @@ void wxGameList::CreateDesktopEntry(GameInfo2& gameInfo) {
     const auto title_name = gameInfo.GetTitleName();
     auto icon_path = game_path / "meta" / "iconTex.tga";
 
-    wxMessageDialog create_icon_dialog(this, "Creates an icon as PNG, so that the icon is viewable on more desktop environments", "Create a png icon" , wxYES_NO | wxCANCEL);
+    wxMessageDialog create_icon_dialog(this, "Creates an icon as PNG, so that the icon is viewable on more desktop environments. Otherwise, a direct path to the tga file icon in the game directory is used", "Create a png icon" , wxYES_NO | wxCANCEL);
+
     auto result = create_icon_dialog.ShowModal();
     if (result == wxID_CANCEL)
         return;
@@ -740,7 +741,7 @@ void wxGameList::CreateDesktopEntry(GameInfo2& gameInfo) {
         tgaHandler.LoadFile(&image, tga_file, false);
 
         fs::create_directories(out_icon_dir);
-        icon_path = out_icon_dir / (std::to_string(title_id) + ".png");
+        icon_path = out_icon_dir / fmt::format("{:016x}.png", gameInfo.GetBaseTitleId());
 
         wxFileOutputStream png_file(_pathToUtf8(icon_path));
         wxPNGHandler pngHandler;

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1233,7 +1233,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
     // Get '%APPDATA%\Microsoft\Windows\Start Menu\Programs' path
     PWSTR user_shortcut_folder;
     SHGetKnownFolderPath(FOLDERID_Programs, 0, NULL, &user_shortcut_folder);
-    const wxString desktop_entry_name = wxString::Format("%s.lnk", title_name);
+    const wxString shortcut_name = wxString::Format("%s.lnk", title_name);
     wxFileDialog entry_dialog(this, _("Choose shortcut location"), _pathToUtf8(user_shortcut_folder), shortcut_name,
                               "Shortcut (*.lnk)|*.lnk", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);
 #endif

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -40,6 +40,8 @@
 #include <objidl.h>
 #include <shlguid.h>
 #include <shlobj.h>
+
+#include <fmt/xchar.h>
 #endif
 
 // public events

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -54,7 +54,7 @@ public:
 	void DeleteCachedStrings();
 
 #if BOOST_OS_LINUX
-    void CreateDesktopEntry(GameInfo2& gameInfo);
+    void CreateShortcut(GameInfo2& gameInfo);
 #endif
 
 	long FindListItemByTitleId(uint64 title_id) const;

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -10,6 +10,7 @@
 #include <wx/listctrl.h>
 #include <wx/timer.h>
 #include <wx/panel.h>
+#include <Cafe/TitleList/GameInfo.h>
 #include "util/helpers/Semaphore.h"
 
 class wxTitleIdEvent : public wxCommandEvent
@@ -52,6 +53,10 @@ public:
 	void ReloadGameEntries(bool cached = false);
 	void DeleteCachedStrings();
 
+#if BOOST_OS_LINUX
+    void CreateDesktopEntry(GameInfo2& gameInfo);
+#endif
+
 	long FindListItemByTitleId(uint64 title_id) const;
 	void OnClose(wxCloseEvent& event);
 
@@ -75,8 +80,9 @@ private:
 		ColumnGameTime,
 		ColumnGameStarted,
 		ColumnRegion,
-		//ColumnFavorite,
-		ColumnCounts
+        ColumnTitleID,
+        //ColumnFavorite,
+		ColumnCounts,
 	};
 
 	int s_last_column = ColumnName;

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -53,7 +53,7 @@ public:
 	void ReloadGameEntries(bool cached = false);
 	void DeleteCachedStrings();
 
-#if BOOST_OS_LINUX
+#if BOOST_OS_LINUX || BOOST_OS_WINDOWS
     void CreateShortcut(GameInfo2& gameInfo);
 #endif
 


### PR DESCRIPTION
- `--title-id` parameter to allow launching a game by its title ID
- Desktop entries (Linux) / Shortcuts (Windows) can be created from the game list context menu
- Title ID column added to game list