### PR TITLE
nsyshid: add linux support using libusb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libudev-dev nasm ninja-build
+        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libudev-dev libusb-1.0-0-dev nasm ninja-build
 
     - name: "Bootstrap vcpkg"
       run: |
@@ -107,7 +107,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream
+        sudo apt install -y clang-12 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libusb-1.0-0-dev nasm ninja-build appstream
 
     - name: "Build AppImage"
       run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -25,7 +25,7 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
 ### Installing dependencies
 
 #### For Ubuntu and derivatives:
-`sudo apt install -y cmake curl freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build` 
+`sudo apt install -y cmake curl freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libusb-1.0-0-dev nasm ninja-build` 
 
 *Additionally, for Ubuntu 22.04 only:*
  - `sudo apt install -y clang-12`
@@ -33,10 +33,10 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
    `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang-12 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-12 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja`
 
 #### For Arch and derivatives:
-`sudo pacman -S --needed base-devel clang cmake freeglut git glm gtk3 libgcrypt libpulse libsecret linux-headers llvm nasm ninja systemd unzip zip`
+`sudo pacman -S --needed base-devel clang cmake freeglut git glm gtk3 libgcrypt libpulse libsecret libusb linux-headers llvm nasm ninja systemd unzip zip`
 
 #### For Fedora and derivatives:
-`sudo dnf install clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel nasm ninja-build perl-core systemd-devel zlib-devel`
+`sudo dnf install clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel libusb1-devel nasm ninja-build perl-core systemd-devel zlib-devel`
 
 ### Build Cemu using cmake and clang
 1. `git clone --recursive https://github.com/cemu-project/Cemu`

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -524,6 +524,10 @@ if (ENABLE_WAYLAND)
   target_link_libraries(CemuCafe PUBLIC Wayland::Client)
 endif()
 
+if (UNIX AND NOT APPLE)
+	target_link_libraries(CemuCafe PRIVATE usb-1.0)
+endif()
+
 if (ENABLE_WXWIDGETS)
 	target_link_libraries(CemuCafe PRIVATE wx::base wx::core)
 endif()

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -830,6 +830,1014 @@ namespace nsyshid
 	}
 }
 
+#elif __linux__
+
+#include <mutex>
+#include <libusb-1.0/libusb.h>
+
+#include "Cafe/OS/libs/coreinit/coreinit_Thread.h"
+
+#pragma comment(lib, "Setupapi.lib")
+#pragma comment(lib, "hid.lib")
+
+namespace nsyshid {
+
+	typedef struct {
+		/* +0x00 */ uint32be handle;
+		/* +0x04 */ uint32 ukn04;
+		/* +0x08 */ uint16 vendorId; // little-endian ?
+		/* +0x0A */ uint16 productId; // little-endian ?
+		/* +0x0C */ uint8 ifIndex;
+		/* +0x0D */ uint8 subClass;
+		/* +0x0E */ uint8 protocol;
+		/* +0x0F */ uint8 paddingGuessed0F;
+		/* +0x10 */ uint16be maxPacketSizeRX;
+		/* +0x12 */ uint16be maxPacketSizeTX;
+	} HIDDevice_t;
+
+	static_assert(offsetof(HIDDevice_t, vendorId)
+
+				  == 0x8, "");
+
+	static_assert(offsetof(HIDDevice_t, productId)
+
+				  == 0xA, "");
+
+	static_assert(offsetof(HIDDevice_t, ifIndex)
+
+				  == 0xC, "");
+
+	static_assert(offsetof(HIDDevice_t, protocol)
+
+				  == 0xE, "");
+
+	class HIDDeviceInfo {
+	public:
+		HIDDeviceInfo() :
+				handle(0),
+				physicalDeviceInstance(0),
+				vendorId(0),
+				productId(0),
+				interfaceIndex(0),
+				interfaceSubClass(0),
+				protocol(0),
+				hidDevice(nullptr),
+				libusbHandle(nullptr),
+				libusbBusNumber(0),
+				libusbDeviceAddress(0),
+				libusbHasEndpointIn(false),
+				libusbEndpointIn(0),
+				libusbEndpointInMaxPacketSize(0),
+				libusbHasEndpointOut(false),
+				libusbEndpointOut(0),
+				libusbEndpointOutMaxPacketSize(0) {
+
+		}
+
+		~HIDDeviceInfo() {
+			if (libusbHandle != nullptr) {
+				libusb_close(libusbHandle);
+				libusbHandle = nullptr;
+			}
+		}
+
+		uint32 handle;
+		uint32 physicalDeviceInstance;
+		uint16 vendorId;
+		uint16 productId;
+		uint8 interfaceIndex;
+		uint8 interfaceSubClass;
+		uint8 protocol;
+		HIDDevice_t *hidDevice; // this info is passed to applications and must remain intact
+		// host
+		libusb_device_handle *libusbHandle;
+		uint8 libusbBusNumber;
+		uint8 libusbDeviceAddress;
+		bool libusbHasEndpointIn;
+		uint8 libusbEndpointIn;
+		uint16 libusbEndpointInMaxPacketSize;
+		bool libusbHasEndpointOut;
+		uint8 libusbEndpointOut;
+		uint16 libusbEndpointOutMaxPacketSize;
+	};
+
+	std::list<std::shared_ptr<HIDDeviceInfo>> deviceInfoList;
+
+	typedef struct _HIDClient_t {
+		MEMPTR<_HIDClient_t> next;
+		uint32be callbackFunc; // attach/detach callback
+	} HIDClient_t;
+
+	HIDClient_t *firstHIDClient = nullptr;
+
+	std::recursive_mutex hidMutex;
+
+	libusb_context *libusbContext;
+
+	void attachClientToList(HIDClient_t *hidClient) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		// todo - append at the beginning or end of the list? List order matters because it also controls the order in which attach callbacks are called
+		if (firstHIDClient) {
+			hidClient->next = firstHIDClient;
+			firstHIDClient = hidClient;
+		} else {
+			hidClient->next = nullptr;
+			firstHIDClient = hidClient;
+		}
+	}
+
+	void attachDeviceToList(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		deviceInfoList.push_back(hidDeviceInfo);
+	}
+
+	void detachDeviceFromList(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		deviceInfoList.remove(hidDeviceInfo);
+	}
+
+	std::shared_ptr<HIDDeviceInfo> findDeviceInfo(struct libusb_device *dev) {
+		struct libusb_device_descriptor desc;
+		int ret = libusb_get_device_descriptor(dev, &desc);
+		if (ret < 0) {
+			cemuLog_logDebug(LogType::Force, "nsyshid.findDevice(): failed to get device descriptor");
+			return nullptr;
+		}
+		uint8 busNumber = libusb_get_bus_number(dev);
+		uint8 deviceAddress = libusb_get_device_address(dev);
+		{
+			std::lock_guard<std::recursive_mutex> lock(hidMutex);
+			for (auto it = deviceInfoList.begin(); it != deviceInfoList.end(); it++) {
+				std::shared_ptr<HIDDeviceInfo> deviceInfo = *it;
+				if (desc.idVendor == deviceInfo->vendorId &&
+					desc.idProduct == deviceInfo->productId &&
+					busNumber == deviceInfo->libusbBusNumber &&
+					deviceAddress == deviceInfo->libusbDeviceAddress) {
+
+					// we found our device!
+					return deviceInfo;
+				}
+			}
+		}
+		return nullptr;
+	}
+
+	bool openDevice(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo) {
+		libusb_device **devices;
+		ssize_t deviceCount = libusb_get_device_list(libusbContext, &devices);
+		if (deviceCount < 0) {
+			cemuLog_log(LogType::Force, "nsyshid: failed to get usb devices with libusb");
+			return false;
+		}
+		libusb_device *dev;
+		libusb_device *found = nullptr;
+		for (int i = 0; (dev = devices[i]) != nullptr; i++) {
+			struct libusb_device_descriptor desc;
+			int ret = libusb_get_device_descriptor(dev, &desc);
+			if (ret < 0) {
+				cemuLog_log(LogType::Force,
+							"nsyshid: failed to get device descriptor with libusb; return code: %i", ret);
+				libusb_free_device_list(devices, 1);
+				return false;
+			}
+			if (desc.idVendor == hidDeviceInfo->vendorId &&
+				desc.idProduct == hidDeviceInfo->productId &&
+				libusb_get_bus_number(dev) == hidDeviceInfo->libusbBusNumber &&
+				libusb_get_device_address(dev) == hidDeviceInfo->libusbDeviceAddress) {
+
+				// we found our device!
+				found = dev;
+				break;
+			}
+		}
+
+		if (found != nullptr) {
+			{
+				int ret = libusb_open(dev, &(hidDeviceInfo->libusbHandle));
+				if (ret < 0) {
+					cemuLog_log(LogType::Force,
+								"nsyshid: failed to open device with libusb; return code: %i",
+								ret);
+					libusb_free_device_list(devices, 1);
+					return false;
+				}
+			}
+			if (libusb_kernel_driver_active(hidDeviceInfo->libusbHandle, 0) == 1) {
+				cemuLog_logDebug(LogType::Force, "nsyshid: kernel driver active");
+				if (libusb_detach_kernel_driver(hidDeviceInfo->libusbHandle, 0) == 0) {
+					cemuLog_logDebug(LogType::Force, "nsyshid: kernel driver detached");
+				} else {
+					cemuLog_logDebug(LogType::Force, "nsyshid: failed to detach kernel driver");
+				}
+			}
+			{
+				int ret = libusb_claim_interface(hidDeviceInfo->libusbHandle, 0);
+				if (ret != 0) {
+					cemuLog_logDebug(LogType::Force, "nsyshid: cannot claim interface");
+				}
+			}
+		}
+
+		libusb_free_device_list(devices, 1);
+		return found != nullptr;
+	}
+
+	std::shared_ptr<HIDDeviceInfo> getHIDDeviceInfoByHandle(uint32 handle, bool openFileHandle = false) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		for (auto it = deviceInfoList.begin(); it != deviceInfoList.end(); it++) {
+			std::shared_ptr<HIDDeviceInfo> deviceInfo = *it;
+			if (deviceInfo->handle == handle) {
+				if (openFileHandle && deviceInfo->libusbHandle == nullptr) {
+					if (!openDevice(deviceInfo)) {
+						return nullptr;
+					}
+				}
+				return deviceInfo;
+			}
+		}
+		return nullptr;
+	}
+
+	uint32 _lastGeneratedHidHandle = 1;
+
+	uint32 generateHIDHandle() {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		_lastGeneratedHidHandle++;
+		return _lastGeneratedHidHandle;
+	}
+
+	const int HID_MAX_NUM_DEVICES = 128;
+
+	SysAllocator<HIDDevice_t, HID_MAX_NUM_DEVICES> _devicePool;
+	bool _devicePoolIndexQueueInitialized = false;
+	std::queue<size_t> devicePoolIndexQueue;
+
+	void initDevicePoolIndexQueue() {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		if (_devicePoolIndexQueueInitialized) {
+			return;
+		}
+		_devicePoolIndexQueueInitialized = true;
+		for (size_t i = 0; i < HID_MAX_NUM_DEVICES; i++) {
+			devicePoolIndexQueue.push(i);
+		}
+	}
+
+	HIDDevice_t *getFreeDevice() {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		initDevicePoolIndexQueue();
+		if (devicePoolIndexQueue.empty()) {
+			return nullptr;
+		}
+		size_t index = devicePoolIndexQueue.front();
+		devicePoolIndexQueue.pop();
+		return _devicePool.GetPtr() + index;
+	}
+
+	void releaseDevice(HIDDevice_t *device) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		initDevicePoolIndexQueue();
+		size_t index = device - _devicePool.GetPtr();
+		devicePoolIndexQueue.push(index);
+	}
+
+	bool findDefaultDeviceEndpoints(libusb_device *dev,
+									bool &endpointInFound, uint8 &endpointIn, uint16 &endpointInMaxPacketSize,
+									bool &endpointOutFound, uint8 &endpointOut, uint16 &endpointOutMaxPacketSize) {
+		endpointInFound = false;
+		endpointIn = 0;
+		endpointInMaxPacketSize = 0;
+		endpointOutFound = false;
+		endpointOut = 0;
+		endpointOutMaxPacketSize = 0;
+
+		struct libusb_config_descriptor *conf = nullptr;
+		int ret = libusb_get_active_config_descriptor(dev, &conf);
+
+		if (ret == 0) {
+			for (uint8_t interfaceIndex = 0; interfaceIndex < conf->bNumInterfaces; interfaceIndex++) {
+				const struct libusb_interface &interface = conf->interface[interfaceIndex];
+				for (int altsettingIndex = 0; altsettingIndex < interface.num_altsetting; altsettingIndex++) {
+					const struct libusb_interface_descriptor &altsetting = interface.altsetting[altsettingIndex];
+					for (uint8_t endpointIndex = 0; endpointIndex < altsetting.bNumEndpoints; endpointIndex++) {
+						const struct libusb_endpoint_descriptor &endpoint = altsetting.endpoint[endpointIndex];
+						// figure out direction
+						if ((endpoint.bEndpointAddress & (1 << 7)) != 0) {
+							// in
+							if (!endpointInFound) {
+								endpointInFound = true;
+								endpointIn = endpoint.bEndpointAddress;
+								endpointInMaxPacketSize = endpoint.wMaxPacketSize;
+							}
+						} else {
+							// out
+							if (!endpointOutFound) {
+								endpointOutFound = true;
+								endpointOut = endpoint.bEndpointAddress;
+								endpointOutMaxPacketSize = endpoint.wMaxPacketSize;
+							}
+						}
+					}
+				}
+			}
+			libusb_free_config_descriptor(conf);
+			return true;
+		}
+		return false;
+	}
+
+	std::shared_ptr<HIDDeviceInfo> checkAndAddDevice(libusb_device *dev) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		struct libusb_device_descriptor desc;
+		int ret = libusb_get_device_descriptor(dev, &desc);
+		if (ret < 0) {
+			cemuLog_log(LogType::Force,
+						"nsyshid: failed to get device descriptor with libusb; return code: %i",
+						ret);
+			return nullptr;
+		}
+		if (desc.idVendor == 0x0e6f && desc.idProduct == 0x0241) {
+			cemuLog_logDebug(LogType::Force, "nsyshid: lego dimensions portal detected");
+		}
+		HIDDevice_t *hidDevice = getFreeDevice();
+		if (hidDevice == nullptr) {
+			cemuLog_log(LogType::Force, "nsyshid: Maximum number of supported devices exceeded");
+			return nullptr;
+		}
+
+		auto deviceInfo = std::make_shared<HIDDeviceInfo>();
+		deviceInfo->vendorId = desc.idVendor;
+		deviceInfo->productId = desc.idProduct;
+		deviceInfo->libusbHandle = nullptr;
+		deviceInfo->libusbBusNumber = libusb_get_bus_number(dev);
+		deviceInfo->libusbDeviceAddress = libusb_get_device_address(dev);
+		// figure out device endpoints
+		if (!findDefaultDeviceEndpoints(dev,
+										deviceInfo->libusbHasEndpointIn, deviceInfo->libusbEndpointIn,
+										deviceInfo->libusbEndpointInMaxPacketSize,
+										deviceInfo->libusbHasEndpointOut, deviceInfo->libusbEndpointOut,
+										deviceInfo->libusbEndpointOutMaxPacketSize)) {
+			// couldn't read config descriptor
+			return nullptr;
+		}
+		// generate handle
+		deviceInfo->handle = generateHIDHandle();
+
+		// setup HIDDevice struct
+		memset(hidDevice, 0, sizeof(HIDDevice_t));
+		deviceInfo->hidDevice = hidDevice;
+		hidDevice->handle = deviceInfo->handle;
+		hidDevice->vendorId = deviceInfo->vendorId;
+		hidDevice->productId = deviceInfo->productId;
+		hidDevice->maxPacketSizeRX = deviceInfo->libusbEndpointInMaxPacketSize;
+		hidDevice->maxPacketSizeTX = deviceInfo->libusbEndpointOutMaxPacketSize;
+
+		hidDevice->ukn04 = 0x11223344;
+
+		hidDevice->ifIndex = 1;
+		hidDevice->protocol = 0;
+		hidDevice->subClass = 2;
+
+		// todo - other values
+		//hidDevice->ifIndex = 1;
+
+		attachDeviceToList(deviceInfo);
+		return deviceInfo;
+	}
+
+	void initDeviceList() {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		if (!deviceInfoList.empty()) {
+			// already initialised
+			return;
+		}
+		libusb_device **devices;
+		ssize_t deviceCount = libusb_get_device_list(libusbContext, &devices);
+		if (deviceCount < 0) {
+			cemuLog_log(LogType::Force, "nsyshid: failed to get usb devices with libusb");
+			return;
+		}
+		libusb_device *dev;
+		for (int i = 0; (dev = devices[i]) != nullptr; i++) {
+			checkAndAddDevice(dev);
+		}
+
+		libusb_free_device_list(devices, 1);
+	}
+
+	const int HID_CALLBACK_DETACH = 0;
+	const int HID_CALLBACK_ATTACH = 1;
+
+	uint32 doAttachCallback(HIDClient_t *hidClient, std::shared_ptr<HIDDeviceInfo> deviceInfo) {
+		return PPCCoreCallback(hidClient->callbackFunc, memory_getVirtualOffsetFromPointer(hidClient),
+							   memory_getVirtualOffsetFromPointer(deviceInfo->hidDevice), HID_CALLBACK_ATTACH);
+	}
+
+	void doAttachCallbackAsync(HIDClient_t *hidClient, std::shared_ptr<HIDDeviceInfo> deviceInfo) {
+		coreinitAsyncCallback_add(hidClient->callbackFunc, 3, memory_getVirtualOffsetFromPointer(hidClient),
+								  memory_getVirtualOffsetFromPointer(deviceInfo->hidDevice), HID_CALLBACK_ATTACH);
+	}
+
+	void doDetachCallback(HIDClient_t *hidClient, std::shared_ptr<HIDDeviceInfo> deviceInfo) {
+		PPCCoreCallback(hidClient->callbackFunc, memory_getVirtualOffsetFromPointer(hidClient),
+						memory_getVirtualOffsetFromPointer(deviceInfo->hidDevice), HID_CALLBACK_DETACH);
+	}
+
+	void doDetachCallbackAsync(HIDClient_t *hidClient, std::shared_ptr<HIDDeviceInfo> deviceInfo) {
+		coreinitAsyncCallback_add(hidClient->callbackFunc, 3, memory_getVirtualOffsetFromPointer(hidClient),
+								  memory_getVirtualOffsetFromPointer(deviceInfo->hidDevice), HID_CALLBACK_DETACH);
+	}
+
+	void removeDevice(libusb_device *dev) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		std::shared_ptr<HIDDeviceInfo> deviceInfo = findDeviceInfo(dev);
+		if (deviceInfo == nullptr) {
+			cemuLog_logDebug(LogType::Force, "nsyshid.removeDevice(): failed to find device info");
+			return;
+		}
+
+		HIDClient_t *clientItr = firstHIDClient;
+		while (clientItr) {
+			doDetachCallbackAsync(clientItr, deviceInfo);
+			clientItr = clientItr->next;
+		}
+
+		detachDeviceFromList(deviceInfo);
+
+		releaseDevice(deviceInfo->hidDevice);
+		cemuLog_logDebug(LogType::Force, "nsyshid.removeDevide(): device removed: {:04x}:{:04x}",
+						 deviceInfo->vendorId,
+						 deviceInfo->productId);
+	}
+
+	void export_HIDAddClient(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamTypePtr(hidClient, HIDClient_t, 0);
+		ppcDefineParamMPTR(callbackFuncMPTR, 1);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDAddClient(0x{:08x},0x{:08x})", hCPU->gpr[3], hCPU->gpr[4]);
+		hidClient->callbackFunc = callbackFuncMPTR;
+		attachClientToList(hidClient);
+		initDeviceList();
+		// do attach callbacks
+		for (auto it = deviceInfoList.begin(); it != deviceInfoList.end(); it++) {
+			std::shared_ptr<HIDDeviceInfo> deviceInfo = *it;
+			if (doAttachCallback(hidClient, deviceInfo) != 0)
+				break;
+		}
+
+		osLib_returnFromFunction(hCPU, 0);
+	}
+
+	void export_HIDDelClient(PPCInterpreter_t *hCPU) {
+		ppcDefineParamTypePtr(hidClient, HIDClient_t, 0);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDDelClient(0x{:08x})", hCPU->gpr[3]);
+
+		// todo
+		// do detach callbacks
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		for (auto it = deviceInfoList.begin(); it != deviceInfoList.end(); it++) {
+			std::shared_ptr<HIDDeviceInfo> deviceInfo = *it;
+			doDetachCallback(hidClient, deviceInfo);
+		}
+
+		osLib_returnFromFunction(hCPU, 0);
+	}
+
+	void export_HIDGetDescriptor(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamU8(descType, 1); // r4
+		ppcDefineParamU8(descIndex, 2); // r5
+		ppcDefineParamU8(lang, 3); // r6
+		ppcDefineParamUStr(output, 4); // r7
+		ppcDefineParamU32(outputMaxLength, 5); // r8
+		ppcDefineParamMPTR(cbFuncMPTR, 6); // r9
+		ppcDefineParamMPTR(cbParamMPTR, 7); // r10
+
+		std::shared_ptr<HIDDeviceInfo> hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle);
+		if (hidDeviceInfo) {
+			if (hidDeviceInfo->libusbHandle != nullptr) {
+				if (descType == 0x02 && hidDeviceInfo->libusbHasEndpointIn && hidDeviceInfo->libusbHasEndpointOut) {
+					uint8 configurationDescriptor[0x29];
+
+					uint8 *currentWritePtr;
+
+					// configuration descriptor
+					currentWritePtr = configurationDescriptor + 0;
+					*(uint8 *) (currentWritePtr + 0) = 9; // bLength
+					*(uint8 *) (currentWritePtr + 1) = 2; // bDescriptorType
+					*(uint16be *) (currentWritePtr + 2) = 0x0029; // wTotalLength
+					*(uint8 *) (currentWritePtr + 4) = 1; // bNumInterfaces
+					*(uint8 *) (currentWritePtr + 5) = 1; // bConfigurationValue
+					*(uint8 *) (currentWritePtr + 6) = 0; // iConfiguration
+					*(uint8 *) (currentWritePtr + 7) = 0x80; // bmAttributes
+					*(uint8 *) (currentWritePtr + 8) = 0xFA; // MaxPower
+					currentWritePtr = currentWritePtr + 9;
+					// configuration descriptor
+					*(uint8 *) (currentWritePtr + 0) = 9; // bLength
+					*(uint8 *) (currentWritePtr + 1) = 0x04; // bDescriptorType
+					*(uint8 *) (currentWritePtr + 2) = 0; // bInterfaceNumber
+					*(uint8 *) (currentWritePtr + 3) = 0; // bAlternateSetting
+					*(uint8 *) (currentWritePtr + 4) = 2; // bNumEndpoints
+					*(uint8 *) (currentWritePtr + 5) = 3; // bInterfaceClass
+					*(uint8 *) (currentWritePtr + 6) = 0; // bInterfaceSubClass
+					*(uint8 *) (currentWritePtr + 7) = 0; // bInterfaceProtocol
+					*(uint8 *) (currentWritePtr + 8) = 0; // iInterface
+					currentWritePtr = currentWritePtr + 9;
+					// configuration descriptor
+					*(uint8 *) (currentWritePtr + 0) = 9; // bLength
+					*(uint8 *) (currentWritePtr + 1) = 0x21; // bDescriptorType
+					*(uint16be *) (currentWritePtr + 2) = 0x0111; // bcdHID
+					*(uint8 *) (currentWritePtr + 4) = 0x00; // bCountryCode
+					*(uint8 *) (currentWritePtr + 5) = 0x01; // bNumDescriptors
+					*(uint8 *) (currentWritePtr + 6) = 0x22; // bDescriptorType
+					*(uint16be *) (currentWritePtr + 7) = 0x001D; // wDescriptorLength
+					currentWritePtr = currentWritePtr + 9;
+					// endpoint descriptor 1
+					*(uint8 *) (currentWritePtr + 0) = 7; // bLength
+					*(uint8 *) (currentWritePtr + 1) = 0x05; // bDescriptorType
+					*(uint8 *) (currentWritePtr + 1) = hidDeviceInfo->libusbEndpointIn; // bEndpointAddress
+					*(uint8 *) (currentWritePtr + 2) = 0x03; // bmAttributes
+					*(uint16be *) (currentWritePtr + 3) =
+							hidDeviceInfo->libusbEndpointInMaxPacketSize; // wMaxPacketSize
+					*(uint8 *) (currentWritePtr + 5) = 0x01; // bInterval
+					currentWritePtr = currentWritePtr + 7;
+					// endpoint descriptor 2
+					*(uint8 *) (currentWritePtr + 0) = 7; // bLength
+					*(uint8 *) (currentWritePtr + 1) = 0x05; // bDescriptorType
+					*(uint8 *) (currentWritePtr + 1) = hidDeviceInfo->libusbEndpointOut; // bEndpointAddress
+					*(uint8 *) (currentWritePtr + 2) = 0x03; // bmAttributes
+					*(uint16be *) (currentWritePtr + 3) =
+							hidDeviceInfo->libusbEndpointOutMaxPacketSize; // wMaxPacketSize
+					*(uint8 *) (currentWritePtr + 5) = 0x01; // bInterval
+					currentWritePtr = currentWritePtr + 7;
+
+					cemu_assert_debug((currentWritePtr - configurationDescriptor) == 0x29);
+
+					memcpy(output, configurationDescriptor,
+						   std::min<uint32>(outputMaxLength, sizeof(configurationDescriptor)));
+				} else {
+					cemu_assert_unimplemented();
+				}
+			} else {
+				cemu_assert_unimplemented();
+			}
+		} else {
+			cemu_assert_suspicious();
+		}
+		osLib_returnFromFunction(hCPU, 0);
+	}
+
+	void _debugPrintHex(std::string prefix, uint8 *data, size_t len) {
+		char debugOutput[1024] = {0};
+		len = std::min(len, (size_t) 100);
+		for (sint32 i = 0; i < len; i++) {
+			sprintf(debugOutput + i * 3, "%02x ", data[i]);
+		}
+		fmt::print("{} Data: {}\n", prefix, debugOutput);
+		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
+	}
+
+	void doHIDTransferCallback(MPTR callbackFuncMPTR, MPTR callbackParamMPTR, uint32 hidHandle, uint32 errorCode,
+							   MPTR buffer, sint32 length) {
+		coreinitAsyncCallback_add(callbackFuncMPTR, 5, hidHandle, errorCode, buffer, length, callbackParamMPTR);
+	}
+
+	void export_HIDSetIdle(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamU32(ifIndex, 1); // r4
+		ppcDefineParamU32(ukn, 2); // r5
+		ppcDefineParamU32(duration, 3); // r6
+		ppcDefineParamMPTR(callbackFuncMPTR, 4); // r7
+		ppcDefineParamMPTR(callbackParamMPTR, 5); // r8
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetIdle(...)");
+
+		// todo
+		if (callbackFuncMPTR) {
+			doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidHandle, 0, MPTR_NULL, 0);
+		} else {
+			cemu_assert_unimplemented();
+		}
+		osLib_returnFromFunction(hCPU, 0); // for non-async version, return number of bytes transferred
+	}
+
+	void export_HIDSetProtocol(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamU32(ifIndex, 1); // r4
+		ppcDefineParamU32(protocol, 2); // r5
+		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
+		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetProtocol(...)");
+
+		if (callbackFuncMPTR) {
+			doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidHandle, 0, MPTR_NULL, 0);
+		} else {
+			cemu_assert_unimplemented();
+		}
+		osLib_returnFromFunction(hCPU, 0); // for non-async version, return number of bytes transferred
+	}
+
+	// handler for async HIDSetReport transfers
+	void _hidSetReportAsync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *reportData, sint32 length,
+							uint8 *originalData,
+							sint32 originalLength, MPTR callbackFuncMPTR, MPTR callbackParamMPTR) {
+		cemuLog_logDebug(LogType::Force, "_hidSetReportAsync begin");
+		// ToDo: implement this with libusb
+		/*
+		sint32 retryCount = 0;
+		while (true) {
+			BOOL r = HidD_SetOutputReport(hidDeviceInfo->hFile, reportData, length);
+			if (r != FALSE)
+				break;
+			Sleep(20); // retry
+			retryCount++;
+			if (retryCount >= 40) {
+				cemuLog_log(LogType::Force, "HID async SetReport failed");
+				sint32 errorCode = -1;
+				doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidDeviceInfo->handle, errorCode,
+									  memory_getVirtualOffsetFromPointer(originalData), 0);
+				free(reportData);
+				return;
+			}
+		}
+		doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidDeviceInfo->handle, 0,
+							  memory_getVirtualOffsetFromPointer(originalData), originalLength);
+		free(reportData);
+		 */
+	}
+
+	// handler for synchronous HIDSetReport transfers
+	sint32 _hidSetReportSync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *reportData, sint32 length,
+							 uint8 *originalData,
+							 sint32 originalLength, OSThread_t *osThread) {
+		//cemuLog_logDebug(LogType::Force, "_hidSetReportSync begin");
+		_debugPrintHex("_hidSetReportSync Begin", reportData, length);
+		sint32 retryCount = 0;
+		sint32 returnCode = 0;
+		// ToDo: implement this with libusb
+		/*
+		while (true) {
+			BOOL r = HidD_SetOutputReport(hidDeviceInfo->hFile, reportData, length);
+			if (r != FALSE) {
+				returnCode = originalLength;
+				break;
+			}
+			Sleep(100); // retry
+			retryCount++;
+			if (retryCount >= 10)
+				assert_dbg();
+		}
+		 */
+		free(reportData);
+		cemuLog_logDebug(LogType::Force, "_hidSetReportSync end. returnCode: {}", returnCode);
+		coreinit_resumeThread(osThread, 1000);
+		return returnCode;
+	}
+
+	void export_HIDSetReport(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamU32(reportRelatedUkn, 1); // r4
+		ppcDefineParamU32(reportId, 2); // r5
+		ppcDefineParamUStr(data, 3); // r6
+		ppcDefineParamU32(dataLength, 4); // r7
+		ppcDefineParamMPTR(callbackFuncMPTR, 5); // r8
+		ppcDefineParamMPTR(callbackParamMPTR, 6); // r9
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDSetReport({},0x{:02x},0x{:02x},...)", hidHandle, reportRelatedUkn,
+						 reportId);
+
+		_debugPrintHex("HIDSetReport", data, dataLength);
+
+#ifdef CEMU_DEBUG_ASSERT
+		if (reportRelatedUkn != 2 || reportId != 0)
+			assert_dbg();
+#endif
+
+		std::shared_ptr<HIDDeviceInfo> hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle, true);
+		if (hidDeviceInfo == nullptr) {
+			cemuLog_log(LogType::Force, "nsyshid.HIDSetReport(): Unable to find device with hid handle {}", hidHandle);
+			osLib_returnFromFunction(hCPU, -1);
+			return;
+		}
+
+		// prepare report data
+		// note: Currently we need to pad the data to 0x20 bytes for it to work (plus one extra byte for HidD_SetOutputReport)
+		// Does IOSU pad data to 0x20 byte? Also check if this is specific to Skylanders portal
+		sint32 paddedLength = (dataLength + 0x1F) & ~0x1F;
+		uint8 *reportData = (uint8 *) malloc(paddedLength + 1);
+		memset(reportData, 0, paddedLength + 1);
+		reportData[0] = 0;
+		memcpy(reportData + 1, data, dataLength);
+
+
+		// issue request (synchronous or asynchronous)
+		sint32 returnCode = 0;
+		if (callbackFuncMPTR == MPTR_NULL) {
+			std::future<sint32> res = std::async(std::launch::async, &_hidSetReportSync, hidDeviceInfo, reportData,
+												 paddedLength + 1, data, dataLength,
+												 coreinitThread_getCurrentThreadDepr(hCPU));
+			coreinit_suspendThread(coreinitThread_getCurrentThreadDepr(hCPU), 1000);
+			PPCCore_switchToScheduler();
+			returnCode = res.get();
+		} else {
+			// asynchronous
+			std::thread(&_hidSetReportAsync, hidDeviceInfo, reportData, paddedLength + 1, data, dataLength,
+						callbackFuncMPTR, callbackParamMPTR).detach();
+			returnCode = 0;
+		}
+		osLib_returnFromFunction(hCPU, returnCode);
+	}
+
+	sint32 _hidReadInternalSync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength) {
+		sint32 returnCode = 0;
+		if (hidDeviceInfo->libusbHandle == nullptr) {
+			cemuLog_logDebug(LogType::Force, "nsyshid: cannot read from a non-opened device");
+			return -1;
+		}
+		memset(data, 0, maxLength);
+
+		const unsigned int timeout = 50;
+		int actualLength;
+		int ret = 0;
+		do {
+			ret = libusb_bulk_transfer(hidDeviceInfo->libusbHandle,
+									   hidDeviceInfo->libusbEndpointIn,
+									   data,
+									   maxLength,
+									   &actualLength,
+									   timeout);
+		} while (ret == LIBUSB_ERROR_TIMEOUT && actualLength == 0);
+
+		if (ret == 0 || ret == LIBUSB_ERROR_TIMEOUT) {
+			// success
+			cemuLog_logDebug(LogType::Force, "nsyshid.hidReadInternalSync(): read: {} of {} bytes",
+							 actualLength,
+							 maxLength);
+			returnCode = actualLength;
+		} else {
+			cemuLog_logDebug(LogType::Force, "nsyshid.hidReadInternalSync(): libusb read error: {}", ret);
+			returnCode = -1;
+		}
+
+		return returnCode;
+	}
+
+	void
+	_hidReadAsync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength, MPTR callbackFuncMPTR,
+				  MPTR callbackParamMPTR) {
+		sint32 returnCode = _hidReadInternalSync(hidDeviceInfo, data, maxLength);
+		sint32 errorCode = 0;
+		if (returnCode < 0)
+			errorCode = returnCode; // dont return number of bytes in error code
+		doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidDeviceInfo->handle, errorCode,
+							  memory_getVirtualOffsetFromPointer(data), (returnCode > 0) ? returnCode : 0);
+	}
+
+	sint32
+	_hidReadSync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength, OSThread_t *osThread) {
+		sint32 returnCode = _hidReadInternalSync(hidDeviceInfo, data, maxLength);
+		coreinit_resumeThread(osThread, 1000);
+		return returnCode;
+	}
+
+	void export_HIDRead(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamUStr(data, 1); // r4
+		ppcDefineParamU32(maxLength, 2); // r5
+		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
+		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDRead(0x{:x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3],
+						 hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+
+		std::shared_ptr<HIDDeviceInfo> hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle, true);
+		if (hidDeviceInfo == nullptr) {
+			cemuLog_log(LogType::Force, "nsyshid.HIDRead(): Unable to find device with hid handle {}", hidHandle);
+			osLib_returnFromFunction(hCPU, -1);
+			return;
+		}
+		sint32 returnCode = 0;
+		if (callbackFuncMPTR != MPTR_NULL) {
+			// asynchronous transfer
+			std::thread(&_hidReadAsync, hidDeviceInfo, data, maxLength, callbackFuncMPTR, callbackParamMPTR).detach();
+			returnCode = 0;
+		} else {
+			// synchronous transfer
+			std::future<sint32> res = std::async(std::launch::async, &_hidReadSync, hidDeviceInfo, data, maxLength,
+												 coreinitThread_getCurrentThreadDepr(hCPU));
+			coreinit_suspendThread(coreinitThread_getCurrentThreadDepr(hCPU), 1000);
+			PPCCore_switchToScheduler();
+			returnCode = res.get();
+		}
+
+		osLib_returnFromFunction(hCPU, returnCode);
+	}
+
+	sint32 _hidWriteInternalSync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength) {
+		cemuLog_logDebug(LogType::Force, "HidWrite Begin (Length 0x{:08x})", maxLength);
+		if (hidDeviceInfo->libusbHandle == nullptr) {
+			cemuLog_logDebug(LogType::Force, "nsyshid: cannot write to a non-opened device");
+			return -1;
+		}
+		int actualLength;
+		int ret = 0;
+		ret = libusb_bulk_transfer(hidDeviceInfo->libusbHandle,
+								   hidDeviceInfo->libusbEndpointOut,
+								   data,
+								   maxLength,
+								   &actualLength,
+								   0);
+		sint32 returnCode = 0;
+		if (ret == 0) {
+			// success
+			returnCode = maxLength;
+			cemuLog_logDebug(LogType::Force, "nsyshid: write: written {} of {} bytes", actualLength, maxLength);
+		} else {
+			cemuLog_logDebug(LogType::Force, "nsyshid: libusb write error: {}", ret);
+			returnCode = -1;
+		}
+		return returnCode;
+	}
+
+	void
+	_hidWriteAsync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength, MPTR callbackFuncMPTR,
+				   MPTR callbackParamMPTR) {
+		sint32 returnCode = _hidWriteInternalSync(hidDeviceInfo, data, maxLength);
+		sint32 errorCode = 0;
+		if (returnCode < 0)
+			errorCode = returnCode; // dont return number of bytes in error code
+		doHIDTransferCallback(callbackFuncMPTR, callbackParamMPTR, hidDeviceInfo->handle, errorCode,
+							  memory_getVirtualOffsetFromPointer(data), (returnCode > 0) ? returnCode : 0);
+	}
+
+	sint32
+	_hidWriteSync(std::shared_ptr<HIDDeviceInfo> hidDeviceInfo, uint8 *data, sint32 maxLength, OSThread_t *osThread) {
+		sint32 returnCode = _hidWriteInternalSync(hidDeviceInfo, data, maxLength);
+		coreinit_resumeThread(osThread, 1000);
+		return returnCode;
+	}
+
+	void export_HIDWrite(PPCInterpreter_t *hCPU) {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		ppcDefineParamU32(hidHandle, 0); // r3
+		ppcDefineParamUStr(data, 1); // r4
+		ppcDefineParamU32(maxLength, 2); // r5
+		ppcDefineParamMPTR(callbackFuncMPTR, 3); // r6
+		ppcDefineParamMPTR(callbackParamMPTR, 4); // r7
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDWrite(0x{:x},0x{:08x},0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3],
+						 hCPU->gpr[4], hCPU->gpr[5], hCPU->gpr[6], hCPU->gpr[7]);
+
+		std::shared_ptr<HIDDeviceInfo> hidDeviceInfo = getHIDDeviceInfoByHandle(hidHandle, true);
+		if (hidDeviceInfo == nullptr) {
+			cemuLog_log(LogType::Force, "nsyshid.HIDWrite(): Unable to find device with hid handle {}", hidHandle);
+			osLib_returnFromFunction(hCPU, -1);
+			return;
+		}
+		sint32 returnCode = 0;
+		if (callbackFuncMPTR != MPTR_NULL) {
+			// asynchronous transfer
+			std::thread(&_hidWriteAsync, hidDeviceInfo, data, maxLength, callbackFuncMPTR, callbackParamMPTR).detach();
+			returnCode = 0;
+		} else {
+			// synchronous transfer
+			std::future<sint32> res = std::async(std::launch::async, &_hidWriteSync, hidDeviceInfo, data, maxLength,
+												 coreinitThread_getCurrentThreadDepr(hCPU));
+			coreinit_suspendThread(coreinitThread_getCurrentThreadDepr(hCPU), 1000);
+			PPCCore_switchToScheduler();
+			returnCode = res.get();
+		}
+
+		osLib_returnFromFunction(hCPU, returnCode);
+	}
+
+	void export_HIDDecodeError(PPCInterpreter_t *hCPU) {
+		ppcDefineParamU32(errorCode, 0);
+		ppcDefineParamTypePtr(ukn0, uint32be, 1);
+		ppcDefineParamTypePtr(ukn1, uint32be, 2);
+		cemuLog_logDebug(LogType::Force, "nsyshid.HIDDecodeError(0x{:08x},0x{:08x},0x{:08x})", hCPU->gpr[3],
+						 hCPU->gpr[4], hCPU->gpr[5]);
+
+		// todo
+		*ukn0 = 0x3FF;
+		*ukn1 = (uint32) -0x7FFF;
+
+		osLib_returnFromFunction(hCPU, 0);
+	}
+
+	int hotplug_callback(struct libusb_context *ctx, struct libusb_device *dev,
+						 libusb_hotplug_event event, void *user_data) {
+		struct libusb_device_descriptor desc;
+		int ret = libusb_get_device_descriptor(dev, &desc);
+		if (ret < 0) {
+			cemuLog_logDebug(LogType::Force, "nsyshid.hotplug_callback(): failed to get device descriptor");
+			return 0;
+		}
+
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+
+		switch (event) {
+			case LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED: {
+				cemuLog_logDebug(LogType::Force, "nsyshid.hotplug_callback(): device arrived: {:04x}:{:04x}",
+								 desc.idVendor,
+								 desc.idProduct);
+				HIDClient_t *clientItr = firstHIDClient;
+				std::shared_ptr<HIDDeviceInfo> device = checkAndAddDevice(dev);
+				while (clientItr) {
+					doAttachCallbackAsync(clientItr, device);
+					clientItr = clientItr->next;
+				}
+			}
+				break;
+			case LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT: {
+				cemuLog_logDebug(LogType::Force, "nsyshid.hotplug_callback(): device left: {:04x}:{:04x}",
+								 desc.idVendor,
+								 desc.idProduct);
+				removeDevice(dev);
+			}
+				break;
+		}
+		return 0;
+	}
+
+	class LibusbInitWrapper {
+	public:
+		LibusbInitWrapper() : callbackRegistered(false) {
+			initReturnCode = libusb_init(&libusbContext);
+			if (initReturnCode < 0) {
+				libusbContext = nullptr;
+				cemuLog_logDebug(LogType::Force, "nsyshid: failed to initialize libusb with return code %i",
+								 initReturnCode);
+				return;
+			}
+			//libusb_set_option(nullptr, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
+			if (libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
+				int ret = libusb_hotplug_register_callback(libusbContext,
+														   LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |
+														   LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,
+														   0,
+														   LIBUSB_HOTPLUG_MATCH_ANY,
+														   LIBUSB_HOTPLUG_MATCH_ANY,
+														   LIBUSB_HOTPLUG_MATCH_ANY,
+														   hotplug_callback,
+														   nullptr,
+														   &hotplugCallbackHandle);
+				if (ret != LIBUSB_SUCCESS) {
+					cemuLog_logDebug(LogType::Force, "nsyshid: failed to register hotplug callback with return code %i",
+									 ret);
+				} else {
+					cemuLog_logDebug(LogType::Force, "nsyshid: registered hotplug callback");
+					callbackRegistered = true;
+					auto hotplugThread = std::thread([] {
+						while (true) {
+							libusb_handle_events_completed(libusbContext, nullptr);
+							std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+						}
+					});
+					hotplugThread.detach();
+				}
+			} else {
+				cemuLog_logDebug(LogType::Force, "nsyshid: hotplug not supported by this version of libusb");
+			}
+		}
+
+		~LibusbInitWrapper() {
+			libusb_exit(libusbContext);
+			libusbContext = nullptr;
+		}
+
+		bool isInitialized() {
+			return initReturnCode == 0;
+		}
+
+	private:
+		int initReturnCode;
+		bool callbackRegistered;
+		libusb_hotplug_callback_handle hotplugCallbackHandle;
+	};
+
+	void load() {
+		std::lock_guard<std::recursive_mutex> lock(hidMutex);
+		static LibusbInitWrapper libusbInitialized;
+		if (!libusbInitialized.isInitialized()) {
+			return;
+		}
+		osLib_addFunction("nsyshid", "HIDAddClient", export_HIDAddClient);
+		osLib_addFunction("nsyshid", "HIDDelClient", export_HIDDelClient);
+		osLib_addFunction("nsyshid", "HIDGetDescriptor", export_HIDGetDescriptor);
+		osLib_addFunction("nsyshid", "HIDSetIdle", export_HIDSetIdle);
+		osLib_addFunction("nsyshid", "HIDSetProtocol", export_HIDSetProtocol);
+		osLib_addFunction("nsyshid", "HIDSetReport", export_HIDSetReport);
+
+		osLib_addFunction("nsyshid", "HIDRead", export_HIDRead);
+		osLib_addFunction("nsyshid", "HIDWrite", export_HIDWrite);
+
+		osLib_addFunction("nsyshid", "HIDDecodeError", export_HIDDecodeError);
+		firstHIDClient = nullptr;
+	}
+}
+
 #else
 
 namespace nsyshid
@@ -839,6 +1847,5 @@ namespace nsyshid
 		// unimplemented
 	};
 };
-
 
 #endif


### PR DESCRIPTION
This adds USB hid support to the linux build using libusb.

Works nicely with the Lego Dimensions portal (and has seen several hours of (ab)use); I can't test with any other devices though because I don't own them or the games that use them.

Libusb needs to be installed as a system dependency.

To be able to use a device, one needs to add some udev rules. For example to use the Lego Dimensions portal, you'd need to create a file `/etc/udev/rules.d/99-lego-dimensions-portal.rules` with the following contents:

```
# allow applications to talk to the lego dimensions portal
# place this file in '/etc/udev/rules.d/'
# after that you need to reboot or run 'sudo udevadm control --reload' and replug the device for the rules to apply
SUBSYSTEM=="usb", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0241", MODE="0666"
```

Some things aren't implemented, but it seems like they are not needed for Lego Dimensions to function properly.

This has been cooking for a while (and at least somewhat working since may 2023). I always told myself that I would implement the missing stuff, but never got around to it :sweat_smile:  
So, since at least the device I wanted to support seems to work very well, I'm just gonna declare this as ready now.

Note that I am not experienced at all when it comes to working with usb devices or libusb. Suggestions how to improve this are very welcome :)

One neat thing that is included here as well is hotplug support - having to restart the game because of a flaky USB connection drove me mad enough to add this.
For hotplug support there needs to be someone that regularily calls `libusb_handle_events_completed`. I did this with a separate thread, but feel like there should be a better place to call this from.

Originally, I wanted to wrap only the parts that were different in preprocessor statements, but I ended up changing a bunch of other stuff as well and have no way to (easily) test on windows, so the implementation using libusb is completely separate from the native windows one.

Should ideally close #275 but, as I said above, I've got no way to test devices other than the Lego Dimensions portal.

Flatpak build: Shouldn't cause any issues, because `libusb` is already bundled by the line `- shared-modules/libusb/libusb.json` in the `modules` section of `info.cemu.Cemu.yml`.
AppImage: Seems to assume that `libusb` is part of the base system because it is on the [excludelist](https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludelist) and thus shouldn't cause any issues either.

This might also work on macOS if we were to bundle libusb (and in `nsyshid.cpp` the `#elif __linux__` is replaced by something like `#elif __unix__` and we always link against libusb by replacing `if (UNIX AND NOT APPLE)` with `if (UNIX)` in `src/Cafe/CMakeLists.txt`), but I don't know anything about macOS USB handling / permissions and have no way to test on that OS.

Things that I'd have liked to add, but am not planning to, and probably belong in another pr anyways:

- device whitelist - Currently, this exposes all USB devices to the emulated Wii U
- proper device descriptor passthrough - `export_HIDGetDescriptor` creates pretty much the same config descriptor for all devices