### PR TITLE
Localization improvements and fixes

### DIFF
--- a/src/Cafe/Account/Account.h
+++ b/src/Cafe/Account/Account.h
@@ -16,22 +16,6 @@ enum class OnlineAccountError
 	kPasswordCacheEmpty,
 	kNoPrincipalId,
 };
-template <>
-struct fmt::formatter<OnlineAccountError> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(const OnlineAccountError v, FormatContext& ctx) {
-		switch (v)
-		{
-		case OnlineAccountError::kNoAccountId: return formatter<string_view>::format("AccountId missing (The account is not connected to a NNID)", ctx);
-		case OnlineAccountError::kNoPasswordCached: return formatter<string_view>::format("IsPasswordCacheEnabled is set to false (The remember password option on your Wii U must be enabled for this account before dumping it)", ctx);
-		case OnlineAccountError::kPasswordCacheEmpty: return formatter<string_view>::format("AccountPasswordCache is empty (The remember password option on your Wii U must be enabled for this account before dumping it)", ctx);
-		case OnlineAccountError::kNoPrincipalId: return formatter<string_view>::format("PrincipalId missing", ctx);
-		default: break;
-		}
-		return formatter<string_view>::format("no error", ctx);
-	}
-};
-
 
 struct OnlineValidator
 {

--- a/src/Cafe/Filesystem/FST/KeyCache.cpp
+++ b/src/Cafe/Filesystem/FST/KeyCache.cpp
@@ -1,5 +1,6 @@
 #include <wx/msgdlg.h>
 #include <mutex>
+#include <gui/helpers/wxHelpers.h>
 
 #include "config/ActiveSettings.h"
 #include "util/crypto/aes128.h"
@@ -107,7 +108,7 @@ void KeyCache_Prepare()
 			continue;
 		if( strishex(line) == false )
 		{
-			auto errorMsg = fmt::format(fmt::runtime(_("Error in keys.txt at line {}").utf8_string()), lineNumber);
+			auto errorMsg = formatWxString(_("Error in keys.txt at line {}"), lineNumber);
 			wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 			continue;
 		}

--- a/src/Cafe/Filesystem/FST/KeyCache.cpp
+++ b/src/Cafe/Filesystem/FST/KeyCache.cpp
@@ -107,7 +107,7 @@ void KeyCache_Prepare()
 			continue;
 		if( strishex(line) == false )
 		{
-			auto errorMsg = fmt::format(fmt::runtime(_("Error in keys.txt at line {}").ToStdString()), lineNumber);
+			auto errorMsg = fmt::format(fmt::runtime(_("Error in keys.txt at line {}").utf8_string()), lineNumber);
 			wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 			continue;
 		}

--- a/src/Cafe/Filesystem/FST/KeyCache.cpp
+++ b/src/Cafe/Filesystem/FST/KeyCache.cpp
@@ -74,7 +74,7 @@ void KeyCache_Prepare()
 		}
 		else
 		{
-			wxMessageBox("Unable to create file keys.txt\nThis can happen if Cemu does not have write permission to it's own directory, the disk is full or if anti-virus software is blocking Cemu.", "Error", wxOK | wxCENTRE | wxICON_ERROR);
+			wxMessageBox(_("Unable to create file keys.txt\nThis can happen if Cemu does not have write permission to its own directory, the disk is full or if anti-virus software is blocking Cemu."), _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 		}
 		mtxKeyCache.unlock();
 		return;
@@ -107,10 +107,8 @@ void KeyCache_Prepare()
 			continue;
 		if( strishex(line) == false )
 		{
-			// show error message
-			char errorMsg[512];
-			sprintf(errorMsg, "Error in keys.txt in line %d\n", lineNumber);
-			wxMessageBox(errorMsg, "Error", wxOK | wxCENTRE | wxICON_ERROR);
+			auto errorMsg = fmt::format(fmt::runtime(_("Error in keys.txt at line {}").ToStdString()), lineNumber);
+			wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 			continue;
 		}
 		if(line.size() == 32 )

--- a/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
@@ -43,9 +43,9 @@ void PatchErrorHandler::showStageErrorMessageBox()
 	if (m_gp)
 	{
 		if (m_stage == STAGE::PARSER)
-			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to load patches for graphic pack \'{}\'").ToStdString()), m_gp->GetName()));
+			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to load patches for graphic pack \'{}\'").utf8_string()), m_gp->GetName()));
 		else
-			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to apply patches for graphic pack \'{}\'").ToStdString()), m_gp->GetName()));
+			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to apply patches for graphic pack \'{}\'").utf8_string()), m_gp->GetName()));
 	}
 	else
 	{

--- a/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
@@ -6,6 +6,7 @@
 #include "boost/algorithm/string.hpp"
 
 #include "gui/wxgui.h" // for wxMessageBox
+#include "gui/helpers/wxHelpers.h"
 
 // error handler
 void PatchErrorHandler::printError(class PatchGroup* patchGroup, sint32 lineNumber, std::string_view errorMsg)
@@ -39,13 +40,13 @@ void PatchErrorHandler::printError(class PatchGroup* patchGroup, sint32 lineNumb
 
 void PatchErrorHandler::showStageErrorMessageBox()
 {
-	std::string errorMsg;
+	wxString errorMsg;
 	if (m_gp)
 	{
 		if (m_stage == STAGE::PARSER)
-			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to load patches for graphic pack \'{}\'").utf8_string()), m_gp->GetName()));
+			errorMsg.assign(formatWxString(_("Failed to load patches for graphic pack \'{}\'"), m_gp->GetName()));
 		else
-			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to apply patches for graphic pack \'{}\'").utf8_string()), m_gp->GetName()));
+			errorMsg.assign(formatWxString(_("Failed to apply patches for graphic pack \'{}\'"), m_gp->GetName()));
 	}
 	else
 	{

--- a/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
@@ -43,9 +43,9 @@ void PatchErrorHandler::showStageErrorMessageBox()
 	if (m_gp)
 	{
 		if (m_stage == STAGE::PARSER)
-			errorMsg.assign(fmt::format("Failed to load patches for graphic pack \'{}\'", m_gp->GetName()));
+			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to load patches for graphic pack \'{}\'").ToStdString()), m_gp->GetName()));
 		else
-			errorMsg.assign(fmt::format("Failed to apply patches for graphic pack \'{}\'", m_gp->GetName()));
+			errorMsg.assign(fmt::format(fmt::runtime(_("Failed to apply patches for graphic pack \'{}\'").ToStdString()), m_gp->GetName()));
 	}
 	else
 	{
@@ -53,7 +53,9 @@ void PatchErrorHandler::showStageErrorMessageBox()
 	}
 	if (cemuLog_isLoggingEnabled(LogType::Patches))
 	{
-		errorMsg.append("\n \nDetails:\n");
+		errorMsg.append("\n \n")
+			.append(_("Details:"))
+			.append("\n");
 		for (auto& itr : errorMessages)
 		{
 			errorMsg.append(itr);
@@ -61,7 +63,7 @@ void PatchErrorHandler::showStageErrorMessageBox()
 		}
 	}
 
-	wxMessageBox(errorMsg, "Graphic pack error");
+	wxMessageBox(errorMsg, _("Graphic pack error"));
 }
 
 // loads Cemu-style patches (patch_<anything>.asm)

--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -792,10 +792,9 @@ void LatteShaderCache_handleDeprecatedCacheFiles(fs::path pathGeneric, fs::path 
 	if (hasOldCacheFiles && !hasNewCacheFiles)
 	{
 		// ask user if they want to delete or keep the old cache file
-		const auto infoMsg = L"Outdated shader cache\n\nCemu detected that the shader cache for this game is outdated\nOnly shader caches generated with Cemu 1.25.0 or above are supported\n\n"
-			"We recommend deleting the outdated cache file as it will no longer be used by Cemu";
+		auto infoMsg = _("Cemu detected that the shader cache for this game is outdated.\nOnly shader caches generated with Cemu 1.25.0 or above are supported.\n\nWe recommend deleting the outdated cache file as it will no longer be used by Cemu.");
 			
-		wxMessageDialog dialog(nullptr, _(infoMsg), _("Outdated shader cache"),
+		wxMessageDialog dialog(nullptr, infoMsg, _("Outdated shader cache"),
 			wxYES_NO | wxCENTRE | wxICON_EXCLAMATION);
 
 		dialog.SetYesNoLabels(_("Delete outdated cache file [recommended]"), _("Keep outdated cache file"));

--- a/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
+++ b/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
@@ -371,7 +371,7 @@ bool DownloadManager::syncAccountTickets()
 	for (auto& tiv : resultTicketIds.tivs)
 	{
 		index++;
-		std::string msg = _("Downloading account ticket").ToStdString();
+		std::string msg = _("Downloading account ticket").utf8_string();
 		msg.append(fmt::format(" {0}/{1}", index, count));
 		setStatusMessage(msg, DLMGR_STATUS_CODE::CONNECTING);
 		// skip if already cached
@@ -508,7 +508,7 @@ bool DownloadManager::syncUpdateTickets()
 		if (titleIdParser.GetType() != TitleIdParser::TITLE_TYPE::BASE_TITLE_UPDATE)
 			continue;
 
-		std::string msg = _("Downloading ticket").ToStdString();
+		std::string msg = _("Downloading ticket").utf8_string();
 		msg.append(fmt::format(" {0}/{1}", updateIndex, numUpdates));
 		updateIndex++;
 		setStatusMessage(msg, DLMGR_STATUS_CODE::CONNECTING);
@@ -561,7 +561,7 @@ bool DownloadManager::syncTicketCache()
 	for (auto& ticketInfo : m_ticketCache)
 	{
 		index++;
-		std::string msg = _("Downloading meta data").ToStdString();
+		std::string msg = _("Downloading meta data").utf8_string();
 		msg.append(fmt::format(" {0}/{1}", index, count));
 		setStatusMessage(msg, DLMGR_STATUS_CODE::CONNECTING);
 		prepareIDBE(ticketInfo.titleId);
@@ -1054,7 +1054,7 @@ void DownloadManager::asyncPackageDownloadTMD(Package* package)
 	std::unique_lock<std::recursive_mutex> _l(m_mutex);
 	if (!tmdResult.isValid)
 	{
-		setPackageError(package, from_wxString(_("TMD download failed")));
+		setPackageError(package, _("TMD download failed").utf8_string());
 		package->state.isDownloadingTMD = false;
 		return;
 	}
@@ -1063,7 +1063,7 @@ void DownloadManager::asyncPackageDownloadTMD(Package* package)
 	NCrypto::TMDParser tmdParser;
 	if (!tmdParser.parse(tmdResult.tmdData.data(), tmdResult.tmdData.size()))
 	{
-		setPackageError(package, from_wxString(_("Invalid TMD")));
+		setPackageError(package, _("Invalid TMD").utf8_string());
 		package->state.isDownloadingTMD = false;
 		return;
 	}
@@ -1172,7 +1172,7 @@ void DownloadManager::asyncPackageDownloadContentFile(Package* package, uint16 i
 				size_t bytesWritten = callbackInfo->receiveBuffer.size();
 				if (callbackInfo->fileOutput->writeData(callbackInfo->receiveBuffer.data(), callbackInfo->receiveBuffer.size()) != (uint32)callbackInfo->receiveBuffer.size())
 				{
-					callbackInfo->downloadMgr->setPackageError(callbackInfo->package, from_wxString(_("Cannot write file. Disk full?")));
+					callbackInfo->downloadMgr->setPackageError(callbackInfo->package, _("Cannot write file. Disk full?").utf8_string());
 					return false;
 				}
 				callbackInfo->receiveBuffer.clear();
@@ -1193,12 +1193,12 @@ void DownloadManager::asyncPackageDownloadContentFile(Package* package, uint16 i
 	callbackInfoData.fileOutput = FileStream::createFile2(packageDownloadPath / fmt::format("{:08x}.app", contentId));
 	if (!callbackInfoData.fileOutput)
 	{
-		setPackageError(package, from_wxString(_("Cannot create file")));
+		setPackageError(package, _("Cannot create file").utf8_string());
 		return;
 	}
 	if (!NAPI::CCS_GetContentFile(titleId, contentId, CallbackInfo::writeCallback, &callbackInfoData))
 	{
-		setPackageError(package, from_wxString(_("Download failed")));
+		setPackageError(package, _("Download failed").utf8_string());
 		delete callbackInfoData.fileOutput;
 		return;
 	}

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -6,6 +6,7 @@
 #include "Cafe/Account/Account.h"
 
 #include <wx/language.h>
+#include <wx/intl.h>
 
 struct GameEntry
 {
@@ -258,15 +259,15 @@ struct fmt::formatter<CafeConsoleRegion> : formatter<string_view> {
 		string_view name;
 		switch (v)
 		{
-		case CafeConsoleRegion::JPN: name = "Japan"; break;
-		case CafeConsoleRegion::USA: name = "USA"; break;
-		case CafeConsoleRegion::EUR: name = "Europe"; break;
-		case CafeConsoleRegion::AUS_DEPR: name = "Australia"; break;
-		case CafeConsoleRegion::CHN: name = "China"; break;
-		case CafeConsoleRegion::KOR: name = "Korea"; break;
-		case CafeConsoleRegion::TWN: name = "Taiwan"; break;
-		case CafeConsoleRegion::Auto: name = "Auto"; break;
-		default: name = "many"; break;
+		case CafeConsoleRegion::JPN: name = wxTRANSLATE("Japan"); break;
+		case CafeConsoleRegion::USA: name = wxTRANSLATE("USA"); break;
+		case CafeConsoleRegion::EUR: name = wxTRANSLATE("Europe"); break;
+		case CafeConsoleRegion::AUS_DEPR: name = wxTRANSLATE("Australia"); break;
+		case CafeConsoleRegion::CHN: name = wxTRANSLATE("China"); break;
+		case CafeConsoleRegion::KOR: name = wxTRANSLATE("Korea"); break;
+		case CafeConsoleRegion::TWN: name = wxTRANSLATE("Taiwan"); break;
+		case CafeConsoleRegion::Auto: name = wxTRANSLATE("Auto"); break;
+		default: name = wxTRANSLATE("many"); break;
 		
 		}
 		return formatter<string_view>::format(name, ctx);

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -88,7 +88,7 @@ bool CemuApp::OnInit()
 #endif
 	auto failed_write_access = ActiveSettings::LoadOnce(exePath, user_data_path, config_path, cache_path, data_path);
 	for (auto&& path : failed_write_access)
-		wxMessageBox(fmt::format(fmt::runtime(_("Cemu can't write to {}!").ToStdString()), path.generic_string()),
+		wxMessageBox(fmt::format(fmt::runtime(_("Cemu can't write to {}!").utf8_string()), path.generic_string()),
 			_("Warning"), wxOK | wxCENTRE | wxICON_EXCLAMATION, nullptr);
 
 	NetworkConfig::LoadOnce();
@@ -342,7 +342,7 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	catch (const std::exception& ex)
 	{
 		std::stringstream errorMsg;
-		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required mlc01 subfolder or file!\n\nError: {0}\nTarget path:\n{1}").ToStdString()), ex.what(), _pathToUtf8(mlc));
+		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required mlc01 subfolder or file!\n\nError: {0}\nTarget path:\n{1}").utf8_string()), ex.what(), _pathToUtf8(mlc));
 
 #if BOOST_OS_WINDOWS
 		const DWORD lastError = GetLastError();
@@ -368,7 +368,7 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	catch (const std::exception& ex)
 	{
 		std::stringstream errorMsg;
-		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required cemu directory or file!\n\nError: {0}").ToStdString()), ex.what());
+		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required cemu directory or file!\n\nError: {0}").utf8_string()), ex.what());
 
 #if BOOST_OS_WINDOWS
 		const DWORD lastError = GetLastError();

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -88,7 +88,8 @@ bool CemuApp::OnInit()
 #endif
 	auto failed_write_access = ActiveSettings::LoadOnce(exePath, user_data_path, config_path, cache_path, data_path);
 	for (auto&& path : failed_write_access)
-		wxMessageBox(fmt::format("Cemu can't write to {} !", path.generic_string()), _("Warning"), wxOK | wxCENTRE | wxICON_EXCLAMATION, nullptr);
+		wxMessageBox(fmt::format(fmt::runtime(_("Cemu can't write to {}!").ToStdString()), path.generic_string()),
+			_("Warning"), wxOK | wxCENTRE | wxICON_EXCLAMATION, nullptr);
 
 	NetworkConfig::LoadOnce();
 	g_config.Load();
@@ -268,7 +269,7 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	{
 		const std::wstring message = fmt::format(fmt::runtime(_(L"Your mlc01 folder seems to be missing.\n\nThis is where Cemu stores save files, game updates and other Wii U files.\n\nThe expected path is:\n{}\n\nDo you want to create the folder at the expected path?").ToStdWstring()), mlc.wstring());
 		
-		wxMessageDialog dialog(nullptr, message, "Error", wxCENTRE | wxYES_NO | wxCANCEL| wxICON_WARNING);
+		wxMessageDialog dialog(nullptr, message, _("Error"), wxCENTRE | wxYES_NO | wxCANCEL| wxICON_WARNING);
 		dialog.SetYesNoCancelLabels(_("Yes"), _("No"), _("Select a custom path"));
 		const auto dialogResult = dialog.ShowModal();
 		if (dialogResult == wxID_NO)

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -44,16 +44,6 @@ void unused_translation_dummy()
 	void(_("dlc"));
 	void(_("save"));
 
-	void(_("Japan"));
-	void(_("USA"));
-	void(_("Europe"));
-	void(_("Australia"));
-	void(_("China"));
-	void(_("Korea"));
-	void(_("Taiwan"));
-	void(_("Auto"));
-	void(_("many"));
-
 	void(_("Japanese"));
 	void(_("English"));
 	void(_("French"));

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -67,13 +67,6 @@ void unused_translation_dummy()
 	void(_("Russian"));
 	void(_("Taiwanese"));
 	void(_("unknown"));
-
-
-	// account.h
-	void(_("AccountId missing (The account is not connected to a NNID)"));
-	void(_("IsPasswordCacheEnabled is set to false (The remember password option on your Wii U must be enabled for this account before dumping it)"));
-	void(_("AccountPasswordCache is empty (The remember password option on your Wii U must be enabled for this account before dumping it)"));
-	void(_("PrincipalId missing"));
 }
 
 bool CemuApp::OnInit()

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -38,11 +38,6 @@ void unused_translation_dummy()
 	void(_("Browse"));
 	void(_("Select a file"));
 	void(_("Select a directory"));
-	
-	void(_("base"));
-	void(_("update"));
-	void(_("dlc"));
-	void(_("save"));
 
 	void(_("Japanese"));
 	void(_("English"));

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -88,7 +88,7 @@ bool CemuApp::OnInit()
 #endif
 	auto failed_write_access = ActiveSettings::LoadOnce(exePath, user_data_path, config_path, cache_path, data_path);
 	for (auto&& path : failed_write_access)
-		wxMessageBox(fmt::format(fmt::runtime(_("Cemu can't write to {}!").utf8_string()), path.generic_string()),
+		wxMessageBox(formatWxString(_("Cemu can't write to {}!"), path.generic_string()),
 			_("Warning"), wxOK | wxCENTRE | wxICON_EXCLAMATION, nullptr);
 
 	NetworkConfig::LoadOnce();
@@ -267,7 +267,8 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	// check for mlc01 folder missing if custom path has been set
 	if (!fs::exists(mlc) && !first_start)
 	{
-		const std::wstring message = fmt::format(fmt::runtime(_(L"Your mlc01 folder seems to be missing.\n\nThis is where Cemu stores save files, game updates and other Wii U files.\n\nThe expected path is:\n{}\n\nDo you want to create the folder at the expected path?").ToStdWstring()), mlc.wstring());
+		const wxString message = formatWxString(_("Your mlc01 folder seems to be missing.\n\nThis is where Cemu stores save files, game updates and other Wii U files.\n\nThe expected path is:\n{}\n\nDo you want to create the folder at the expected path?"),
+												_pathToUtf8(mlc));
 		
 		wxMessageDialog dialog(nullptr, message, _("Error"), wxCENTRE | wxYES_NO | wxCANCEL| wxICON_WARNING);
 		dialog.SetYesNoCancelLabels(_("Yes"), _("No"), _("Select a custom path"));
@@ -341,16 +342,15 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	}
 	catch (const std::exception& ex)
 	{
-		std::stringstream errorMsg;
-		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required mlc01 subfolder or file!\n\nError: {0}\nTarget path:\n{1}").utf8_string()), ex.what(), _pathToUtf8(mlc));
+		wxString errorMsg = formatWxString(_("Couldn't create a required mlc01 subfolder or file!\n\nError: {0}\nTarget path:\n{1}"), ex.what(), _pathToUtf8(mlc));
 
 #if BOOST_OS_WINDOWS
 		const DWORD lastError = GetLastError();
 		if (lastError != ERROR_SUCCESS)
 			errorMsg << fmt::format("\n\n{}", GetSystemErrorMessage(lastError));
-
-		wxMessageBox(errorMsg.str(), "Error", wxOK | wxCENTRE | wxICON_ERROR);
 #endif
+
+		wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 		exit(0);
 	}
 
@@ -367,17 +367,15 @@ void CemuApp::CreateDefaultFiles(bool first_start)
 	}
 	catch (const std::exception& ex)
 	{
-		std::stringstream errorMsg;
-		errorMsg << fmt::format(fmt::runtime(_("Couldn't create a required cemu directory or file!\n\nError: {0}").utf8_string()), ex.what());
+		wxString errorMsg = formatWxString(_("Couldn't create a required cemu directory or file!\n\nError: {0}"), ex.what());
 
 #if BOOST_OS_WINDOWS
 		const DWORD lastError = GetLastError();
 		if (lastError != ERROR_SUCCESS)
 			errorMsg << fmt::format("\n\n{}", GetSystemErrorMessage(lastError));
-
-
-		wxMessageBox(errorMsg.str(), "Error", wxOK | wxCENTRE | wxICON_ERROR);
 #endif
+
+		wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 		exit(0);
 	}
 }

--- a/src/gui/ChecksumTool.cpp
+++ b/src/gui/ChecksumTool.cpp
@@ -81,8 +81,8 @@ const char kSchema[] = R"(
 
 
 ChecksumTool::ChecksumTool(wxWindow* parent, wxTitleManagerList::TitleEntry& entry)
-	: wxDialog(parent, wxID_ANY, 
-		wxStringFormat2(_("Title checksum of {:08x}-{:08x}"), (uint32)(entry.title_id >> 32), (uint32)(entry.title_id & 0xFFFFFFFF)), 
+	: wxDialog(parent, wxID_ANY,
+		formatWxString(_("Title checksum of {:08x}-{:08x}"), (uint32) (entry.title_id >> 32), (uint32) (entry.title_id & 0xFFFFFFFF)),
 		wxDefaultPosition, wxDefaultSize, wxCAPTION | wxFRAME_TOOL_WINDOW | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxCLOSE_BOX), m_entry(entry)
 {
 
@@ -413,7 +413,7 @@ void ChecksumTool::OnExportChecksums(wxCommandEvent& event)
 	}
 	else
 	{
-		wxMessageBox(wxStringFormat2(_("Can't write to file: {}"), target_file.string()), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+		wxMessageBox(formatWxString(_("Can't write to file: {}"), target_file.string()), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 	}
 }
 
@@ -461,17 +461,17 @@ void ChecksumTool::VerifyJsonEntry(const rapidjson::Document& doc)
 
 		if (m_json_entry.title_id != test_entry.title_id)
 		{
-			wxMessageBox(wxStringFormat2(_("The file you are comparing with is for a different title.")), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+			wxMessageBox(formatWxString(_("The file you are comparing with is for a different title.")), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			return;
 		}
 		if (m_json_entry.version != test_entry.version)
 		{
-			wxMessageBox(wxStringFormat2(_("Wrong version: {}"), test_entry.version), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+			wxMessageBox(formatWxString(_("Wrong version: {}"), test_entry.version), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			return;
 		}
 		if (m_json_entry.region != test_entry.region)
 		{
-			wxMessageBox(wxStringFormat2(_("Wrong region: {}"), test_entry.region), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+			wxMessageBox(formatWxString(_("Wrong region: {}"), test_entry.region), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			return;
 		}
 		if (!m_json_entry.wud_hash.empty())
@@ -483,7 +483,7 @@ void ChecksumTool::VerifyJsonEntry(const rapidjson::Document& doc)
 			}
 			if(!boost::iequals(test_entry.wud_hash, m_json_entry.wud_hash))
 			{
-				wxMessageBox(wxStringFormat2(_("Your game image is invalid!\n\nYour hash:\n{}\n\nExpected hash:\n{}"), m_json_entry.wud_hash, test_entry.wud_hash), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+				wxMessageBox(formatWxString(_("Your game image is invalid!\n\nYour hash:\n{}\n\nExpected hash:\n{}"), m_json_entry.wud_hash, test_entry.wud_hash), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 				return;
 			}
 		}
@@ -563,7 +563,9 @@ void ChecksumTool::VerifyJsonEntry(const rapidjson::Document& doc)
 			}
 			else if (missing_files.empty() && !invalid_hashes.empty())
 			{
-				const int result = wxMessageBox(wxStringFormat2(_("{} files have an invalid hash!\nDo you want to export a list of them to a file?"), invalid_hashes.size()), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR, this);
+				const int result = wxMessageBox(formatWxString(
+						_("{} files have an invalid hash!\nDo you want to export a list of them to a file?"),
+						invalid_hashes.size()), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR, this);
 				if (result == wxYES)
 				{
 					writeMismatchInfoToLog();
@@ -572,7 +574,9 @@ void ChecksumTool::VerifyJsonEntry(const rapidjson::Document& doc)
 			}
 			else if (!missing_files.empty() && !invalid_hashes.empty())
 			{
-				const int result = wxMessageBox(wxStringFormat2(_("Multiple issues with your game files have been found!\nDo you want to export them to a file?"), invalid_hashes.size()), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR, this);
+				const int result = wxMessageBox(formatWxString(
+						_("Multiple issues with your game files have been found!\nDo you want to export them to a file?"),
+						invalid_hashes.size()), _("Error"), wxYES_NO | wxCENTRE | wxICON_ERROR, this);
 				if (result == wxYES)
 				{
 					writeMismatchInfoToLog();
@@ -584,7 +588,7 @@ void ChecksumTool::VerifyJsonEntry(const rapidjson::Document& doc)
 	}
 	catch (const std::exception& ex)
 	{
-		wxMessageBox(wxStringFormat2(_("JSON parse error: {}"), ex.what()), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+		wxMessageBox(formatWxString(_("JSON parse error: {}"), ex.what()), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 	}
 
 }
@@ -680,7 +684,7 @@ void ChecksumTool::DoWork()
 	case TitleInfo::TitleDataFormat::WUD:
 	{
 		const auto path = m_entry.path.string();
-		wxQueueEvent(this, new wxSetGaugeValue(1, m_progress, m_status, wxStringFormat2(_("Reading game image: {}"), path)));
+		wxQueueEvent(this, new wxSetGaugeValue(1, m_progress, m_status, formatWxString(_("Reading game image: {}"), path)));
 
 		wud_t* wud = wud_open(m_info.GetPath());
 		if (!wud)
@@ -709,11 +713,11 @@ void ChecksumTool::DoWork()
 
 			EVP_DigestUpdate(sha256, buffer.data(), read);
 
-			wxQueueEvent(this, new wxSetGaugeValue((int)((offset * 90) / wud_size), m_progress, m_status, wxStringFormat2(_("Reading game image: {0}/{1} kB"), offset / 1024, wud_size / 1024)));
+			wxQueueEvent(this, new wxSetGaugeValue((int)((offset * 90) / wud_size), m_progress, m_status, formatWxString(_("Reading game image: {0}/{1} kB"), offset / 1024, wud_size / 1024)));
 		} while (read != 0 && size > 0);
 		wud_close(wud);
 
-		wxQueueEvent(this, new wxSetGaugeValue(90, m_progress, m_status, wxStringFormat2(_("Generating checksum of game image: {}"), path)));
+		wxQueueEvent(this, new wxSetGaugeValue(90, m_progress, m_status, formatWxString(_("Generating checksum of game image: {}"), path)));
 
 		if (!m_running.load(std::memory_order_relaxed))
 			return;
@@ -729,7 +733,7 @@ void ChecksumTool::DoWork()
 
 		m_json_entry.wud_hash = str.str();
 
-		wxQueueEvent(this, new wxSetGaugeValue(100, m_progress, m_status, wxStringFormat2(_("Generated checksum of game image: {}"), path)));
+		wxQueueEvent(this, new wxSetGaugeValue(100, m_progress, m_status, formatWxString(_("Generated checksum of game image: {}"), path)));
 		break;
 	}
 	default:
@@ -765,7 +769,7 @@ void ChecksumTool::DoWork()
 			m_json_entry.file_hashes[filename] = str.str();
 
 			++counter;
-			wxQueueEvent(this, new wxSetGaugeValue((int)((counter * 100) / file_count), m_progress, m_status, wxStringFormat2(_("Hashing game file: {}/{}"), counter, file_count)));
+			wxQueueEvent(this, new wxSetGaugeValue((int)((counter * 100) / file_count), m_progress, m_status, formatWxString(_("Hashing game file: {}/{}"), counter, file_count)));
 
 			if (!m_running.load(std::memory_order_relaxed))
 			{
@@ -775,7 +779,7 @@ void ChecksumTool::DoWork()
 		}
 		m_info.Unmount(temporaryMountPath.c_str());
 
-		wxQueueEvent(this, new wxSetGaugeValue(100, m_progress, m_status, wxStringFormat2(_("Generated checksum of {} game files"), file_count)));
+		wxQueueEvent(this, new wxSetGaugeValue(100, m_progress, m_status, formatWxString(_("Generated checksum of {} game files"), file_count)));
 		break;
 	}
 }

--- a/src/gui/ChecksumTool.cpp
+++ b/src/gui/ChecksumTool.cpp
@@ -610,7 +610,7 @@ void ChecksumTool::OnVerifyOnline(wxCommandEvent& event)
 	d.ParseStream(str);
 	if (d.HasParseError())
 	{
-		wxMessageBox(_("Can't parse json file!"), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+		wxMessageBox(_("Can't parse JSON file!"), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}
 
@@ -638,7 +638,7 @@ void ChecksumTool::OnVerifyLocal(wxCommandEvent& event)
 	d.ParseStream(str);
 	if (d.HasParseError())
 	{
-		wxMessageBox(_("Can't parse json file!"), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
+		wxMessageBox(_("Can't parse JSON file!"), _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}
 

--- a/src/gui/GameProfileWindow.cpp
+++ b/src/gui/GameProfileWindow.cpp
@@ -166,7 +166,7 @@ GameProfileWindow::GameProfileWindow(wxWindow* parent, uint64_t title_id)
 
 		for (int i = 0; i < 8; ++i)
 		{
-			profile_sizer->Add(new wxStaticText(panel, wxID_ANY, fmt::format("{} {}", _("Controller").ToStdString(), (i + 1))), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+			profile_sizer->Add(new wxStaticText(panel, wxID_ANY, fmt::format("{} {}", _("Controller").utf8_string(), (i + 1))), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 			m_controller_profile[i] = new wxComboBox(panel, wxID_ANY,"", wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_DROPDOWN| wxCB_READONLY);
 			m_controller_profile[i]->SetMinSize(wxSize(250, -1));
@@ -244,7 +244,7 @@ void GameProfileWindow::SetProfileInt(gameProfileIntegerOption_t& option, wxChec
 void GameProfileWindow::ApplyProfile()
 {
 	if(m_game_profile.m_gameName)
-		this->SetTitle(fmt::format("{} - {}", _("Edit game profile").ToStdString(), m_game_profile.m_gameName.value()));
+		this->SetTitle(fmt::format("{} - {}", _("Edit game profile").utf8_string(), m_game_profile.m_gameName.value()));
 
 	// general
 	m_load_libs->SetValue(m_game_profile.m_loadSharedLibraries.value());

--- a/src/gui/GameUpdateWindow.cpp
+++ b/src/gui/GameUpdateWindow.cpp
@@ -60,8 +60,8 @@ bool GameUpdateWindow::ParseUpdate(const fs::path& metaPath)
 					std::string typeStrToInstall = _GetTitleIdTypeStr(m_title_info.GetAppTitleId());
 					std::string typeStrCurrentlyInstalled = _GetTitleIdTypeStr(tmp.GetAppTitleId());
 
-					std::string wxMsg = wxHelper::MakeUTF8(_("It seems that there is already a title installed at the target location but it has a different type.\nCurrently installed: \'{}\' Installing: \'{}\'\n\nThis can happen for titles which were installed with very old Cemu versions.\nDo you still want to continue with the installation? It will replace the currently installed title."));
-					wxMessageDialog dialog(this, fmt::format(fmt::runtime(wxMsg), typeStrCurrentlyInstalled, typeStrToInstall), _("Warning"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
+					auto wxMsg = _("It seems that there is already a title installed at the target location but it has a different type.\nCurrently installed: \'{}\' Installing: \'{}\'\n\nThis can happen for titles which were installed with very old Cemu versions.\nDo you still want to continue with the installation? It will replace the currently installed title.");
+					wxMessageDialog dialog(this, formatWxString(wxMsg, typeStrCurrentlyInstalled, typeStrToInstall), _("Warning"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
 					if (dialog.ShowModal() != wxID_YES)
 						return false;
 				}
@@ -90,7 +90,7 @@ bool GameUpdateWindow::ParseUpdate(const fs::path& metaPath)
 
 				if (ec)
 				{
-					const auto error_msg = wxStringFormat2(_("Error when trying to move former title installation:\n{}"), GetSystemErrorMessage(ec));
+					const auto error_msg = formatWxString(_("Error when trying to move former title installation:\n{}"), GetSystemErrorMessage(ec));
 					wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 					return false;
 				}

--- a/src/gui/GameUpdateWindow.cpp
+++ b/src/gui/GameUpdateWindow.cpp
@@ -16,18 +16,18 @@ std::string _GetTitleIdTypeStr(TitleId titleId)
 	switch (tip.GetType())
 	{
 	case TitleIdParser::TITLE_TYPE::AOC:
-		return _("DLC").ToStdString();
+		return _("DLC").utf8_string();
 	case TitleIdParser::TITLE_TYPE::BASE_TITLE:
-		return _("Base game").ToStdString();
+		return _("Base game").utf8_string();
 	case TitleIdParser::TITLE_TYPE::BASE_TITLE_DEMO:
-		return _("Demo").ToStdString();
+		return _("Demo").utf8_string();
 	case TitleIdParser::TITLE_TYPE::SYSTEM_TITLE:
 	case TitleIdParser::TITLE_TYPE::SYSTEM_OVERLAY_TITLE:
-		return _("System title").ToStdString();
+		return _("System title").utf8_string();
 	case TitleIdParser::TITLE_TYPE::SYSTEM_DATA:
-		return _("System data title").ToStdString();
+		return _("System data title").utf8_string();
 	case TitleIdParser::TITLE_TYPE::BASE_TITLE_UPDATE:
-		return _("Update").ToStdString();
+		return _("Update").utf8_string();
 	default:
 		break;
 	}
@@ -244,7 +244,7 @@ void GameUpdateWindow::ThreadWork()
 		error_msg << GetSystemErrorMessage(ex);
 
 		if(currentDirEntry != fs::directory_entry{})
-			error_msg << fmt::format("\n{}\n{}",_("Current file:").ToStdString(), _pathToUtf8(currentDirEntry.path()));
+			error_msg << fmt::format("\n{}\n{}",_("Current file:").utf8_string(), _pathToUtf8(currentDirEntry.path()));
 
 		m_thread_exception = error_msg.str();
 		m_thread_state = ThreadCanceled;

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -2036,9 +2036,25 @@ void GeneralSettings2::OnShowOnlineValidator(wxCommandEvent& event)
 
 	if (!validator.valid_account)
 	{
-		err << _("The currently selected account is not a valid or dumped online account:") << fmt::format("\n{}", validator.account_error);
+		err << _("The currently selected account is not a valid or dumped online account:") << '\n';
+		err << GetOnlineAccountErrorMessage(validator.account_error);
 	}
-		
-	
+
 	wxMessageBox(err, _("Online Status"), wxOK | wxCENTRE | wxICON_INFORMATION);
+}
+
+std::string GeneralSettings2::GetOnlineAccountErrorMessage(OnlineAccountError error)
+{
+	switch (error) {
+		case OnlineAccountError::kNoAccountId:
+			return _("AccountId missing (The account is not connected to a NNID)").ToStdString();
+		case OnlineAccountError::kNoPasswordCached:
+			return _("IsPasswordCacheEnabled is set to false (The remember password option on your Wii U must be enabled for this account before dumping it)").ToStdString();
+		case OnlineAccountError::kPasswordCacheEmpty:
+			return _("AccountPasswordCache is empty (The remember password option on your Wii U must be enabled for this account before dumping it)").ToStdString();
+		case OnlineAccountError::kNoPrincipalId:
+			return _("PrincipalId missing").ToStdString();
+		default:
+			return "no error";
+	}
 }

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -2047,13 +2047,13 @@ std::string GeneralSettings2::GetOnlineAccountErrorMessage(OnlineAccountError er
 {
 	switch (error) {
 		case OnlineAccountError::kNoAccountId:
-			return _("AccountId missing (The account is not connected to a NNID)").ToStdString();
+			return _("AccountId missing (The account is not connected to a NNID)").utf8_string();
 		case OnlineAccountError::kNoPasswordCached:
-			return _("IsPasswordCacheEnabled is set to false (The remember password option on your Wii U must be enabled for this account before dumping it)").ToStdString();
+			return _("IsPasswordCacheEnabled is set to false (The remember password option on your Wii U must be enabled for this account before dumping it)").utf8_string();
 		case OnlineAccountError::kPasswordCacheEmpty:
-			return _("AccountPasswordCache is empty (The remember password option on your Wii U must be enabled for this account before dumping it)").ToStdString();
+			return _("AccountPasswordCache is empty (The remember password option on your Wii U must be enabled for this account before dumping it)").utf8_string();
 		case OnlineAccountError::kNoPrincipalId:
-			return _("PrincipalId missing").ToStdString();
+			return _("PrincipalId missing").utf8_string();
 		default:
 			return "no error";
 	}

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -2001,44 +2001,44 @@ void GeneralSettings2::OnShowOnlineValidator(wxCommandEvent& event)
 	if (validator) // everything valid? shouldn't happen
 		return;
 	
-	std::wstringstream err;
-	err << L"The following error(s) have been found:" << std::endl;
+	wxString err;
+	err << _("The following error(s) have been found:") << '\n';
 	
 	if (validator.otp == OnlineValidator::FileState::Missing)
-		err << L"otp.bin missing in cemu root directory" << std::endl;
+		err << _("otp.bin missing in Cemu root directory") << '\n';
 	else if(validator.otp == OnlineValidator::FileState::Corrupted)
-		err << L"otp.bin is invalid" << std::endl;
+		err << _("otp.bin is invalid") << '\n';
 	
 	if (validator.seeprom == OnlineValidator::FileState::Missing)
-		err << L"seeprom.bin missing in cemu root directory" << std::endl;
+		err << _("seeprom.bin missing in Cemu root directory") << '\n';
 	else if(validator.seeprom == OnlineValidator::FileState::Corrupted)
-		err << L"seeprom.bin is invalid" << std::endl;
+		err << _("seeprom.bin is invalid") << '\n';
 
 	if(!validator.missing_files.empty())
 	{
-		err << L"Missing certificate and key files:" << std::endl;
+		err << _("Missing certificate and key files:") << '\n';
 
 		int counter = 0;
 		for (const auto& f : validator.missing_files)
 		{
-			err << f << std::endl;
+			err << f << '\n';
 
 			++counter;
 			if(counter > 10)
 			{
-				err << L"..." << std::endl;
+				err << "..." << '\n';
 				break;
 			}
 		}
 
-		err << std::endl;
+		err << '\n';
 	}
 
 	if (!validator.valid_account)
 	{
-		err << L"The currently selected account is not a valid or dumped online account:\n" << boost::nowide::widen(fmt::format("{}", validator.account_error));
+		err << _("The currently selected account is not a valid or dumped online account:") << fmt::format("\n{}", validator.account_error);
 	}
 		
 	
-	wxMessageBox(err.str(), _("Online Status"), wxOK | wxCENTRE | wxICON_INFORMATION);
+	wxMessageBox(err, _("Online Status"), wxOK | wxCENTRE | wxICON_INFORMATION);
 }

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <wx/collpane.h>
 #include <wx/propgrid/propgrid.h>
+#include <Cafe/Account/Account.h>
 
 class wxColourPickerCtrl;
 
@@ -100,6 +101,7 @@ private:
 	void OnShowOnlineValidator(wxCommandEvent& event);
 	void OnOnlineEnable(wxCommandEvent& event);
 	void OnAccountServiceChanged(wxCommandEvent& event);
+	std::string GetOnlineAccountErrorMessage(OnlineAccountError error);
 
 	// updates cemu audio devices
 	void UpdateAudioDevice();

--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -629,7 +629,7 @@ void GraphicPacksWindow2::OnCheckForUpdates(wxCommandEvent& event)
 			const auto packs = str.str();
 			if(!packs.empty())
 			{
-				wxMessageBox(fmt::format("{}\n \n{} \n{}", _("This update removed or renamed the following graphic packs:").ToStdString(), packs, _("You may need to set them up again.").ToStdString()),
+				wxMessageBox(fmt::format("{}\n \n{} \n{}", _("This update removed or renamed the following graphic packs:").utf8_string(), packs, _("You may need to set them up again.").utf8_string()),
 					_("Warning"), wxOK | wxCENTRE | wxICON_INFORMATION, this);
 			}
 		}

--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -570,8 +570,8 @@ void GraphicPacksWindow2::OnActivePresetChanged(wxCommandEvent& event)
 	wxASSERT(obj);
 	const auto string_data = dynamic_cast<wxStringClientData*>(obj->GetClientObject());
 	wxASSERT(string_data);
-	const auto preset = wxHelper::MakeUTF8(obj->GetStringSelection());
-	if(m_shown_graphic_pack->SetActivePreset(wxHelper::MakeUTF8(string_data->GetData()), preset))
+	const auto preset = obj->GetStringSelection().utf8_string();
+	if(m_shown_graphic_pack->SetActivePreset(string_data->GetData().utf8_string(), preset))
 	{
 		wxWindowUpdateLocker lock(this);
 		ClearPresets();
@@ -668,7 +668,7 @@ void GraphicPacksWindow2::SashPositionChanged(wxEvent& event)
 
 void GraphicPacksWindow2::OnFilterUpdate(wxEvent& event)
 {
-	m_filter = wxHelper::MakeUTF8(m_filter_text->GetValue());
+	m_filter = m_filter_text->GetValue().utf8_string();
 	FillGraphicPackList();
 	event.Skip();
 }

--- a/src/gui/LoggingWindow.cpp
+++ b/src/gui/LoggingWindow.cpp
@@ -88,7 +88,7 @@ void LoggingWindow::OnLogMessage(wxLogEvent& event)
 
 void LoggingWindow::OnFilterChange(wxCommandEvent& event)
 {
-	m_log_list->SetActiveFilter(from_wxString(m_filter->GetValue()));
+	m_log_list->SetActiveFilter(m_filter->GetValue().utf8_string());
 	event.Skip();
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1837,7 +1837,7 @@ public:
 
 	void AddHeaderInfo(wxWindow* parent, wxSizer* sizer)
 	{
-		auto versionString = fmt::format(fmt::runtime(_("Cemu\nVersion {0}\nCompiled on {1}\nOriginal authors: {2}").ToStdString()), BUILD_VERSION_STRING, BUILD_DATE, "Exzap, Petergov");
+		auto versionString = fmt::format(fmt::runtime(_("Cemu\nVersion {0}\nCompiled on {1}\nOriginal authors: {2}").utf8_string()), BUILD_VERSION_STRING, BUILD_DATE, "Exzap, Petergov");
 
 		sizer->Add(new wxStaticText(parent, wxID_ANY, versionString), wxSizerFlags().Border(wxALL, 3).Border(wxTOP, 10));
 		sizer->Add(new wxHyperlinkCtrl(parent, -1, "https://cemu.info", "https://cemu.info"), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 3));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2287,57 +2287,6 @@ void MainWindow::RecreateMenu()
 		SetMenuVisible(false);
 }
 
-void MainWindow::OnAfterCallShowErrorDialog()
-{
-	//wxMessageBox((const wxString&)dialogText, (const wxString&)dialogTitle, wxICON_INFORMATION);
-	//wxDialog* dialog = new wxDialog(NULL,wxID_ANY,(const wxString&)dialogTitle,wxDefaultPosition,wxSize(310,170));
-	//dialog->ShowModal();
-	//dialogState = 1;
-}
-
-bool MainWindow::EnableOnlineMode() const
-{
-	// TODO: not used anymore
-	// 
-	// if enabling online mode, check if all requirements are met
-	std::wstring additionalErrorInfo;
-	const sint32 onlineReqError = iosuCrypt_checkRequirementsForOnlineMode(additionalErrorInfo);
-
-	bool enableOnline = false;
-	if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_OTP_MISSING)
-	{
-		wxMessageBox(_("otp.bin could not be found"), _("Error"), wxICON_ERROR);
-	}
-	else if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_OTP_CORRUPTED)
-	{
-		wxMessageBox(_("otp.bin is corrupted or has invalid size"), _("Error"), wxICON_ERROR);
-	}
-	else if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_SEEPROM_MISSING)
-	{
-		wxMessageBox(_("seeprom.bin could not be found"), _("Error"), wxICON_ERROR);
-	}
-	else if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_SEEPROM_CORRUPTED)
-	{
-		wxMessageBox(_("seeprom.bin is corrupted or has invalid size"), _("Error"), wxICON_ERROR);
-	}
-	else if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_MISSING_FILE)
-	{
-		std::wstring errorMessage = fmt::format(L"Unable to load a necessary file:\n{}", additionalErrorInfo);
-		wxMessageBox(errorMessage.c_str(), _("Error"), wxICON_ERROR);
-	}
-	else if (onlineReqError == IOS_CRYPTO_ONLINE_REQ_OK)
-	{
-		enableOnline = true;
-	}
-	else
-	{
-		wxMessageBox(_("Unknown error occured"), _("Error"), wxICON_ERROR);
-	}
-
-	//config_get()->enableOnlineMode = enableOnline;
-	return enableOnline;
-}
-
 void MainWindow::RestoreSettingsAfterGameExited()
 {
 	RecreateMenu();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -638,7 +638,7 @@ void MainWindow::OnFileMenu(wxCommandEvent& event)
 	const auto menuId = event.GetId();
 	if (menuId == MAINFRAME_MENU_ID_FILE_LOAD)
 	{
-		const auto wildcard = wxStringFormat2(
+		const auto wildcard = formatWxString(
 			"{}|*.wud;*.wux;*.wua;*.iso;*.rpx;*.elf"
 			"|{}|*.wud;*.wux;*.iso"
 			"|{}|*.wua"
@@ -648,7 +648,7 @@ void MainWindow::OnFileMenu(wxCommandEvent& event)
 			_("Wii U image (*.wud, *.wux, *.iso, *.wad)"),
 			_("Wii U archive (*.wua)"),
 			_("Wii U executable (*.rpx, *.elf)"),
-			_("All files (*.*)")		
+			_("All files (*.*)")
 		);
 		
 		wxFileDialog openFileDialog(this, _("Open file to launch"), wxEmptyString, wxEmptyString, wildcard, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
@@ -706,7 +706,7 @@ void MainWindow::OnInstallUpdate(wxCommandEvent& event)
 			{
 				if (!fs::exists(dirPath.parent_path() / "code") || !fs::exists(dirPath.parent_path() / "content") || !fs::exists(dirPath.parent_path() / "meta"))
 				{
-					wxMessageBox(wxStringFormat2(_("The (parent) folder of the title you selected is missing at least one of the required subfolders (\"code\", \"content\" and \"meta\")\nMake sure that the files are complete."), dirPath.filename().string()));
+					wxMessageBox(formatWxString(_("The (parent) folder of the title you selected is missing at least one of the required subfolders (\"code\", \"content\" and \"meta\")\nMake sure that the files are complete."), dirPath.filename().string()));
 					continue;
 				}
 				else
@@ -1837,7 +1837,7 @@ public:
 
 	void AddHeaderInfo(wxWindow* parent, wxSizer* sizer)
 	{
-		auto versionString = fmt::format(fmt::runtime(_("Cemu\nVersion {0}\nCompiled on {1}\nOriginal authors: {2}").utf8_string()), BUILD_VERSION_STRING, BUILD_DATE, "Exzap, Petergov");
+		auto versionString = formatWxString(_("Cemu\nVersion {0}\nCompiled on {1}\nOriginal authors: {2}"), BUILD_VERSION_STRING, BUILD_DATE, "Exzap, Petergov");
 
 		sizer->Add(new wxStaticText(parent, wxID_ANY, versionString), wxSizerFlags().Border(wxALL, 3).Border(wxTOP, 10));
 		sizer->Add(new wxHyperlinkCtrl(parent, -1, "https://cemu.info", "https://cemu.info"), wxSizerFlags().Expand().Border(wxTOP | wxBOTTOM, 3));

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -104,7 +104,6 @@ public:
 	void OnHelpAbout(wxCommandEvent& event);
 	void OnHelpGettingStarted(wxCommandEvent& event);
 	void OnHelpUpdate(wxCommandEvent& event);
-	void OnAfterCallShowErrorDialog();
 	void OnDebugSetting(wxCommandEvent& event);
 	void OnDebugLoggingToggleFlagGeneric(wxCommandEvent& event);
 	void OnPPCInfoToggle(wxCommandEvent& event);
@@ -149,7 +148,6 @@ private:
 	void RecreateMenu();
 	static wxString GetInitialWindowTitle();
 	void ShowGettingStartedDialog();
-	bool EnableOnlineMode() const;
 
 	bool InstallUpdate(const fs::path& metaFilePath);
 

--- a/src/gui/MemorySearcherTool.cpp
+++ b/src/gui/MemorySearcherTool.cpp
@@ -664,30 +664,6 @@ void MemorySearcherTool::SetSearchDataType()
 		m_searchDataType = SearchDataType_None;
 }
 
-std::string MemorySearcherTool::GetSearchTypeName() const
-{
-	switch (m_searchDataType)
-	{
-	case SearchDataType_String:
-		return from_wxString(kDatatypeString);
-	case SearchDataType_Float:
-		return from_wxString(kDatatypeFloat);
-	case SearchDataType_Double:
-		return from_wxString(kDatatypeDouble);
-	case SearchDataType_Int8:
-		return from_wxString(kDatatypeInt8);
-	case SearchDataType_Int16:
-		return from_wxString(kDatatypeInt16);
-	case SearchDataType_Int32:
-		return from_wxString(kDatatypeInt32);
-	case SearchDataType_Int64:
-		return from_wxString(kDatatypeInt64);
-	default: 
-		return "";
-	}
-	
-}
-
 template <>
 bool MemorySearcherTool::ConvertStringToType<signed char>(const char* inValue, sint8& outValue) const
 {

--- a/src/gui/MemorySearcherTool.h
+++ b/src/gui/MemorySearcherTool.h
@@ -56,8 +56,6 @@ private:
 	void RefreshResultList();
 	void RefreshStashList();
 	void SetSearchDataType();
-	std::string GetSearchTypeName() const;
-	void CreateRightClickPopupMenu();
 
 	void Load();
 	void Save();

--- a/src/gui/TitleManager.cpp
+++ b/src/gui/TitleManager.cpp
@@ -622,7 +622,8 @@ void TitleManager::OnSaveExport(wxCommandEvent& event)
 
 	const auto persistent_id = (uint32)(uintptr_t)m_save_account_list->GetClientData(selection_index);
 
-	wxFileDialog path_dialog(this, _("Select a target file to export the save entry"), entry->path.string(), wxEmptyString, "Exported save entry (*.zip)|*.zip", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+	wxFileDialog path_dialog(this, _("Select a target file to export the save entry"), entry->path.string(), wxEmptyString,
+		fmt::format("{}|*.zip", _("Exported save entry (*.zip)")), wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 	if (path_dialog.ShowModal() != wxID_OK || path_dialog.GetPath().IsEmpty())
 		return;
 
@@ -730,11 +731,11 @@ void TitleManager::InitiateConnect()
 
 	if (!NCrypto::SEEPROM_IsPresent())
 	{
-		SetDownloadStatusText("Dumped online files not found");
+		SetDownloadStatusText(_("Dumped online files not found"));
 		return;
 	}
 
-	SetDownloadStatusText("Connecting...");
+	SetDownloadStatusText(_("Connecting..."));
 	// begin async connect
 	dlMgr->setUserData(this);
 	dlMgr->registerCallbacks(

--- a/src/gui/TitleManager.cpp
+++ b/src/gui/TitleManager.cpp
@@ -70,7 +70,7 @@ wxPanel* TitleManager::CreateTitleManagerPage()
 		row->Add(m_refresh_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 		auto* help_button = new wxStaticBitmap(panel, wxID_ANY, wxBITMAP_PNG_FROM_DATA(PNG_HELP));
-		help_button->SetToolTip(wxStringFormat2(_("The following prefixes are supported:\n{0}\n{1}\n{2}\n{3}\n{4}"),
+		help_button->SetToolTip(formatWxString(_("The following prefixes are supported:\n{0}\n{1}\n{2}\n{3}\n{4}"),
 			"titleid:", "name:", "type:", "version:", "region:"));
 		row->Add(help_button, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
@@ -328,7 +328,7 @@ void TitleManager::OnTitleSearchComplete(wxCommandEvent& event)
 	}
 	// update status bar text
 	m_title_list->SortEntries(-1);
-	m_status_bar->SetStatusText(wxStringFormat2(_("Found {0} games, {1} updates, {2} DLCs and {3} save entries"),
+	m_status_bar->SetStatusText(formatWxString(_("Found {0} games, {1} updates, {2} DLCs and {3} save entries"),
 		m_title_list->GetCountByType(wxTitleManagerList::EntryType::Base) + m_title_list->GetCountByType(wxTitleManagerList::EntryType::System),
 		m_title_list->GetCountByType(wxTitleManagerList::EntryType::Update),
 		m_title_list->GetCountByType(wxTitleManagerList::EntryType::Dlc),
@@ -494,7 +494,7 @@ void TitleManager::OnSaveDelete(wxCommandEvent& event)
 	if (selection.IsEmpty())
 		return;
 	
-	const auto msg = wxStringFormat2(_("Are you really sure that you want to delete the save entry for {}"), selection);
+	const auto msg = formatWxString(_("Are you really sure that you want to delete the save entry for {}"), selection);
 	const auto result = wxMessageBox(msg, _("Warning"), wxYES_NO | wxCENTRE | wxICON_EXCLAMATION, this);
 	if (result == wxNO)
 		return;
@@ -545,7 +545,7 @@ void TitleManager::OnSaveDelete(wxCommandEvent& event)
 	fs::remove_all(target, ec);
 	if (ec)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when trying to delete the save directory:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when trying to delete the save directory:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 		return;
 	}
@@ -634,7 +634,7 @@ void TitleManager::OnSaveExport(wxCommandEvent& event)
 	{
 		zip_error_t ziperror;
 		zip_error_init_with_code(&ziperror, ze);
-		const auto error_msg = wxStringFormat2(_("Error when creating the zip for the save entry:\n{}"), zip_error_strerror(&ziperror));
+		const auto error_msg = formatWxString(_("Error when creating the zip for the save entry:\n{}"), zip_error_strerror(&ziperror));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}
@@ -652,7 +652,7 @@ void TitleManager::OnSaveExport(wxCommandEvent& event)
 		{
 			if(zip_dir_add(zip, (const char*)entryname.substr(savedir_str.size() + 1).c_str(), ZIP_FL_ENC_UTF_8) < 0 )
 			{
-				const auto error_msg = wxStringFormat2(_("Error when trying to add a directory to the zip:\n{}"), zip_strerror(zip));
+				const auto error_msg = formatWxString(_("Error when trying to add a directory to the zip:\n{}"), zip_strerror(zip));
 				wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			}
 		}
@@ -661,13 +661,13 @@ void TitleManager::OnSaveExport(wxCommandEvent& event)
 			auto* source = zip_source_file(zip, (const char*)entryname.c_str(), 0, 0);
 			if(!source)
 			{
-				const auto error_msg = wxStringFormat2(_("Error when trying to add a file to the zip:\n{}"), zip_strerror(zip));
+				const auto error_msg = formatWxString(_("Error when trying to add a file to the zip:\n{}"), zip_strerror(zip));
 				wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			}
 
 			if (zip_file_add(zip, (const char*)entryname.substr(savedir_str.size() + 1).c_str(), source, ZIP_FL_ENC_UTF_8) < 0)
 			{
-				const auto error_msg = wxStringFormat2(_("Error when trying to add a file to the zip:\n{}"), zip_strerror(zip));
+				const auto error_msg = formatWxString(_("Error when trying to add a file to the zip:\n{}"), zip_strerror(zip));
 				wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 				
 				zip_source_free(source);
@@ -680,7 +680,7 @@ void TitleManager::OnSaveExport(wxCommandEvent& event)
 	auto* metabuff = zip_source_buffer(zip, metacontent.data(), metacontent.size(), 0);
 	if(zip_file_add(zip, "cemu_meta", metabuff, ZIP_FL_ENC_UTF_8) < 0)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when trying to add cemu_meta file to the zip:\n{}"), zip_strerror(zip));
+		const auto error_msg = formatWxString(_("Error when trying to add cemu_meta file to the zip:\n{}"), zip_strerror(zip));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 
 		zip_source_free(metabuff);

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <wx/msgdlg.h>
+#include <helpers/wxHelpers.h>
 
 VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_window)
 	: IRenderCanvas(is_main_window), wxWindow(parent, wxID_ANY, wxDefaultPosition, size, wxNO_FULL_REPAINT_ON_RESIZE | wxWANTS_CHARS)
@@ -36,8 +37,8 @@ VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_wi
 	}
 	catch(const std::exception& ex)
 	{
-		const auto msg = fmt::format(fmt::runtime(_("Error when initializing Vulkan renderer:\n{}").utf8_string()), ex.what());
-		cemuLog_log(LogType::Force, msg);
+		cemuLog_log(LogType::Force, "Error when initializing Vulkan renderer: {}", ex.what());
+		auto msg = formatWxString(_("Error when initializing Vulkan renderer:\n{}"), ex.what());
 		wxMessageDialog dialog(this, msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 		dialog.ShowModal();
 		exit(0);

--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -36,7 +36,7 @@ VulkanCanvas::VulkanCanvas(wxWindow* parent, const wxSize& size, bool is_main_wi
 	}
 	catch(const std::exception& ex)
 	{
-		const auto msg = fmt::format(fmt::runtime(_("Error when initializing Vulkan renderer:\n{}").ToStdString()), ex.what());
+		const auto msg = fmt::format(fmt::runtime(_("Error when initializing Vulkan renderer:\n{}").utf8_string()), ex.what());
 		cemuLog_log(LogType::Force, msg);
 		wxMessageDialog dialog(this, msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 		dialog.ShowModal();

--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -506,11 +506,11 @@ std::string wxDownloadManagerList::GetTranslatedTitleEntryType(EntryType type)
 	switch (type)
 	{
 		case EntryType::Base:
-			return _("base").ToStdString();
+			return _("base").utf8_string();
 		case EntryType::Update:
-			return _("update").ToStdString();
+			return _("update").utf8_string();
 		case EntryType::DLC:
-			return _("DLC").ToStdString();
+			return _("DLC").utf8_string();
 		default:
 			return std::to_string(static_cast<std::underlying_type_t<EntryType>>(type));
 	}

--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -434,11 +434,9 @@ wxString wxDownloadManagerList::GetTitleEntryText(const TitleEntry& entry, ItemC
 	case ColumnTitleId:
 		return wxStringFormat2("{:08x}-{:08x}", (uint32)(entry.titleId >> 32), (uint32)(entry.titleId & 0xFFFFFFFF));
 	case ColumnName:
-	{
 		return entry.name;
-	}
 	case ColumnType:
-		return wxStringFormat2("{}", entry.type);
+		return GetTranslatedTitleEntryType(entry.type);
 	case ColumnVersion:
 	{
 		// dont show version for base game unless it is not v0
@@ -501,6 +499,21 @@ wxString wxDownloadManagerList::GetTitleEntryText(const TitleEntry& entry, ItemC
 	}
 	
 	return wxEmptyString;
+}
+
+std::string wxDownloadManagerList::GetTranslatedTitleEntryType(EntryType type)
+{
+	switch (type)
+	{
+		case EntryType::Base:
+			return _("base").ToStdString();
+		case EntryType::Update:
+			return _("update").ToStdString();
+		case EntryType::DLC:
+			return _("DLC").ToStdString();
+		default:
+			return std::to_string(static_cast<std::underlying_type_t<EntryType>>(type));
+	}
 }
 
 void wxDownloadManagerList::AddOrUpdateTitle(TitleEntryData_t* obj)

--- a/src/gui/components/wxDownloadManagerList.cpp
+++ b/src/gui/components/wxDownloadManagerList.cpp
@@ -432,7 +432,7 @@ wxString wxDownloadManagerList::GetTitleEntryText(const TitleEntry& entry, ItemC
 	switch (column)
 	{
 	case ColumnTitleId:
-		return wxStringFormat2("{:08x}-{:08x}", (uint32)(entry.titleId >> 32), (uint32)(entry.titleId & 0xFFFFFFFF));
+		return formatWxString("{:08x}-{:08x}", (uint32) (entry.titleId >> 32), (uint32) (entry.titleId & 0xFFFFFFFF));
 	case ColumnName:
 		return entry.name;
 	case ColumnType:
@@ -444,7 +444,7 @@ wxString wxDownloadManagerList::GetTitleEntryText(const TitleEntry& entry, ItemC
 			return "";
 		if (entry.type == EntryType::DLC && entry.version == 0)
 			return "";
-		return wxStringFormat2("v{}", entry.version);
+		return formatWxString("v{}", entry.version);
 	}
 	case ColumnProgress:
 	{
@@ -452,11 +452,11 @@ wxString wxDownloadManagerList::GetTitleEntryText(const TitleEntry& entry, ItemC
 		{
 			if (entry.progress >= 1000)
 				return "100%";
-			return wxStringFormat2("{:.1f}%", (float)entry.progress / 10.0f); // one decimal
+			return formatWxString("{:.1f}%", (float) entry.progress / 10.0f); // one decimal
 		}
 		else if (entry.status == TitleDownloadStatus::Installing || entry.status == TitleDownloadStatus::Checking || entry.status == TitleDownloadStatus::Verifying)
 		{
-			return wxStringFormat2("{0}/{1}", entry.progress, entry.progressMax); // number of processed files/content files
+			return formatWxString("{0}/{1}", entry.progress, entry.progressMax); // number of processed files/content files
 		}
 		return "";
 	}

--- a/src/gui/components/wxDownloadManagerList.h
+++ b/src/gui/components/wxDownloadManagerList.h
@@ -150,25 +150,6 @@ private:
 	bool SortFunc(std::span<int> sortColumnOrder, const Type_t& v1, const Type_t& v2);
 
 	static wxString GetTitleEntryText(const TitleEntry& entry, ItemColumn column);
+	static std::string GetTranslatedTitleEntryType(EntryType entryType);
 	std::future<bool> m_context_worker;
-};
-
-template <>
-struct fmt::formatter<wxDownloadManagerList::EntryType> : formatter<string_view>
-{
-	using base = fmt::formatter<fmt::string_view>;
-	template <typename FormatContext>
-	auto format(const wxDownloadManagerList::EntryType& type, FormatContext& ctx)
-	{
-		switch (type)
-		{
-		case wxDownloadManagerList::EntryType::Base:
-			return base::format("base", ctx);
-		case wxDownloadManagerList::EntryType::Update:
-			return base::format("update", ctx);
-		case wxDownloadManagerList::EntryType::DLC:
-			return base::format("DLC", ctx);
-		}
-		return base::format(std::to_string(static_cast<std::underlying_type_t<wxDownloadManagerList::EntryType>>(type)), ctx);
-	}
 };

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1124,7 +1124,7 @@ void wxGameList::HandleTitleListCallback(CafeTitleListCallbackEvent* evt)
 
 void wxGameList::RemoveCache(const std::list<fs::path>& cachePaths, const std::string& titleName)
 {
-	wxMessageDialog dialog(this, fmt::format(fmt::runtime(_("Remove the shader caches for {}?").ToStdString()), titleName), _("Remove shader caches"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
+	wxMessageDialog dialog(this, fmt::format(fmt::runtime(_("Remove the shader caches for {}?").utf8_string()), titleName), _("Remove shader caches"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
 	dialog.SetYesNoLabels(_("Yes"), _("No"));
 
 	const auto dialogResult = dialog.ShowModal();
@@ -1139,7 +1139,7 @@ void wxGameList::RemoveCache(const std::list<fs::path>& cachePaths, const std::s
 	if (errs.empty())
 		wxMessageDialog(this, _("The shader caches were removed!"), _("Shader caches removed"), wxCENTRE | wxOK | wxICON_INFORMATION).ShowModal();
 	else
-		wxMessageDialog(this, fmt::format(fmt::runtime(_("Failed to remove the shader caches:\n{}").ToStdString()), fmt::join(errs, "\n")), _("Error"), wxCENTRE | wxOK | wxICON_ERROR).ShowModal();
+		wxMessageDialog(this, fmt::format(fmt::runtime(_("Failed to remove the shader caches:\n{}").utf8_string()), fmt::join(errs, "\n")), _("Error"), wxCENTRE | wxOK | wxICON_ERROR).ShowModal();
 }
 
 void wxGameList::AsyncWorkerThread()
@@ -1306,7 +1306,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
     std::ofstream output_stream(output_path);
     if (!output_stream.good())
     {
-        auto errorMsg = fmt::format(fmt::runtime(_("Failed to save desktop entry to {}").ToStdString()), output_path.utf8_string());
+        auto errorMsg = fmt::format(fmt::runtime(_("Failed to save desktop entry to {}").utf8_string()), output_path.utf8_string());
         wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
         return;
     }

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1124,7 +1124,7 @@ void wxGameList::HandleTitleListCallback(CafeTitleListCallbackEvent* evt)
 
 void wxGameList::RemoveCache(const std::list<fs::path>& cachePaths, const std::string& titleName)
 {
-	wxMessageDialog dialog(this, fmt::format(fmt::runtime(_("Remove the shader caches for {}?").utf8_string()), titleName), _("Remove shader caches"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
+	wxMessageDialog dialog(this, formatWxString(_("Remove the shader caches for {}?"), titleName), _("Remove shader caches"), wxCENTRE | wxYES_NO | wxICON_EXCLAMATION);
 	dialog.SetYesNoLabels(_("Yes"), _("No"));
 
 	const auto dialogResult = dialog.ShowModal();
@@ -1139,7 +1139,7 @@ void wxGameList::RemoveCache(const std::list<fs::path>& cachePaths, const std::s
 	if (errs.empty())
 		wxMessageDialog(this, _("The shader caches were removed!"), _("Shader caches removed"), wxCENTRE | wxOK | wxICON_INFORMATION).ShowModal();
 	else
-		wxMessageDialog(this, fmt::format(fmt::runtime(_("Failed to remove the shader caches:\n{}").utf8_string()), fmt::join(errs, "\n")), _("Error"), wxCENTRE | wxOK | wxICON_ERROR).ShowModal();
+		wxMessageDialog(this, formatWxString(_("Failed to remove the shader caches:\n{}"), fmt::join(errs, "\n")), _("Error"), wxCENTRE | wxOK | wxICON_ERROR).ShowModal();
 }
 
 void wxGameList::AsyncWorkerThread()
@@ -1306,7 +1306,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
     std::ofstream output_stream(output_path);
     if (!output_stream.good())
     {
-        auto errorMsg = fmt::format(fmt::runtime(_("Failed to save desktop entry to {}").utf8_string()), output_path.utf8_string());
+        auto errorMsg = formatWxString(_("Failed to save desktop entry to {}"), output_path.utf8_string());
         wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
         return;
     }

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1265,13 +1265,13 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
 
         // In most cases it should find it
         if (!result_index){
-            wxMessageBox("Icon is yet to load, so will not be used by the shortcut", "Warning", wxOK | wxCENTRE | wxICON_WARNING);
+            wxMessageBox(_("Icon is yet to load, so will not be used by the shortcut"), _("Warning"), wxOK | wxCENTRE | wxICON_WARNING);
         }
         else {
             const fs::path out_icon_dir = ActiveSettings::GetUserDataPath("icons");
 
             if (!fs::exists(out_icon_dir) && !fs::create_directories(out_icon_dir)){
-                wxMessageBox("Cannot access the icon directory, the shortcut will have no icon", "Warning", wxOK | wxCENTRE | wxICON_WARNING);
+                wxMessageBox(_("Cannot access the icon directory, the shortcut will have no icon"), _("Warning"), wxOK | wxCENTRE | wxICON_WARNING);
             }
             else {
                 icon_path = out_icon_dir / fmt::format("{:016x}.png", gameInfo.GetBaseTitleId());
@@ -1282,7 +1282,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
                 wxPNGHandler pngHandler;
                 if (!pngHandler.SaveFile(&image, png_file, false)) {
                     icon_path = std::nullopt;
-                    wxMessageBox("The icon was unable to be saved, the shortcut will have no icon", "Warning", wxOK | wxCENTRE | wxICON_WARNING);
+                    wxMessageBox(_("The icon was unable to be saved, the shortcut will have no icon"), _("Warning"), wxOK | wxCENTRE | wxICON_WARNING);
                 }
             }
         }
@@ -1306,7 +1306,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo) {
     std::ofstream output_stream(output_path);
     if (!output_stream.good())
     {
-        const wxString errorMsg = fmt::format("Failed to save desktop entry to {}", output_path.utf8_string());
+        auto errorMsg = fmt::format(fmt::runtime(_("Failed to save desktop entry to {}").ToStdString()), output_path.utf8_string());
         wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
         return;
     }

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -633,7 +633,7 @@ void wxGameList::OnContextMenuSelected(wxCommandEvent& event)
 				if(dialog.ShowModal() == wxID_OK)
 				{
 					const auto custom_name = dialog.GetValue();
-					GetConfig().SetGameListCustomName(title_id, wxHelper::MakeUTF8(custom_name));
+					GetConfig().SetGameListCustomName(title_id, custom_name.utf8_string());
 					m_name_cache.clear();
 					g_config.Save();
 					// update list entry

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1036,8 +1036,8 @@ void wxGameList::OnGameEntryUpdatedByTitleId(wxTitleIdEvent& event)
 
 
 		const auto region_text = fmt::format("{}", gameInfo.GetRegion());
-		SetItem(index, ColumnRegion, _(region_text));
-        SetItem(index, ColumnTitleID, _(fmt::format("{:016x}", titleId)));
+		SetItem(index, ColumnRegion, wxGetTranslation(region_text));
+        SetItem(index, ColumnTitleID, fmt::format("{:016x}", titleId));
 	}
 	else if (m_style == Style::kIcons)
 	{

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -303,29 +303,29 @@ void wxTitleManagerList::OnConvertToCompressedFormat(uint64 titleId, uint64 righ
 		}
 	}
 
-	std::string msg = wxHelper::MakeUTF8(_("The following content will be converted to a compressed Wii U archive file (.wua):"));
+	wxString msg = _("The following content will be converted to a compressed Wii U archive file (.wua):");
 	msg.append("\n \n");
 	
 	if (titleInfo_base.IsValid())
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("Base game:\n{}"))), titleInfo_base.GetPrintPath()));
+		msg.append(formatWxString(_("Base game:\n{}"), titleInfo_base.GetPrintPath()));
 	else
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("Base game:\nNot installed")))));
+		msg.append(_("Base game:\nNot installed"));
 
 	msg.append("\n\n");
 
 	if (titleInfo_update.IsValid())
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("Update:\n{}"))), titleInfo_update.GetPrintPath()));
+		msg.append(formatWxString(_("Update:\n{}"), titleInfo_update.GetPrintPath()));
 	else
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("Update:\nNot installed")))));
+		msg.append(_("Update:\nNot installed"));
 
 	msg.append("\n\n");
 
 	if (titleInfo_aoc.IsValid())
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("DLC:\n{}"))), titleInfo_aoc.GetPrintPath()));
+		msg.append(formatWxString(_("DLC:\n{}"), titleInfo_aoc.GetPrintPath()));
 	else
-		msg.append(fmt::format(fmt::runtime(wxHelper::MakeUTF8(_("DLC:\nNot installed")))));
+		msg.append(_("DLC:\nNot installed"));
 
-	const int answer = wxMessageBox(wxString::FromUTF8(msg), _("Confirmation"), wxOK | wxCANCEL | wxCENTRE | wxICON_QUESTION, this);
+	const int answer = wxMessageBox(msg, _("Confirmation"), wxOK | wxCANCEL | wxCENTRE | wxICON_QUESTION, this);
 	if (answer != wxOK)
 		return;
 	std::vector<TitleInfo*> titlesToConvert;
@@ -732,7 +732,7 @@ void wxTitleManagerList::OnItemSelected(wxListEvent& event)
 	//	return;;
 	//}
 
-	//m_tooltip_text->SetLabel(wxStringFormat2("{}\n{}", msg, _("You can use the context menu to fix it.")));
+	//m_tooltip_text->SetLabel(formatWxString("{}\n{}", msg, _("You can use the context menu to fix it.")));
 	//m_tooltip_window->Fit();
 	//m_tooltip_timer->StartOnce(250);
 }
@@ -792,9 +792,9 @@ bool wxTitleManagerList::DeleteEntry(long index, const TitleEntry& entry)
 	wxString msg;
 	const bool is_directory = fs::is_directory(entry.path);
 	if(is_directory)
-		msg = wxStringFormat2(_("Are you really sure that you want to delete the following folder:\n{}"), wxHelper::FromUtf8(_pathToUtf8(entry.path)));
+		msg = formatWxString(_("Are you really sure that you want to delete the following folder:\n{}"), _pathToUtf8(entry.path));
 	else
-		msg = wxStringFormat2(_("Are you really sure that you want to delete the following file:\n{}"), wxHelper::FromUtf8(_pathToUtf8(entry.path)));
+		msg = formatWxString(_("Are you really sure that you want to delete the following file:\n{}"), _pathToUtf8(entry.path));
 	
 	const auto result = wxMessageBox(msg, _("Warning"), wxYES_NO | wxCENTRE | wxICON_EXCLAMATION, this);
 	if (result == wxNO)
@@ -835,7 +835,7 @@ bool wxTitleManagerList::DeleteEntry(long index, const TitleEntry& entry)
 	
 	if(ec)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when trying to delete the entry:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when trying to delete the entry:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK|wxCENTRE, this);
 		return false;
 	}
@@ -922,13 +922,13 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 	switch (column)
 	{
 	case ColumnTitleId:
-		return wxStringFormat2("{:08x}-{:08x}", (uint32)(entry.title_id >> 32), (uint32)(entry.title_id & 0xFFFFFFFF));
+		return formatWxString("{:08x}-{:08x}", (uint32) (entry.title_id >> 32), (uint32) (entry.title_id & 0xFFFFFFFF));
 	case ColumnName:
 		return entry.name;
 	case ColumnType:
 		return GetTranslatedTitleEntryType(entry.type);
 	case ColumnVersion:
-		return wxStringFormat2("{}", entry.version);
+		return formatWxString("{}", entry.version);
 	case ColumnRegion:
 		return wxGetTranslation(fmt::format("{}", entry.region));
 	case ColumnFormat:
@@ -945,7 +945,6 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 			return _("WUA");
 		}
 		return "";
-		//return wxStringFormat2("{}", entry.format);
 	}
 	case ColumnLocation:
 	{

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -926,7 +926,7 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 	case ColumnName:
 		return entry.name;
 	case ColumnType:
-		return wxStringFormat2("{}", entry.type);
+		return GetTranslatedTitleEntryType(entry.type);
 	case ColumnVersion:
 		return wxStringFormat2("{}", entry.version);
 	case ColumnRegion:
@@ -962,6 +962,25 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 	}
 	
 	return wxEmptyString;
+}
+
+std::string wxTitleManagerList::GetTranslatedTitleEntryType(EntryType type)
+{
+	switch (type)
+	{
+		case EntryType::Base:
+			return _("base").ToStdString();
+		case EntryType::Update:
+			return _("update").ToStdString();
+		case EntryType::Dlc:
+			return _("DLC").ToStdString();
+		case EntryType::Save:
+			return _("save").ToStdString();
+		case EntryType::System:
+			return _("system").ToStdString();
+		default:
+			return std::to_string(static_cast<std::underlying_type_t<EntryType>>(type));
+	}
 }
 
 void wxTitleManagerList::HandleTitleListCallback(CafeTitleListCallbackEvent* evt)

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -930,7 +930,7 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 	case ColumnVersion:
 		return wxStringFormat2("{}", entry.version);
 	case ColumnRegion:
-		return wxStringFormat2("{}", entry.region); // TODO its a flag so formatter is currently not correct
+		return wxGetTranslation(fmt::format("{}", entry.region));
 	case ColumnFormat:
 	{
 		if (entry.type == EntryType::Save)

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -969,15 +969,15 @@ std::string wxTitleManagerList::GetTranslatedTitleEntryType(EntryType type)
 	switch (type)
 	{
 		case EntryType::Base:
-			return _("base").ToStdString();
+			return _("base").utf8_string();
 		case EntryType::Update:
-			return _("update").ToStdString();
+			return _("update").utf8_string();
 		case EntryType::Dlc:
-			return _("DLC").ToStdString();
+			return _("DLC").utf8_string();
 		case EntryType::Save:
-			return _("save").ToStdString();
+			return _("save").utf8_string();
 		case EntryType::System:
-			return _("system").ToStdString();
+			return _("system").utf8_string();
 		default:
 			return std::to_string(static_cast<std::underlying_type_t<EntryType>>(type));
 	}

--- a/src/gui/components/wxTitleManagerList.h
+++ b/src/gui/components/wxTitleManagerList.h
@@ -132,32 +132,9 @@ private:
 	bool SortFunc(int column, const Type_t& v1, const Type_t& v2);
 
 	static wxString GetTitleEntryText(const TitleEntry& entry, ItemColumn column);
+	static std::string GetTranslatedTitleEntryType(EntryType entryType);
 	std::future<bool> m_context_worker;
 
 	uint64 m_callbackIdTitleList;
 	uint64 m_callbackIdSaveList;
-};
-
-template <>
-struct fmt::formatter<wxTitleManagerList::EntryType> : formatter<string_view>
-{
-	using base = fmt::formatter<fmt::string_view>;
-	template <typename FormatContext>
-	auto format(const wxTitleManagerList::EntryType& type, FormatContext& ctx)
-	{
-		switch (type)
-		{
-		case wxTitleManagerList::EntryType::Base:
-			return base::format("base", ctx);
-		case wxTitleManagerList::EntryType::Update:
-			return base::format("update", ctx);
-		case wxTitleManagerList::EntryType::Dlc:
-			return base::format("DLC", ctx);
-		case wxTitleManagerList::EntryType::Save:
-			return base::format("save", ctx);
-		case wxTitleManagerList::EntryType::System:
-			return base::format("system", ctx);
-		}
-		return base::format(std::to_string(static_cast<std::underlying_type_t<wxTitleManagerList::EntryType>>(type)), ctx);
-	}
 };

--- a/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
+++ b/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
@@ -71,7 +71,7 @@ void wxCreateAccountDialog::OnOK(wxCommandEvent& event)
 	const auto id = GetPersistentId();
 	if(id < Account::kMinPersistendId)
 	{
-		wxMessageBox(fmt::format(fmt::runtime(_("The persistent id must be greater than {:x}!").ToStdString()), Account::kMinPersistendId),
+		wxMessageBox(fmt::format(fmt::runtime(_("The persistent id must be greater than {:x}!").utf8_string()), Account::kMinPersistendId),
 			_("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}

--- a/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
+++ b/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
@@ -7,6 +7,7 @@
 #include <wx/button.h>
 #include <wx/textctrl.h>
 #include <wx/msgdlg.h>
+#include <helpers/wxHelpers.h>
 #include "util/helpers/helpers.h"
 
 wxCreateAccountDialog::wxCreateAccountDialog(wxWindow* parent)
@@ -71,7 +72,7 @@ void wxCreateAccountDialog::OnOK(wxCommandEvent& event)
 	const auto id = GetPersistentId();
 	if(id < Account::kMinPersistendId)
 	{
-		wxMessageBox(fmt::format(fmt::runtime(_("The persistent id must be greater than {:x}!").utf8_string()), Account::kMinPersistendId),
+		wxMessageBox(formatWxString(_("The persistent id must be greater than {:x}!"), Account::kMinPersistendId),
 			_("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}

--- a/src/gui/dialogs/SaveImport/SaveImportWindow.cpp
+++ b/src/gui/dialogs/SaveImport/SaveImportWindow.cpp
@@ -30,8 +30,8 @@ SaveImportWindow::SaveImportWindow(wxWindow* parent, uint64 title_id)
 
 		row1->Add(new wxStaticText(this, wxID_ANY, _("Source")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 		m_source_selection = new wxFilePickerCtrl(this, wxID_ANY, wxEmptyString,
-			_("Select a zipped save file"), 
-			wxStringFormat2("{}|*.zip", _("Save entry (*.zip)")));
+			_("Select a zipped save file"),
+			formatWxString("{}|*.zip", _("Save entry (*.zip)")));
 		m_source_selection->SetMinSize({ 270, -1 });
 		row1->Add(m_source_selection, 1, wxALL | wxEXPAND, 5);
 
@@ -118,7 +118,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 					const uint64_t titleId = ConvertString<uint64>(str.substr(sizeof("titleId = ") + 1), 16);
 					if(titleId != 0 && titleId != m_title_id)
 					{
-						const auto msg = wxStringFormat2(_("You are trying to import a savegame for a different title than your currently selected one: {:016x} vs {:016x}\nAre you sure that you want to continue?"), titleId, m_title_id);
+						const auto msg = formatWxString(_("You are trying to import a savegame for a different title than your currently selected one: {:016x} vs {:016x}\nAre you sure that you want to continue?"), titleId, m_title_id);
 						const auto res = wxMessageBox(msg, _("Error"), wxYES_NO | wxCENTRE | wxICON_WARNING, this);
 						if(res == wxNO)
 						{
@@ -143,7 +143,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 	//auto tmp_source = fs::temp_directory_path(ec);
 	//if(ec)
 	//{
-	//	const auto error_msg = wxStringFormat2(_("Error when getting the temp directory path:\n{}"), GetSystemErrorMessage(ec));
+	//	const auto error_msg = formatWxString(_("Error when getting the temp directory path:\n{}"), GetSystemErrorMessage(ec));
 	//	wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 	//	return;
 	//}
@@ -158,7 +158,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 		target_id = ConvertString<uint32>(m_target_selection->GetValue().ToStdString(), 16);
 		if (target_id < Account::kMinPersistendId)
 		{
-			const auto msg = wxStringFormat2(_("The given account id is not valid!\nIt must be a hex number bigger or equal than {:08x}"), Account::kMinPersistendId);
+			const auto msg = formatWxString(_("The given account id is not valid!\nIt must be a hex number bigger or equal than {:08x}"), Account::kMinPersistendId);
 			wxMessageBox(msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			return;
 		}
@@ -170,7 +170,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 	{
 		if (!fs::is_directory(target_path))
 		{
-			const auto msg = wxStringFormat2(_("There's already a file at the target directory:\n{}"), _pathToUtf8(target_path));
+			const auto msg = formatWxString(_("There's already a file at the target directory:\n{}"), _pathToUtf8(target_path));
 			wxMessageBox(msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			m_return_code = wxCANCEL;
 			Close();
@@ -193,7 +193,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 
 			if (ec)
 			{
-				const auto error_msg = wxStringFormat2(_("Error when trying to delete the former save game:\n{}"), GetSystemErrorMessage(ec));
+				const auto error_msg = formatWxString(_("Error when trying to delete the former save game:\n{}"), GetSystemErrorMessage(ec));
 				wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 				return;
 			}
@@ -213,7 +213,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 	fs::create_directories(tmp_source, ec);
 	if (ec)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when creating the extraction path:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when creating the extraction path:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}
@@ -221,7 +221,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 	zip = zip_open(zipfile.c_str(), ZIP_RDONLY, &ziperr);
 	if (!zip)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when opening the import zip file:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when opening the import zip file:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 		return;
 	}
@@ -319,7 +319,7 @@ void SaveImportWindow::OnImport(wxCommandEvent& event)
 	fs::rename(tmp_source, target_path, ec);
 	if (ec)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when trying to move the extracted save game:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when trying to move the extracted save game:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 		return;
 	}*/

--- a/src/gui/dialogs/SaveImport/SaveTransfer.cpp
+++ b/src/gui/dialogs/SaveImport/SaveTransfer.cpp
@@ -92,7 +92,7 @@ void SaveTransfer::OnTransfer(wxCommandEvent& event)
 		target_id = ConvertString<uint32>(m_target_selection->GetValue().ToStdString(), 16);
 		if(target_id < Account::kMinPersistendId)
 		{
-			const auto msg = wxStringFormat2(_("The given account id is not valid!\nIt must be a hex number bigger or equal than {:08x}"), Account::kMinPersistendId);
+			const auto msg = formatWxString(_("The given account id is not valid!\nIt must be a hex number bigger or equal than {:08x}"), Account::kMinPersistendId);
 			wxMessageBox(msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			return;
 		}
@@ -108,7 +108,7 @@ void SaveTransfer::OnTransfer(wxCommandEvent& event)
 	{
 		if(!fs::is_directory(target_path))
 		{
-			const auto msg = wxStringFormat2(_("There's already a file at the target directory:\n{}"), _pathToUtf8(target_path));
+			const auto msg = formatWxString(_("There's already a file at the target directory:\n{}"), _pathToUtf8(target_path));
 			wxMessageBox(msg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR, this);
 			m_return_code = wxCANCEL;
 			Close();
@@ -131,7 +131,7 @@ void SaveTransfer::OnTransfer(wxCommandEvent& event)
 
 			if (ec)
 			{
-				const auto error_msg = wxStringFormat2(_("Error when trying to delete the former save game:\n{}"), GetSystemErrorMessage(ec));
+				const auto error_msg = formatWxString(_("Error when trying to delete the former save game:\n{}"), GetSystemErrorMessage(ec));
 				wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 				return;
 			}
@@ -187,7 +187,7 @@ void SaveTransfer::OnTransfer(wxCommandEvent& event)
 	fs::rename(source_path, target_path, ec);
 	if (ec)
 	{
-		const auto error_msg = wxStringFormat2(_("Error when trying to move the save game:\n{}"), GetSystemErrorMessage(ec));
+		const auto error_msg = formatWxString(_("Error when trying to move the save game:\n{}"), GetSystemErrorMessage(ec));
 		wxMessageBox(error_msg, _("Error"), wxOK | wxCENTRE, this);
 		return;
 	}

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -136,7 +136,7 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 		g_mainFrame->AsyncSetTitle(windowText);
 		auto* pad = g_mainFrame->GetPadView();
 		if (pad)
-			pad->AsyncSetTitle(fmt::format("GamePad View - FPS: {:.02f}", fps));
+			pad->AsyncSetTitle(fmt::format("{} - FPS: {:.02f}", _("GamePad View").ToStdString(), fps));
 	}
 }
 

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -136,7 +136,7 @@ void gui_updateWindowTitles(bool isIdle, bool isLoading, double fps)
 		g_mainFrame->AsyncSetTitle(windowText);
 		auto* pad = g_mainFrame->GetPadView();
 		if (pad)
-			pad->AsyncSetTitle(fmt::format("{} - FPS: {:.02f}", _("GamePad View").ToStdString(), fps));
+			pad->AsyncSetTitle(fmt::format("{} - FPS: {:.02f}", _("GamePad View").utf8_string(), fps));
 	}
 }
 

--- a/src/gui/helpers/wxHelpers.h
+++ b/src/gui/helpers/wxHelpers.h
@@ -86,14 +86,6 @@ inline wxString to_wxString(std::string_view str)
 	return wxString::FromUTF8(str.data(), str.size());
 }
 
-// creates utf8 std::string from wxString
-inline std::string from_wxString(const wxString& str)
-{
-	const auto tmp = str.ToUTF8();
-	return std::string{ tmp.data(), tmp.length() };
-}
-
-
 template <typename T>
 T get_next_sibling(const T element)
 {

--- a/src/gui/helpers/wxHelpers.h
+++ b/src/gui/helpers/wxHelpers.h
@@ -45,16 +45,9 @@ public:
 };
 
 template<typename ...TArgs>
-wxString wxStringFormat2(const wxString& format, TArgs&&...args)
+wxString formatWxString(const wxString& format, TArgs&&...args)
 {
-	// ignores locale?
-	return fmt::format(fmt::runtime(format.ToStdString()), std::forward<TArgs>(args)...);
-}
-
-template<typename ...TArgs>
-wxString wxStringFormat2W(const wxString& format, TArgs&&...args)
-{
-	return fmt::format(fmt::runtime(format.ToStdWstring()), std::forward<TArgs>(args)...);
+	return wxString::FromUTF8(fmt::format(fmt::runtime(format.utf8_string()), std::forward<TArgs>(args)...));
 }
 
 // executes a function when destroying the obj

--- a/src/gui/input/InputAPIAddWindow.cpp
+++ b/src/gui/input/InputAPIAddWindow.cpp
@@ -23,7 +23,7 @@ using wxControllerData = wxCustomData<ControllerPtr>;
 
 InputAPIAddWindow::InputAPIAddWindow(wxWindow* parent, const wxPoint& position,
                                      const std::vector<ControllerPtr>& controllers)
-	: wxDialog(parent, wxID_ANY, _("Add input API"), position, wxDefaultSize, 0), m_controllers(controllers)
+	: wxDialog(parent, wxID_ANY, "Add input API", position, wxDefaultSize, 0), m_controllers(controllers)
 {
 	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
 

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -79,7 +79,7 @@ InputSettings2::InputSettings2(wxWindow* parent)
 	{
 		auto* page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 		page->SetClientObject(nullptr); // force internal type to client object
-		m_notebook->AddPage(page, wxStringFormat2(_("Controller {}"), i + 1));
+		m_notebook->AddPage(page, formatWxString(_("Controller {}"), i + 1));
 	}
 
 	m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &InputSettings2::on_controller_page_changed, this);

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -585,9 +585,7 @@ void InputSettings2::on_profile_text_changed(wxCommandEvent& event)
 
 	// load_bttn, save_bttn, delete_bttn, profile_status
 	const auto text = event.GetString();
-	const auto text_str = from_wxString(text);
-
-	const bool valid_name = InputManager::is_valid_profilename(text_str);
+	const bool valid_name = InputManager::is_valid_profilename(text.utf8_string());
 	const bool name_exists = profile_names->FindString(text) != wxNOT_FOUND;
 
 	page_data.m_profile_load->Enable(name_exists);
@@ -603,7 +601,7 @@ void InputSettings2::on_profile_load(wxCommandEvent& event)
 	auto* profile_names = page_data.m_profiles;
 	auto* text = page_data.m_profile_status;
 
-	const auto selection = from_wxString(profile_names->GetValue());
+	const auto selection = profile_names->GetValue().utf8_string();
 	text->Show();
 	if (selection.empty() || !InputManager::is_valid_profilename(selection))
 	{
@@ -639,7 +637,7 @@ void InputSettings2::on_profile_save(wxCommandEvent& event)
 	auto* profile_names = page_data.m_profiles;
 	auto* text = page_data.m_profile_status;
 
-	const auto selection = from_wxString(profile_names->GetValue());
+	const auto selection = profile_names->GetValue().utf8_string();
 	text->Show();
 	if (selection.empty() || !InputManager::is_valid_profilename(selection))
 	{
@@ -670,7 +668,7 @@ void InputSettings2::on_profile_delete(wxCommandEvent& event)
 	auto* profile_names = page_data.m_profiles;
 	auto* text = page_data.m_profile_status;
 
-	const auto selection = from_wxString(profile_names->GetStringSelection());
+	const auto selection = profile_names->GetStringSelection().utf8_string();
 
 	text->Show();
 	if (selection.empty() || !InputManager::is_valid_profilename(selection))
@@ -725,10 +723,9 @@ void InputSettings2::on_emulated_controller_selected(wxCommandEvent& event)
 	}
 	else
 	{
-		const auto type_str = from_wxString(event.GetString());
 		try
 		{
-			const auto type = EmulatedController::type_from_string(type_str);
+			const auto type = EmulatedController::type_from_string(event.GetString().utf8_string());
 			// same has already been selected
 			if (page_data.m_controller && page_data.m_controller->type() == type)
 				return;

--- a/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
+++ b/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
@@ -8,6 +8,7 @@
 #include "gui/components/wxProgressDialogManager.h"
 
 #include <cinttypes>
+#include <helpers/wxHelpers.h>
 
 enum
 {
@@ -364,8 +365,7 @@ void DebugPPCThreadsWindow::ProfileThreadWorker(OSThread_t* thread)
 		totalSampleCount++;
 		if ((totalSampleCount % 50) == 0)
 		{
-			wxString msg = fmt::format(fmt::runtime(_("Capturing samples... ({:})\nResults will be written to log.txt\n").utf8_string()),
-									   totalSampleCount);
+			wxString msg = formatWxString(_("Capturing samples... ({:})\nResults will be written to log.txt\n"), totalSampleCount);
 			if (totalSampleCount < 30000)
 				msg.Append(_("Click Skip button for early results with lower accuracy"));
 			else

--- a/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
+++ b/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
@@ -333,7 +333,7 @@ void DebugPPCThreadsWindow::PresentProfileResults(OSThread_t* thread, const std:
 void DebugPPCThreadsWindow::ProfileThreadWorker(OSThread_t* thread)
 {
 	wxProgressDialogManager progressDialog(this);
-	progressDialog.Create("Profiling thread",
+	progressDialog.Create(_("Profiling thread"),
 						  _("Capturing samples..."),
 						  1000, // range
 						  wxPD_CAN_SKIP);
@@ -364,7 +364,7 @@ void DebugPPCThreadsWindow::ProfileThreadWorker(OSThread_t* thread)
 		totalSampleCount++;
 		if ((totalSampleCount % 50) == 0)
 		{
-			wxString msg = fmt::format("Capturing samples... ({:})\nResults will be written to log.txt\n",
+			wxString msg = fmt::format(fmt::runtime(_("Capturing samples... ({:})\nResults will be written to log.txt\n").ToStdString()),
 									   totalSampleCount);
 			if (totalSampleCount < 30000)
 				msg.Append(_("Click Skip button for early results with lower accuracy"));

--- a/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
+++ b/src/gui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.cpp
@@ -364,7 +364,7 @@ void DebugPPCThreadsWindow::ProfileThreadWorker(OSThread_t* thread)
 		totalSampleCount++;
 		if ((totalSampleCount % 50) == 0)
 		{
-			wxString msg = fmt::format(fmt::runtime(_("Capturing samples... ({:})\nResults will be written to log.txt\n").ToStdString()),
+			wxString msg = fmt::format(fmt::runtime(_("Capturing samples... ({:})\nResults will be written to log.txt\n").utf8_string()),
 									   totalSampleCount);
 			if (totalSampleCount < 30000)
 				msg.Append(_("Click Skip button for early results with lower accuracy"));

--- a/src/gui/wxHelper.h
+++ b/src/gui/wxHelper.h
@@ -3,13 +3,6 @@
 
 namespace wxHelper
 {
-    // wxString to utf8 std::string
-    inline std::string MakeUTF8(const wxString& str)
-    {
-        auto tmpUtf8 = str.ToUTF8();
-        return std::string(tmpUtf8.data(), tmpUtf8.length());
-    }
-
     inline fs::path MakeFSPath(const wxString& str)
     {
         auto tmpUtf8 = str.ToUTF8();


### PR DESCRIPTION
This PR aims to fix several issues in UI localization that I've found while working to update the Italian translation to the latest version.
The issues I've fixed can be roughly divided in the following categories:
- the UI displayed some strings that couldn't be translated
- the UI displayed some strings in their untranslated form even if the translation was actually present, due to missing/wrong gettext lookups (eaf29a1, 63daf47, 63ca572, 2399808)
- the source code included some strings that could have been translated, but those strings belonged to unused functions or were never displayed to the user (fe1297f, af1881f)

Overall, there is a fair amount of different changes in this PR, but they should be fairly quick and easy to review commit by commit.