### PR TITLE
[Linux/MacOS] Further Wiimote changes for parity with Windows

### DIFF
--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -976,7 +976,7 @@ void InputSettings2::on_controller_settings(wxCommandEvent& event)
 
 	case InputAPI::Keyboard: break;
 
-	#if BOOST_OS_WINDOWS
+	#if SUPPORTS_WIIMOTE
 	case InputAPI::Wiimote: {
 		const auto wiimote = std::dynamic_pointer_cast<NativeWiimoteController>(controller);
 		wxASSERT(wiimote);

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -976,7 +976,7 @@ void InputSettings2::on_controller_settings(wxCommandEvent& event)
 
 	case InputAPI::Keyboard: break;
 
-	#if SUPPORTS_WIIMOTE
+	#ifdef SUPPORTS_WIIMOTE
 	case InputAPI::Wiimote: {
 		const auto wiimote = std::dynamic_pointer_cast<NativeWiimoteController>(controller);
 		wxASSERT(wiimote);

--- a/src/gui/input/settings/WiimoteControllerSettings.cpp
+++ b/src/gui/input/settings/WiimoteControllerSettings.cpp
@@ -14,7 +14,7 @@
 #include "gui/components/wxInputDraw.h"
 #include "gui/input/InputAPIAddWindow.h"
 
-#if SUPPORTS_WIIMOTE
+#ifdef SUPPORTS_WIIMOTE
 
 WiimoteControllerSettings::WiimoteControllerSettings(wxWindow* parent, const wxPoint& position, std::shared_ptr<NativeWiimoteController> controller)
 	: wxDialog(parent, wxID_ANY, _("Controller settings"), position, wxDefaultSize,

--- a/src/gui/input/settings/WiimoteControllerSettings.cpp
+++ b/src/gui/input/settings/WiimoteControllerSettings.cpp
@@ -14,7 +14,7 @@
 #include "gui/components/wxInputDraw.h"
 #include "gui/input/InputAPIAddWindow.h"
 
-#if BOOST_OS_WINDOWS
+#if SUPPORTS_WIIMOTE
 
 WiimoteControllerSettings::WiimoteControllerSettings(wxWindow* parent, const wxPoint& position, std::shared_ptr<NativeWiimoteController> controller)
 	: wxDialog(parent, wxID_ANY, _("Controller settings"), position, wxDefaultSize,
@@ -55,6 +55,7 @@ WiimoteControllerSettings::WiimoteControllerSettings(wxWindow* parent, const wxP
 
 			// Motion
 			m_use_motion = new wxCheckBox(box, wxID_ANY, _("Use motion"));
+			m_use_motion->SetValue(m_settings.motion);
 			m_use_motion->SetValue(m_settings.motion);
 			m_use_motion->Enable(m_controller->has_motion());
 			row_sizer->Add(m_use_motion, 0, wxALL, 5);

--- a/src/gui/input/settings/WiimoteControllerSettings.h
+++ b/src/gui/input/settings/WiimoteControllerSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if BOOST_OS_WINDOWS
+#if SUPPORTS_WIIMOTE
 
 #include <wx/dialog.h>
 #include <wx/timer.h>

--- a/src/gui/input/settings/WiimoteControllerSettings.h
+++ b/src/gui/input/settings/WiimoteControllerSettings.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if SUPPORTS_WIIMOTE
+#ifdef SUPPORTS_WIIMOTE
 
 #include <wx/dialog.h>
 #include <wx/timer.h>

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WIN32)
 endif()
 
 if (ENABLE_WIIMOTE)
+	target_compile_definitions(CemuInput PUBLIC SUPPORTS_WIIMOTE)
 	target_sources(CemuInput PRIVATE
 			api/Wiimote/WiimoteControllerProvider.h
 			api/Wiimote/WiimoteControllerProvider.cpp

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -5,7 +5,7 @@
 #include "input/api/XInput/XInputControllerProvider.h"
 #endif
 
-#if defined(HAS_HIDAPI) || BOOST_OS_WINDOWS
+#ifdef SUPPORTS_WIIMOTE
 #include "input/api/Wiimote/WiimoteControllerProvider.h"
 #endif
 

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
@@ -35,6 +35,7 @@ std::vector<WiimoteDevicePtr> HidapiWiimote::get_devices() {
             cemuLog_logDebug(LogType::Force, "Unable to open Wiimote device at {}: {}", it->path, boost::nowide::narrow(hid_error(nullptr)));
         }
         else {
+            hid_set_nonblocking(dev, true);
             // Enough to have a unique id for each device within a session
             uint64_t id = (static_cast<uint64>(it->interface_number) << 32) |
                           (static_cast<uint64>(it->usage_page) << 16) |

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
@@ -5,8 +5,8 @@ static constexpr uint16 WIIMOTE_PRODUCT_ID = 0x0306;
 static constexpr uint16 WIIMOTE_MP_PRODUCT_ID = 0x0330;
 static constexpr uint16 WIIMOTE_MAX_INPUT_REPORT_LENGTH = 22;
 
-HidapiWiimote::HidapiWiimote(hid_device* dev, uint64_t identifier)
- : m_handle(dev), m_identifier(identifier) {
+HidapiWiimote::HidapiWiimote(hid_device* dev, uint64_t identifier, std::string_view path)
+ : m_handle(dev), m_identifier(identifier), m_path(path) {
 
 }
 
@@ -39,7 +39,7 @@ std::vector<WiimoteDevicePtr> HidapiWiimote::get_devices() {
             uint64_t id = (static_cast<uint64>(it->interface_number) << 32) |
                           (static_cast<uint64>(it->usage_page) << 16) |
                           (it->usage);
-            wiimote_devices.push_back(std::make_shared<HidapiWiimote>(dev, id));
+            wiimote_devices.push_back(std::make_shared<HidapiWiimote>(dev, id, it->path));
         }
     }
     hid_free_enumeration(device_enumeration);
@@ -47,7 +47,8 @@ std::vector<WiimoteDevicePtr> HidapiWiimote::get_devices() {
 }
 
 bool HidapiWiimote::operator==(WiimoteDevice& o) const  {
-    return m_identifier == static_cast<HidapiWiimote&>(o).m_identifier;
+    auto const& other_mote = static_cast<HidapiWiimote const&>(o);
+    return m_identifier == other_mote.m_identifier && other_mote.m_path == m_path;
 }
 
 HidapiWiimote::~HidapiWiimote() {

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.h
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.h
@@ -5,7 +5,7 @@
 
 class HidapiWiimote : public WiimoteDevice {
 public:
-    HidapiWiimote(hid_device* dev, uint64_t identifier);
+    HidapiWiimote(hid_device* dev, uint64_t identifier, std::string_view path);
     ~HidapiWiimote() override;
 
     bool write_data(const std::vector<uint8> &data) override;
@@ -16,7 +16,8 @@ public:
 
 private:
     hid_device* m_handle;
-    uint64_t m_identifier;
+    const uint64_t m_identifier;
+    const std::string m_path;
 
 };
 

--- a/src/input/emulated/EmulatedController.cpp
+++ b/src/input/emulated/EmulatedController.cpp
@@ -2,7 +2,7 @@
 
 #include "input/api/Controller.h"
 
-#if BOOST_OS_WINDOWS
+#ifdef SUPPORTS_WIIMOTE
 #include "input/api/Wiimote/NativeWiimoteController.h"
 #endif
 
@@ -131,15 +131,15 @@ bool EmulatedController::has_second_motion() const
 		if(controller->use_motion())
 		{
 			// if wiimote has nunchuck connected, we use its acceleration
-			#if BOOST_OS_WINDOWS
-			if(controller->api() == InputAPI::Wiimote)
+            #if SUPPORTS_WIIMOTE
+            if(controller->api() == InputAPI::Wiimote)
 			{
 				if(((NativeWiimoteController*)controller.get())->get_extension() == NativeWiimoteController::Nunchuck)
 				{
 					return true;
 				}
 			}
-			#endif
+            #endif
 			motion++;
 		}
 	}
@@ -156,7 +156,7 @@ MotionSample EmulatedController::get_second_motion_data() const
 		if (controller->use_motion())
 		{
 			// if wiimote has nunchuck connected, we use its acceleration
-			#if BOOST_OS_WINDOWS
+            #ifdef SUPPORTS_WIIMOTE
 			if (controller->api() == InputAPI::Wiimote)
 			{
 				if (((NativeWiimoteController*)controller.get())->get_extension() == NativeWiimoteController::Nunchuck)
@@ -211,12 +211,11 @@ void EmulatedController::add_controller(std::shared_ptr<ControllerBase> controll
 {
 	controller->connect();
 
-	#if BOOST_OS_WINDOWS
-	if (const auto wiimote = std::dynamic_pointer_cast<NativeWiimoteController>(controller)) {
+    #ifdef SUPPORTS_WIIMOTE
+    if (const auto wiimote = std::dynamic_pointer_cast<NativeWiimoteController>(controller)) {
 		wiimote->set_player_index(m_player_index);
 	}
-	#endif
-
+    #endif
 	std::scoped_lock lock(m_mutex);
 	m_controllers.emplace_back(std::move(controller));
 }


### PR DESCRIPTION
(Edit) Changes:
- Change Wiimote comparison so that controllers cannot be mistaken as others, so that using multiple Wiimotes is actually possible
- Use non-blocking reads to reduce input lag for extra Wiimotes
- Enable nunchuk motion
- Enable the Wiimote settings menu

Original Comment: 
> Now there should be no way that one controller is mistaken as being another connected controller