### PR TITLE
Vulkan: Retry instance creation if validation layer is not present

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -350,7 +350,15 @@ VulkanRenderer::VulkanRenderer()
 	create_info.ppEnabledLayerNames = m_layerNames.data();
 	create_info.enabledLayerCount = m_layerNames.size();
 
-	if ((err = vkCreateInstance(&create_info, nullptr, &m_instance)) != VK_SUCCESS)
+	err = vkCreateInstance(&create_info, nullptr, &m_instance);
+
+	if (err == VK_ERROR_LAYER_NOT_PRESENT) {
+		cemuLog_log(LogType::Force, "Failed to enable vulkan validation (VK_LAYER_KHRONOS_validation)");
+		create_info.enabledLayerCount = 0;
+		err = vkCreateInstance(&create_info, nullptr, &m_instance);
+	}
+
+	if (err != VK_SUCCESS)
 		throw std::runtime_error(fmt::format("Unable to create a Vulkan instance: {}", err));
 
 	if (!InitializeInstanceVulkan(m_instance))


### PR DESCRIPTION
When running the flatpak if the vulkan validation layer is enabled Cemu crashes with an error box that says "Error when initializing Vulkan renderer: Unable to create a Vulkan instance: -6"

![an error box that says "Error when initializing Vulkan renderer: Unable to create a Vulkan instance: -6"
](https://github.com/cemu-project/Cemu/assets/334272/0bca5db2-4d5e-447c-969c-640a48098463)

For some reason this goes away when running with the `--devel` option.

This MR adds a second attempt at creating a instance disabling all vulkan layers.

This is what [Q2RTX](https://github.com/NVIDIA/Q2RTX/blob/4f5662a7bbe70becae36b2295d956f360826ca73/src/refresh/vkpt/main.c#L892) does.

I initially tried checking against the list returned by `vkEnumerateInstanceLayerProperties` but it reports that `VK_LAYER_KHRONOS_validation` is present.
