### PR TITLE
fmt: enable compatibility with fmt>=10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ find_package(ZLIB REQUIRED)
 find_package(zstd MODULE REQUIRED) # MODULE so that zstd::zstd is available
 find_package(OpenSSL COMPONENTS Crypto SSL REQUIRED)
 find_package(glm REQUIRED)
-find_package(fmt 9.1.0...<10 REQUIRED)
+find_package(fmt 9.1.0 REQUIRED)
 find_package(PNG REQUIRED)
 
 # glslang versions older than 11.11.0 define targets without a namespace

--- a/src/Cafe/HW/Latte/Core/LatteConst.h
+++ b/src/Cafe/HW/Latte/Core/LatteConst.h
@@ -103,6 +103,8 @@ using LatteIndexType = Latte::LATTE_VGT_DMA_INDEX_TYPE::E_INDEX_TYPE;
 
 namespace LatteConst
 {
+	using fmt::enums::format_as;
+
 	enum class ShaderType : uint32
 	{
 		Reserved = 0,

--- a/src/Cafe/HW/Latte/ISA/LatteInstructions.h
+++ b/src/Cafe/HW/Latte/ISA/LatteInstructions.h
@@ -117,6 +117,11 @@ protected:
 	uint32 word1;
 };
 
+inline auto format_as(LatteCFInstruction::OPCODE opcode)
+{
+	return fmt::underlying(opcode);
+}
+
 // default encoding, CF_DWORD0 + CF_DWORD1
 // used for opcodes: See list in MatchesOpcode()
 class LatteCFInstruction_DEFAULT : public LatteCFInstruction

--- a/src/Cafe/HW/Latte/ISA/LatteReg.h
+++ b/src/Cafe/HW/Latte/ISA/LatteReg.h
@@ -2,6 +2,8 @@
 
 namespace Latte
 {
+	using fmt::enums::format_as;
+
 	// common enums
 	enum class E_DIM : uint32 // shared between Latte backend and GX2 code
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/CocoaSurface.mm
@@ -53,7 +53,7 @@ VkSurfaceKHR CreateCocoaSurface(VkInstance instance, void* handle)
 	if ((err = vkCreateMetalSurfaceEXT(instance, &surface, nullptr, &result)) != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "Cannot create a Metal Vulkan surface: {}", (sint32)err);
-		throw std::runtime_error(fmt::format("Cannot create a Metal Vulkan surface: {}", err));
+		throw std::runtime_error(fmt::format("Cannot create a Metal Vulkan surface: {}", fmt::underlying(err)));
 	}
 
 	return result;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -240,7 +240,7 @@ void RendererShaderVk::CreateVkShaderModule(std::span<uint32> spirvBuffer)
 	if (result != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "Vulkan: Shader error");
-		throw std::runtime_error(fmt::format("Failed to create shader module: {}", result));
+		throw std::runtime_error(fmt::format("Failed to create shader module: {}", fmt::underlying(result)));
 	}
 
 	// set debug name

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.cpp
@@ -214,7 +214,7 @@ bool SwapchainInfoVk::AcquireImage(uint64 timeout)
 	{
 		swapchainImageIndex = -1;
 		if (result != VK_ERROR_OUT_OF_DATE_KHR)
-			throw std::runtime_error(fmt::format("Failed to acquire next image: {}", result));
+			throw std::runtime_error(fmt::format("Failed to acquire next image: {}", fmt::underlying(result)));
 		return false;
 	}
 	m_currentSemaphore = acquireSemaphore;
@@ -249,7 +249,7 @@ SwapchainInfoVk::QueueFamilyIndices SwapchainInfoVk::FindQueueFamilies(VkSurface
 		VkBool32 presentSupport = false;
 		const VkResult result = vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface, &presentSupport);
 		if (result != VK_SUCCESS)
-			throw std::runtime_error(fmt::format("Error while attempting to check if a surface supports presentation: {}", result));
+			throw std::runtime_error(fmt::format("Error while attempting to check if a surface supports presentation: {}", fmt::underlying(result)));
 
 		if (queueFamily.queueCount > 0 && presentSupport)
 			indices.presentFamily = i;
@@ -270,7 +270,7 @@ SwapchainInfoVk::SwapchainSupportDetails SwapchainInfoVk::QuerySwapchainSupport(
 	{
 		if (result != VK_ERROR_SURFACE_LOST_KHR)
 			cemuLog_log(LogType::Force, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed. Error {}", (sint32)result);
-		throw std::runtime_error(fmt::format("Unable to retrieve physical device surface capabilities: {}", result));
+		throw std::runtime_error(fmt::format("Unable to retrieve physical device surface capabilities: {}", fmt::underlying(result)));
 	}
 
 	uint32_t formatCount = 0;
@@ -278,7 +278,7 @@ SwapchainInfoVk::SwapchainSupportDetails SwapchainInfoVk::QuerySwapchainSupport(
 	if (result != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "vkGetPhysicalDeviceSurfaceFormatsKHR failed. Error {}", (sint32)result);
-		throw std::runtime_error(fmt::format("Unable to retrieve the number of formats for a surface on a physical device: {}", result));
+		throw std::runtime_error(fmt::format("Unable to retrieve the number of formats for a surface on a physical device: {}", fmt::underlying(result)));
 	}
 
 	if (formatCount != 0)
@@ -288,7 +288,7 @@ SwapchainInfoVk::SwapchainSupportDetails SwapchainInfoVk::QuerySwapchainSupport(
 		if (result != VK_SUCCESS)
 		{
 			cemuLog_log(LogType::Force, "vkGetPhysicalDeviceSurfaceFormatsKHR failed. Error {}", (sint32)result);
-			throw std::runtime_error(fmt::format("Unable to retrieve the formats for a surface on a physical device: {}", result));
+			throw std::runtime_error(fmt::format("Unable to retrieve the formats for a surface on a physical device: {}", fmt::underlying(result)));
 		}
 	}
 
@@ -297,7 +297,7 @@ SwapchainInfoVk::SwapchainSupportDetails SwapchainInfoVk::QuerySwapchainSupport(
 	if (result != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "vkGetPhysicalDeviceSurfacePresentModesKHR failed. Error {}", (sint32)result);
-		throw std::runtime_error(fmt::format("Unable to retrieve the count of present modes for a surface on a physical device: {}", result));
+		throw std::runtime_error(fmt::format("Unable to retrieve the count of present modes for a surface on a physical device: {}", fmt::underlying(result)));
 	}
 
 	if (presentModeCount != 0)
@@ -307,7 +307,7 @@ SwapchainInfoVk::SwapchainSupportDetails SwapchainInfoVk::QuerySwapchainSupport(
 		if (result != VK_SUCCESS)
 		{
 			cemuLog_log(LogType::Force, "vkGetPhysicalDeviceSurfacePresentModesKHR failed. Error {}", (sint32)result);
-			throw std::runtime_error(fmt::format("Unable to retrieve the present modes for a surface on a physical device: {}", result));
+			throw std::runtime_error(fmt::format("Unable to retrieve the present modes for a surface on a physical device: {}", fmt::underlying(result)));
 		}
 	}
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineCompiler.cpp
@@ -921,7 +921,7 @@ bool PipelineCompiler::InitFromCurrentGPUState(PipelineInfo* pipelineInfo, const
 	VkResult result = vkCreatePipelineLayout(vkRenderer->m_logicalDevice, &pipelineLayoutInfo, nullptr, &m_pipeline_layout);
 	if (result != VK_SUCCESS)
 	{
-		cemuLog_log(LogType::Force, "Failed to create pipeline layout: {}", result);
+		cemuLog_log(LogType::Force, "Failed to create pipeline layout: {}", fmt::underlying(result));
 		s_nvidiaWorkaround.unlock();
 		return false;
 	}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -141,7 +141,7 @@ std::vector<VulkanRenderer::DeviceInfo> VulkanRenderer::GetDevices()
 	{
 		VkResult err;
 		if ((err = vkCreateInstance(&create_info, nullptr, &instance)) != VK_SUCCESS)
-			throw std::runtime_error(fmt::format("Unable to create a Vulkan instance: {}", err));
+			throw std::runtime_error(fmt::format("Unable to create a Vulkan instance: {}", fmt::underlying(err)));
 
 		if (!InitializeInstanceVulkan(instance))
 			throw std::runtime_error("can't initialize instanced vulkan functions");
@@ -358,7 +358,7 @@ VulkanRenderer::VulkanRenderer()
 	}
 
 	if (err != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Unable to create a Vulkan instance: {}", err));
+		throw std::runtime_error(fmt::format("Unable to create a Vulkan instance: {}", fmt::underlying(err)));
 
 	if (!InitializeInstanceVulkan(m_instance))
 		throw std::runtime_error("Unable to load instanced Vulkan functions");
@@ -495,7 +495,7 @@ VulkanRenderer::VulkanRenderer()
 	if (result != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "Vulkan: Unable to create a logical device. Error {}", (sint32)result);
-		throw std::runtime_error(fmt::format("Unable to create a logical device: {}", result));
+		throw std::runtime_error(fmt::format("Unable to create a logical device: {}", fmt::underlying(result)));
 	}
 
 	InitializeDeviceVulkan(m_logicalDevice);
@@ -1112,12 +1112,12 @@ bool VulkanRenderer::CheckDeviceExtensionSupport(const VkPhysicalDevice device, 
 	uint32_t extensionCount;
 	VkResult result = vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr);
 	if (result != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Cannot retrieve count of properties for a physical device: {}", result));
+		throw std::runtime_error(fmt::format("Cannot retrieve count of properties for a physical device: {}", fmt::underlying(result)));
 
 	availableDeviceExtensions.resize(extensionCount);
 	result = vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, availableDeviceExtensions.data());
 	if (result != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Cannot retrieve properties for a physical device: {}", result));
+		throw std::runtime_error(fmt::format("Cannot retrieve properties for a physical device: {}", fmt::underlying(result)));
 
 	std::set<std::string> requiredExtensions(kRequiredDeviceExtensions.begin(), kRequiredDeviceExtensions.end());
 	for (const auto& extension : availableDeviceExtensions)
@@ -1179,11 +1179,11 @@ std::vector<const char*> VulkanRenderer::CheckInstanceExtensionSupport(FeatureCo
 	// get list of available instance extensions
 	uint32_t count;
 	if ((err = vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr)) != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Failed to retrieve the instance extension properties : {}", err));
+		throw std::runtime_error(fmt::format("Failed to retrieve the instance extension properties : {}", fmt::underlying(err)));
 
 	availableInstanceExtensions.resize(count);
 	if ((err = vkEnumerateInstanceExtensionProperties(nullptr, &count, availableInstanceExtensions.data())) != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Failed to retrieve the instance extension properties: {}", err));
+		throw std::runtime_error(fmt::format("Failed to retrieve the instance extension properties: {}", fmt::underlying(err)));
 
 	// build list of required extensions
 	std::vector<const char*> requiredInstanceExtensions;
@@ -1270,7 +1270,7 @@ VkSurfaceKHR VulkanRenderer::CreateWinSurface(VkInstance instance, HWND hwindow)
 	if ((err = vkCreateWin32SurfaceKHR(instance, &sci, nullptr, &result)) != VK_SUCCESS)
 	{
 		cemuLog_log(LogType::Force, "Cannot create a Win32 Vulkan surface: {}", (sint32)err);
-		throw std::runtime_error(fmt::format("Cannot create a Win32 Vulkan surface: {}", err));
+		throw std::runtime_error(fmt::format("Cannot create a Win32 Vulkan surface: {}", fmt::underlying(err)));
 	}
 
 	return result;
@@ -1291,7 +1291,7 @@ VkSurfaceKHR VulkanRenderer::CreateXlibSurface(VkInstance instance, Display* dpy
     if ((err = vkCreateXlibSurfaceKHR(instance, &sci, nullptr, &result)) != VK_SUCCESS)
     {
 		cemuLog_log(LogType::Force, "Cannot create a X11 Vulkan surface: {}", (sint32)err);
-        throw std::runtime_error(fmt::format("Cannot create a X11 Vulkan surface: {}", err));
+        throw std::runtime_error(fmt::format("Cannot create a X11 Vulkan surface: {}", fmt::underlying(err)));
     }
 
     return result;
@@ -1310,7 +1310,7 @@ VkSurfaceKHR VulkanRenderer::CreateXcbSurface(VkInstance instance, xcb_connectio
     if ((err = vkCreateXcbSurfaceKHR(instance, &sci, nullptr, &result)) != VK_SUCCESS)
     {
         cemuLog_log(LogType::Force, "Cannot create a XCB Vulkan surface: {}", (sint32)err);
-        throw std::runtime_error(fmt::format("Cannot create a XCB Vulkan surface: {}", err));
+        throw std::runtime_error(fmt::format("Cannot create a XCB Vulkan surface: {}", fmt::underlying(err)));
     }
 
     return result;
@@ -1329,7 +1329,7 @@ VkSurfaceKHR VulkanRenderer::CreateWaylandSurface(VkInstance instance, wl_displa
     if ((err = vkCreateWaylandSurfaceKHR(instance, &sci, nullptr, &result)) != VK_SUCCESS)
     {
         cemuLog_log(LogType::Force, "Cannot create a Wayland Vulkan surface: {}", (sint32)err);
-        throw std::runtime_error(fmt::format("Cannot create a Wayland Vulkan surface: {}", err));
+        throw std::runtime_error(fmt::format("Cannot create a Wayland Vulkan surface: {}", fmt::underlying(err)));
     }
 
     return result;
@@ -1363,7 +1363,7 @@ void VulkanRenderer::CreateCommandPool()
 
 	VkResult result = vkCreateCommandPool(m_logicalDevice, &poolInfo, nullptr, &m_commandPool);
 	if (result != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Failed to create command pool: {}", result));
+		throw std::runtime_error(fmt::format("Failed to create command pool: {}", fmt::underlying(result)));
 }
 
 void VulkanRenderer::CreateCommandBuffers()
@@ -1389,8 +1389,8 @@ void VulkanRenderer::CreateCommandBuffers()
 	const VkResult result = vkAllocateCommandBuffers(m_logicalDevice, &allocInfo, m_commandBuffers.data());
 	if (result != VK_SUCCESS)
 	{
-		cemuLog_log(LogType::Force, "Failed to allocate command buffers: {}", result);
-		throw std::runtime_error(fmt::format("Failed to allocate command buffers: {}", result));
+		cemuLog_log(LogType::Force, "Failed to allocate command buffers: {}", fmt::underlying(result));
+		throw std::runtime_error(fmt::format("Failed to allocate command buffers: {}", fmt::underlying(result)));
 	}
 
 	for (auto& semItr : m_commandBufferSemaphores)
@@ -1963,7 +1963,7 @@ void VulkanRenderer::SubmitCommandBuffer(VkSemaphore signalSemaphore, VkSemaphor
 
 	const VkResult result = vkQueueSubmit(m_graphicsQueue, 1, &submitInfo, m_cmd_buffer_fences[m_commandBufferIndex]);
 	if (result != VK_SUCCESS)
-		UnrecoverableError(fmt::format("failed to submit command buffer. Error {}", result).c_str());
+		UnrecoverableError(fmt::format("failed to submit command buffer. Error {}", fmt::underlying(result)).c_str());
 	m_numSubmittedCmdBuffers++;
 
 	// check if any previously submitted command buffers have finished execution
@@ -2101,7 +2101,7 @@ void VulkanRenderer::PipelineCacheSaveThread(size_t cache_size)
 			}
 			else
 			{
-				cemuLog_log(LogType::Force, "can't retrieve pipeline cache data: 0x{:x}", res);
+				cemuLog_log(LogType::Force, "can't retrieve pipeline cache data: 0x{:x}", fmt::underlying(res));
 			}
 		}
 		else
@@ -2140,7 +2140,7 @@ void VulkanRenderer::CreatePipelineCache()
 	createInfo.pInitialData = cacheData.data();
 	VkResult result = vkCreatePipelineCache(m_logicalDevice, &createInfo, nullptr, &m_pipeline_cache);
 	if (result != VK_SUCCESS)
-		UnrecoverableError(fmt::format("Failed to create pipeline cache: {}", result).c_str());
+		UnrecoverableError(fmt::format("Failed to create pipeline cache: {}", fmt::underlying(result)).c_str());
 
 	size_t cache_size = 0;
 	vkGetPipelineCacheData(m_logicalDevice, m_pipeline_cache, &cache_size, nullptr);
@@ -2565,7 +2565,7 @@ VkPipeline VulkanRenderer::backbufferBlit_createGraphicsPipeline(VkDescriptorSet
 
 	VkResult result = vkCreatePipelineLayout(m_logicalDevice, &pipelineLayoutInfo, nullptr, &m_pipelineLayout);
 	if (result != VK_SUCCESS)
-		throw std::runtime_error(fmt::format("Failed to create pipeline layout: {}", result));
+		throw std::runtime_error(fmt::format("Failed to create pipeline layout: {}", fmt::underlying(result)));
 
 	VkGraphicsPipelineCreateInfo pipelineInfo = {};
 	pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
@@ -2588,8 +2588,8 @@ VkPipeline VulkanRenderer::backbufferBlit_createGraphicsPipeline(VkDescriptorSet
 	result = vkCreateGraphicsPipelines(m_logicalDevice, m_pipeline_cache, 1, &pipelineInfo, nullptr, &pipeline);
 	if (result != VK_SUCCESS)
 	{
-		cemuLog_log(LogType::Force, "Failed to create graphics pipeline. Error {}", result);
-		throw std::runtime_error(fmt::format("Failed to create graphics pipeline: {}", result));
+		cemuLog_log(LogType::Force, "Failed to create graphics pipeline. Error {}", fmt::underlying(result));
+		throw std::runtime_error(fmt::format("Failed to create graphics pipeline: {}", fmt::underlying(result)));
 	}
 
 	s_pipeline_cache[hash] = pipeline;
@@ -2730,7 +2730,7 @@ void VulkanRenderer::SwapBuffer(bool mainWindow)
 	VkResult result = vkQueuePresentKHR(m_presentQueue, &presentInfo);
 	if (result < 0 && result != VK_ERROR_OUT_OF_DATE_KHR)
 	{
-		throw std::runtime_error(fmt::format("Failed to present image: {}", result));
+		throw std::runtime_error(fmt::format("Failed to present image: {}", fmt::underlying(result)));
 	}
 	if(result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR)
 		chainInfo.m_shouldRecreate = true;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanSurfaceCopy.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanSurfaceCopy.cpp
@@ -353,7 +353,7 @@ CopySurfacePipelineInfo* VulkanRenderer::copySurface_getOrCreateGraphicsPipeline
 	VkResult result = vkCreatePipelineLayout(m_logicalDevice, &pipelineLayoutInfo, nullptr, &vkObjPipeline->pipeline_layout);
 	if (result != VK_SUCCESS)
 	{
-		cemuLog_log(LogType::Force, "Failed to create pipeline layout: {}", result);
+		cemuLog_log(LogType::Force, "Failed to create pipeline layout: {}", fmt::underlying(result));
 		vkObjPipeline->pipeline = VK_NULL_HANDLE;
 		return copyPipeline;
 	}

--- a/src/Cafe/IOSU/fsa/fsa_types.h
+++ b/src/Cafe/IOSU/fsa/fsa_types.h
@@ -40,6 +40,11 @@ enum class FSA_RESULT : sint32 // aka FSError/FSAStatus
 	FATAL_ERROR = -0x30000 - 0x400,
 };
 
+inline auto format_as(FSA_RESULT result)
+{
+	return fmt::underlying(result);
+}
+
 enum class FSA_CMD_OPERATION_TYPE : uint32
 {
 	CHANGEDIR = 0x5,

--- a/src/Cafe/OS/libs/TCL/TCL.cpp
+++ b/src/Cafe/OS/libs/TCL/TCL.cpp
@@ -3,6 +3,7 @@
 
 namespace TCL
 {
+	using fmt::enums::format_as;
 
 	enum class TCL_SUBMISSION_FLAG : uint32
 	{

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -42,6 +42,8 @@ bool strcpy_whole(char* dst, size_t dstLength, const char* src)
 
 namespace coreinit
 {
+	using fmt::enums::format_as;
+
 	std::mutex sFSClientLock;
 	std::recursive_mutex sFSGlobalMutex;
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_HWInterface.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_HWInterface.cpp
@@ -3,6 +3,8 @@
 
 namespace coreinit
 {
+	using fmt::enums::format_as;
+
 	enum class RegisterInterfaceId : uint32 // for __OSRead/__OSWrite API (register access in userspace)
 	{
 		INTERFACE_VI_UKN = 0, // 0x0C1E0000

--- a/src/Cafe/OS/libs/coreinit/coreinit_MEM.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MEM.h
@@ -49,6 +49,8 @@ void coreinitExport_MEMGetBaseHeapHandle(PPCInterpreter_t* hCPU);
 
 namespace coreinit
 {
+	using fmt::enums::format_as;
+
 #define MEM_HEAP_INVALID_HANDLE (nullptr)
 #define MEM_HEAP_DEFAULT_ALIGNMENT 4
 #define MIN_ALIGNMENT 4

--- a/src/Cafe/OS/libs/coreinit/coreinit_MEM_FrmHeap.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MEM_FrmHeap.h
@@ -3,6 +3,8 @@
 
 namespace coreinit
 {
+	using fmt::enums::format_as;
+
 	struct MEMFrmHeapRecordedState
 	{
 		uint32be id;

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.h
@@ -87,6 +87,7 @@ static_assert(sizeof(crt_t) == 0x1D8, "");
 
 namespace coreinit
 {
+	using fmt::enums::format_as;
 
 	/********* OSThreadQueue *********/
 
@@ -491,6 +492,11 @@ struct OSThread_t
 
 	/* +0x680 */ uint32								padding680[28 / 4];
 };
+
+inline auto format_as(OSThread_t::THREAD_TYPE type)
+{
+	return fmt::underlying(type);
+}
 
 static_assert(sizeof(OSThread_t) == 0x6A0-4); // todo - determine correct size
 

--- a/src/Cafe/OS/libs/gx2/GX2_Blit.h
+++ b/src/Cafe/OS/libs/gx2/GX2_Blit.h
@@ -2,6 +2,8 @@
 
 namespace GX2
 {
+	using fmt::enums::format_as;
+
 	enum class GX2ClearFlags : uint32
 	{
 		CLEAR_DEPTH = 0x01, // clear depth to given clear value

--- a/src/Cafe/OS/libs/gx2/GX2_Command.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Command.cpp
@@ -42,6 +42,8 @@ void gx2WriteGather_submitU32AsLEArray(uint32* v, uint32 numValues)
 
 namespace GX2
 {
+	using fmt::enums::format_as;
+
 	sint32 gx2WriteGatherCurrentMainCoreIndex = -1;
 	bool gx2WriteGatherInited = false;
 

--- a/src/Cafe/OS/libs/gx2/GX2_Event.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Event.cpp
@@ -12,6 +12,7 @@
 
 namespace GX2
 {
+	using fmt::enums::format_as;
 
 	SysAllocator<coreinit::OSThreadQueue> g_vsyncThreadQueue;
 	SysAllocator<coreinit::OSThreadQueue> g_flipThreadQueue;

--- a/src/Cafe/OS/libs/gx2/GX2_Event.h
+++ b/src/Cafe/OS/libs/gx2/GX2_Event.h
@@ -2,6 +2,8 @@
 
 namespace GX2
 {
+	using fmt::enums::format_as;
+
 	void GX2Init_event();
 	void GX2EventResetToDefaultState();
 

--- a/src/Cafe/OS/libs/gx2/GX2_Misc.h
+++ b/src/Cafe/OS/libs/gx2/GX2_Misc.h
@@ -2,6 +2,8 @@
 
 namespace GX2
 {
+	using fmt::enums::format_as;
+
 	extern uint32 sGX2MainCoreIndex;
 
 	enum class E_TVRES

--- a/src/Cafe/OS/libs/gx2/GX2_Shader.h
+++ b/src/Cafe/OS/libs/gx2/GX2_Shader.h
@@ -23,6 +23,11 @@ struct GX2FetchShader_t
 	}
 };
 
+inline auto format_as(GX2FetchShader_t::FetchShaderType type)
+{
+	return fmt::underlying(type);
+}
+
 static_assert(sizeof(GX2FetchShader_t) == 0x20);
 static_assert(sizeof(betype<GX2FetchShader_t::FetchShaderType>) == 4);
 

--- a/src/Cafe/OS/libs/gx2/GX2_State.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_State.cpp
@@ -7,6 +7,8 @@
 
 namespace GX2
 {
+	using fmt::enums::format_as;
+
 	using namespace Latte;
 
 	void GX2InitAlphaTestReg(GX2AlphaTestReg* reg, uint32 alphaTestEnable, GX2_ALPHAFUNC alphaFunc, float alphaRef)

--- a/src/Cafe/OS/libs/nn_acp/nn_acp.h
+++ b/src/Cafe/OS/libs/nn_acp/nn_acp.h
@@ -4,6 +4,8 @@ namespace nn
 {
 namespace acp
 {
+	using fmt::enums::format_as;
+
 	enum ACPStatus : uint32
 	{
 		SUCCESS = 0,

--- a/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
+++ b/src/Cafe/OS/libs/nn_boss/nn_boss.cpp
@@ -23,6 +23,8 @@ memset(bossRequest, 0, sizeof(iosuBossCemuRequest_t)); \
 memset(bossBufferVector, 0, sizeof(ioBufferVector_t)); \
 bossBufferVector->buffer = (uint8*)bossRequest;
 
+	using fmt::enums::format_as;
+
 	SysAllocator<coreinit::OSMutex> g_mutex;
 	sint32 g_initCounter = 0;
 	bool g_isInitialized = false;

--- a/src/Cafe/OS/libs/nn_ndm/nn_ndm.cpp
+++ b/src/Cafe/OS/libs/nn_ndm/nn_ndm.cpp
@@ -6,6 +6,7 @@ namespace nn
 {
 	namespace ndm
 	{
+		using fmt::enums::format_as;
 
 		enum class DAEMON_NAME : uint32
 		{

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
@@ -6,6 +6,8 @@ namespace nn
 {
 	namespace olv
 	{
+		using fmt::enums::format_as;
+
 		struct DownloadedDataBase
 		{
 			enum class FLAGS : uint32

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -60,21 +60,6 @@ bool cemuLog_log(LogType type, std::u8string_view text);
 bool cemuLog_log(LogType type, std::wstring_view text);
 void cemuLog_waitForFlush(); // wait until all log lines are written
 
-template <typename T>
-auto ForwardEnum(T t) 
-{
-  if constexpr (std::is_enum_v<T>)
-    return fmt::underlying(t);
-  else
-    return std::forward<T>(t);
-}
-
-template <typename... TArgs>
-auto ForwardEnum(std::tuple<TArgs...> t) 
-{ 
-	return std::apply([](auto... x) { return std::make_tuple(ForwardEnum(x)...); }, t);
-}
-
 template<typename T, typename ... TArgs>
 bool cemuLog_log(LogType type, std::basic_string<T> formatStr, TArgs&&... args)
 {
@@ -88,7 +73,7 @@ bool cemuLog_log(LogType type, std::basic_string<T> formatStr, TArgs&&... args)
 	else
 	{
 		const auto format_view = fmt::basic_string_view<T>(formatStr);
-		const auto text = fmt::vformat(format_view, fmt::make_format_args<fmt::buffer_context<T>>(ForwardEnum(args)...));
+		const auto text = fmt::vformat(format_view, fmt::make_format_args<fmt::buffer_context<T>>(args...));
 		cemuLog_log(type, std::basic_string_view(text.data(), text.size()));
 	}
 	return true;

--- a/src/Cemu/napi/napi.h
+++ b/src/Cemu/napi/napi.h
@@ -11,8 +11,15 @@ enum class NAPI_RESULT
 	SERVICE_ERROR = 4, // server reply indicates error. Extended error code (serviceError) is set
 };
 
+inline auto format_as(NAPI_RESULT apiError)
+{
+	return fmt::underlying(apiError);
+}
+
 namespace NAPI
 {
+	using fmt::enums::format_as;
+
 	// common auth info structure shared by ACT, ECS and IAS service
 	struct AuthInfo
 	{

--- a/src/Common/MemPtr.h
+++ b/src/Common/MemPtr.h
@@ -159,5 +159,5 @@ template <typename T>
 struct fmt::formatter<MEMPTR<T>> : formatter<string_view>
 {
 	template <typename FormatContext>
-	auto format(const MEMPTR<T>& v, FormatContext& ctx) { return formatter<string_view>::format(fmt::format("{:#x}", v.GetMPTR()), ctx); }
+	auto format(const MEMPTR<T>& v, FormatContext& ctx) const { return formatter<string_view>::format(fmt::format("{:#x}", v.GetMPTR()), ctx); }
 };

--- a/src/Common/betype.h
+++ b/src/Common/betype.h
@@ -204,6 +204,12 @@ private:
 	T m_value;
 };
 
+template <typename T>
+inline auto format_as(const betype<T>& v)
+{
+	return v.value();
+}
+
 using uint64be = betype<uint64>;
 using uint32be = betype<uint32>;
 using uint16be = betype<uint16>;

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -16,13 +16,9 @@
 
 #define SDL_MAIN_HANDLED
 
-// #if FMT_VERSION > 80102
-// // restore generic formatter for enum (class) to underlying. We currently utilize this for HLE call logging
-// template <typename Enum, std::enable_if_t<std::is_enum<Enum>::value, int> = 0>
-// constexpr auto format_as(Enum e) noexcept -> std::underlying_type<Enum> {
-//   return static_cast<std::underlying_type<Enum>>(e);
-// }
-// #endif
+#if FMT_VERSION >= 100000
+using fmt::enums::format_as;
+#endif
 
 // arch defines
 

--- a/src/audio/IAudioAPI.h
+++ b/src/audio/IAudioAPI.h
@@ -82,6 +82,11 @@ private:
 	
 };
 
+inline auto format_as(IAudioAPI::AudioAPI api)
+{
+	return fmt::underlying(api);
+}
+
 using AudioAPIPtr = std::unique_ptr<IAudioAPI>;
 extern std::shared_mutex g_audioMutex;
 extern AudioAPIPtr g_tvAudio;

--- a/src/audio/IAudioInputAPI.h
+++ b/src/audio/IAudioInputAPI.h
@@ -66,6 +66,11 @@ protected:
 private:
 };
 
+inline auto format_as(IAudioInputAPI::AudioInputAPI api)
+{
+	return fmt::underlying(api);
+}
+
 using AudioInputAPIPtr = std::unique_ptr<IAudioInputAPI>;
 extern std::shared_mutex g_audioInputMutex;
 extern AudioInputAPIPtr g_inputAudio;

--- a/src/input/api/InputAPI.h
+++ b/src/input/api/InputAPI.h
@@ -49,6 +49,11 @@ namespace InputAPI
 		throw std::runtime_error(fmt::format("unknown input api: {}", to_underlying(type)));
 	}
 
+	inline auto format_as(Type type)
+	{
+		return to_string(type);
+	}
+
 	constexpr Type from_string(std::string_view str)
 	{
 		if (str == to_string(Keyboard))

--- a/src/util/EventService.h
+++ b/src/util/EventService.h
@@ -10,6 +10,11 @@ enum class Events : int32_t
 	ControllerChanged,
 };
 
+inline auto format_as(Events event)
+{
+	return fmt::underlying(event);
+}
+
 using ControllerChangedFunc = void(void);
 
 class EventService : public Singleton<EventService>


### PR DESCRIPTION
I have no idea what I'm doing, but this seems to compile fine against both ~~fmt9~~ and fmt10.
fmt10 basically removed implicit conversions for enums.