### PR TITLE
Various fixes + Coding style guidelines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,65 @@
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands: true
+AlignTrailingComments: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: Inline
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeElse: true
+  BeforeWhile: true
+  SplitEmptyFunction: false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceBeforeCtorInitializerColon: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 4
+UseTab: Always

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -1,0 +1,98 @@
+
+# Coding style guidelines for Cemu
+
+This document describes the latest version of our coding-style guidelines. Since we did not use this style from the beginning, older code may not adhere to these guidelines. Nevertheless, use these rules even if the surrounding code does not match. 
+
+Cemu comes with a `.clang-format` file which is supported by most IDEs for formatting. Avoid auto-reformatting whole files, PRs with a lot of formatting changes are difficult to review.
+
+## Names for variables, functions and classes
+
+- Always prefix class member variables with `m_`
+- Always prefix static class variables with `s_`
+- For variable names: Camel case, starting with a lower case letter after the prefix. Examples: `m_option`, `s_audioVolume`
+- For functions/class names: Use camel case starting with a capital letter. Examples: `MyClass`, `SetActive`
+- Avoid underscores in variable names after the prefix. Use `m_myVariable` instead of `m_my_variable`
+
+## About types
+
+Cemu provides it's own set of basic fixed-width types. They are:
+`uint8`, `sint8`, `uint16`, `sint16`, `uint32`, `sint32`, `uint64`, `sint64`. Always use these types over something like `uint32_t`. Using `size_t` is also acceptable where suitable. Avoid C types like `int` or `long`. The only exception is when interacting with external libraries which expect these types as parameters.
+
+## When and where to put brackets
+
+Always put curly-brackets (`{ }`) on their own line. Example:
+
+```
+void FooBar()
+{
+   if (m_hasFoo)
+   {
+       ...
+   }
+}
+```
+As an exception, you can put short lambdas onto the same line:
+```
+SomeFunc([]() { .... });
+```
+You can skip brackets for single-statement `if`. Example:
+```
+if (cond)
+    action();
+```
+
+## Printing
+
+Avoid sprintf and similar C-style formatting API. Use `fmt::format()`.  
+In UI related code you can use `formatWxString`, but be aware that number formatting with this function will be locale dependent!
+
+## Strings and encoding
+
+We use UTF-8 encoded `std::string` where possible. Some conversations need special handling and we have helper functions for those:
+```cpp
+// std::filesystem::path <-> std::string (in precompiled.h)
+std::string _pathToUtf8(const fs::path& path);
+fs::path _utf8ToPath(std::string_view input);
+
+// wxString <-> std::string
+wxString to_wxString(std::string_view str); // in gui/helpers.h
+std::string wxString::utf8_string();
+
+```
+
+## Logging
+
+If you want to write to log.txt use `cemuLog_log()`. The log type parameter should be mostly self-explanatory. Use `LogType::Force` if you always want to log something. For example:  
+`cemuLog_log(LogType::Force, "The value is {}", 123);`
+
+## HLE and endianness
+
+A pretty large part of Cemu's code base are re-implementations of various Cafe OS modules (e.g. `coreinit.rpl`, `gx2.rpl`...). These generally run in the context of the emulated process, thus special care has to be taken to use types with the correct size and endianness when interacting with memory.
+
+Keep in mind that the emulated Espresso CPU is 32bit big-endian, while the host architectures targeted by Cemu are 64bit litte-endian! 
+
+To keep code simple and remove the need for manual endian-swapping, Cemu has templates and aliases of the basic types with explicit endian-ness.
+For big-endian types add the suffix `be`. Example: `uint32be`
+
+When you need to store a pointer in the guest's memory. Use `MEMPTR<T>`. It will automatically store any pointer as 32bit big-endian. The pointer you store must point to memory that is within the guest address space.
+
+## HLE interfaces
+
+The implementation for each HLE module is inside a namespace with a matching name. E.g. `coreinit.rpl` functions go into `coreinit` namespace.
+
+To expose a new function as callable from within the emulated machine, use `cafeExportRegister` or `cafeExportRegisterFunc`. Here is a short example:
+```cpp
+namespace coreinit
+{
+	uint32 OSGetCoreCount()
+	{
+		return Espresso::CORE_COUNT;
+	}
+	
+	void Init()
+	{
+		cafeExportRegister("coreinit", OSGetCoreCount, LogType::CoreinitThread);
+	}
+}
+```
+You may also see some code which uses `osLib_addFunction` directly. This is a deprecated way of registering functions.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Matrix Server](https://img.shields.io/matrix/cemu:cemu.info?server_fqdn=matrix.cemu.info&label=cemu:cemu.info&logo=matrix&logoColor=FFFFFF)](https://matrix.to/#/#cemu:cemu.info)
 
 This is the code repository of Cemu, a Wii U emulator that is able to run most Wii U games and homebrew in a playable state.
-It's written in C/C++ and is being actively developed with new features and fixes to increase compatibility, convenience and usability.
+It's written in C/C++ and is being actively developed with new features and fixes.
 
 Cemu is currently only available for 64-bit Windows, Linux & macOS devices.
 
@@ -24,11 +24,9 @@ Cemu is currently only available for 64-bit Windows, Linux & macOS devices.
 
 ## Download
 
-You can download the latest Cemu releases from the [GitHub Releases](https://github.com/cemu-project/Cemu/releases/) or from [Cemu's website](https://cemu.info).
+You can download the latest Cemu releases for Windows, Linux and Mac from the [GitHub Releases](https://github.com/cemu-project/Cemu/releases/). For Linux you can also find Cemu on [flathub](https://flathub.org/apps/info.cemu.Cemu).
 
-Cemu is currently only available in a portable format so no installation is required besides extracting it in a safe place.
-
-The native Linux build is currently a work-in-progress. See [Current State Of Linux builds](https://github.com/cemu-project/Cemu/issues/107) for more information about the things to be aware of. 
+On Windows Cemu is currently only available in a portable format so no installation is required besides extracting it in a safe place.
 
 The native macOS build is currently purely experimental and should not be considered stable or ready for issue-free gameplay. There are also known issues with degraded performance due to the use of MoltenVK and Rosetta for ARM Macs. We appreciate your patience while we improve Cemu for macOS.
 
@@ -36,7 +34,7 @@ Pre-2.0 releases can be found on Cemu's [changelog page](https://cemu.info/chang
 
 ## Build Instructions
 
-To compile Cemu yourself on Windows, Linux or macOS, view the [BUILD.md file](/BUILD.md).
+To compile Cemu yourself on Windows, Linux or macOS, view [BUILD.md](/BUILD.md).
 
 ## Issues
 
@@ -46,6 +44,7 @@ The old bug tracker can be found at [bugs.cemu.info](https://bugs.cemu.info) and
 ## Contributing
 
 Pull requests are very welcome. For easier coordination you can visit the developer discussion channel on [Discord](https://discord.gg/5psYsup) or alternatively the [Matrix Server](https://matrix.to/#/#cemu:cemu.info).
+Before submitting a pull request, please read and follow our code style guidelines listed in [CODING_STYLE.md](/CODING_STYLE.md).
 
 If coding isn't your thing, testing games and making detailed bug reports or updating the (usually outdated) compatibility wiki is also appreciated!
 

--- a/dependencies/ih264d/CMakeLists.txt
+++ b/dependencies/ih264d/CMakeLists.txt
@@ -183,4 +183,10 @@ endif()
 
 if(MSVC)
 set_property(TARGET ih264d PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+# tune settings for slightly better performance
+target_compile_options(ih264d PRIVATE $<$<CONFIG:Release,RelWithDebInfo>:/Oi>) # enable intrinsic functions
+target_compile_options(ih264d PRIVATE $<$<CONFIG:Release,RelWithDebInfo>:/Ot>) # favor speed
+target_compile_options(ih264d PRIVATE "/GS-") # disable runtime checks
+
 endif()

--- a/dependencies/ih264d/common/x86/ih264_platform_macros.h
+++ b/dependencies/ih264d/common/x86/ih264_platform_macros.h
@@ -79,10 +79,8 @@
 static inline int __builtin_clz(unsigned x)
 {
 	unsigned long n;
-	if (x == 0)
-		return 32;
 	_BitScanReverse(&n, x);
-	return 31 - n;
+	return n ^ 31;
 }
 
 static inline int __builtin_ctz(unsigned x) {

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -165,7 +165,7 @@ void LoadMainExecutable()
 	{
 		// RPX
 		RPLLoader_AddDependency(_pathToExecutable.c_str());
-		applicationRPX = rpl_loadFromMem(rpxData, rpxSize, (char*)_pathToExecutable.c_str());
+		applicationRPX = RPLLoader_LoadFromMemory(rpxData, rpxSize, (char*)_pathToExecutable.c_str());
 		if (!applicationRPX)
 		{
 			wxMessageBox(_("Failed to run this title because the executable is damaged"));

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -487,7 +487,7 @@ namespace CafeSystem
 	#if BOOST_OS_WINDOWS
 	std::string GetWindowsNamedVersion(uint32& buildNumber)
 	{
-		static char productName[256];
+		char productName[256];
 		HKEY hKey;
 		DWORD dwType = REG_SZ;
 		DWORD dwSize = sizeof(productName);

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
@@ -325,6 +325,8 @@ void PPCRecompiler_thread()
 			PPCRecompilerState.recompilerSpinlock.unlock();
 
 			PPCRecompiler_recompileAtAddress(enterAddress);
+			if(s_recompilerThreadStopSignal)
+				return;
 		}
 	}
 }

--- a/src/Cafe/HW/Latte/Core/FetchShader.cpp
+++ b/src/Cafe/HW/Latte/Core/FetchShader.cpp
@@ -228,13 +228,13 @@ void _fetchShaderDecompiler_parseInstruction_VTX_SEMANTIC(LatteFetchShader* pars
 	else if (srcSelX == LatteClauseInstruction_VTX::SRC_SEL::SEL_Y)
 	{
 		// use alu divisor 1
-		attribGroup->attrib[groupAttribIndex].aluDivisor = (sint32)contextRegister[mmVGT_INSTANCE_STEP_RATE_0 + 0];
+		attribGroup->attrib[groupAttribIndex].aluDivisor = (sint32)contextRegister[Latte::REGADDR::VGT_INSTANCE_STEP_RATE_0];
 		cemu_assert_debug(attribGroup->attrib[groupAttribIndex].aluDivisor > 0);
 	}
 	else if (srcSelX == LatteClauseInstruction_VTX::SRC_SEL::SEL_Z)
 	{
 		// use alu divisor 2
-		attribGroup->attrib[groupAttribIndex].aluDivisor = (sint32)contextRegister[mmVGT_INSTANCE_STEP_RATE_0 + 1];
+		attribGroup->attrib[groupAttribIndex].aluDivisor = (sint32)contextRegister[Latte::REGADDR::VGT_INSTANCE_STEP_RATE_1];
 		cemu_assert_debug(attribGroup->attrib[groupAttribIndex].aluDivisor > 0);
 	}
 }

--- a/src/Cafe/HW/Latte/ISA/LatteReg.h
+++ b/src/Cafe/HW/Latte/ISA/LatteReg.h
@@ -381,6 +381,9 @@ namespace Latte
 		PA_SC_GENERIC_SCISSOR_TL			= 0xA090,
 		PA_SC_GENERIC_SCISSOR_BR			= 0xA091,
 
+		SQ_VTX_SEMANTIC_0					= 0xA0E0,
+		SQ_VTX_SEMANTIC_31					= 0xA0FF,
+
 		VGT_MULTI_PRIM_IB_RESET_INDX		= 0xA103,
 		SX_ALPHA_TEST_CONTROL				= 0xA104,
 		CB_BLEND_RED						= 0xA105,
@@ -398,6 +401,10 @@ namespace Latte
 		PA_CL_VPORT_ZSCALE					= 0xA113,
 		PA_CL_VPORT_ZOFFSET					= 0xA114,
 
+		SPI_VS_OUT_ID_0						= 0xA185,
+
+		SPI_VS_OUT_CONFIG					= 0xA1B1,
+
 		CB_BLEND0_CONTROL					= 0xA1E0, // first
 		CB_BLEND7_CONTROL					= 0xA1E7, // last
 
@@ -408,13 +415,58 @@ namespace Latte
 		PA_CL_CLIP_CNTL						= 0xA204,
 		PA_SU_SC_MODE_CNTL					= 0xA205,
 		PA_CL_VTE_CNTL						= 0xA206,
-		
+		PA_CL_VS_OUT_CNTL					= 0xA207,
+
+		// shader program descriptors:
+		SQ_PGM_START_PS						= 0xA210,
+		SQ_PGM_RESOURCES_PS					= 0xA214,
+		SQ_PGM_EXPORTS_PS					= 0xA215,
+		SQ_PGM_START_VS						= 0xA216,
+		SQ_PGM_RESOURCES_VS					= 0xA21A,
+		SQ_PGM_START_GS 					= 0xA21B,
+		SQ_PGM_RESOURCES_GS					= 0xA21F,
+		SQ_PGM_START_ES						= 0xA220,
+		SQ_PGM_RESOURCES_ES					= 0xA224,
+		SQ_PGM_START_FS						= 0xA225,
+		SQ_PGM_RESOURCES_FS					= 0xA229,
+
+		SQ_VTX_SEMANTIC_CLEAR				= 0xA238,
+
 		PA_SU_POINT_SIZE					= 0xA280,
 		PA_SU_POINT_MINMAX					= 0xA281,
 
 		VGT_GS_MODE							= 0xA290,
 
 		VGT_DMA_INDEX_TYPE					= 0xA29F, // todo - verify offset
+
+		VGT_PRIMITIVEID_EN					= 0xA2A1,
+
+		VGT_MULTI_PRIM_IB_RESET_EN 			= 0xA2A5,
+
+		VGT_INSTANCE_STEP_RATE_0			= 0xA2A8,
+		VGT_INSTANCE_STEP_RATE_1			= 0xA2A9,
+
+		VGT_STRMOUT_BUFFER_SIZE_0			= 0xA2B4,
+		VGT_STRMOUT_VTX_STRIDE_0			= 0xA2B5,
+		VGT_STRMOUT_BUFFER_BASE_0			= 0xA2B6,
+		VGT_STRMOUT_BUFFER_OFFSET_0			= 0xA2B7,
+		VGT_STRMOUT_BUFFER_SIZE_1			= 0xA2B8,
+		VGT_STRMOUT_VTX_STRIDE_1			= 0xA2B9,
+		VGT_STRMOUT_BUFFER_BASE_1			= 0xA2BA,
+		VGT_STRMOUT_BUFFER_OFFSET_1			= 0xA2BB,
+		VGT_STRMOUT_BUFFER_SIZE_2			= 0xA2BC,
+		VGT_STRMOUT_VTX_STRIDE_2			= 0xA2BD,
+		VGT_STRMOUT_BUFFER_BASE_2			= 0xA2BE,
+		VGT_STRMOUT_BUFFER_OFFSET_2			= 0xA2BF,
+		VGT_STRMOUT_BUFFER_SIZE_3			= 0xA2C0,
+		VGT_STRMOUT_VTX_STRIDE_3			= 0xA2C1,
+		VGT_STRMOUT_BUFFER_BASE_3			= 0xA2C2,
+		VGT_STRMOUT_BUFFER_OFFSET_3			= 0xA2C3,
+		VGT_STRMOUT_BASE_OFFSET_0			= 0xA2C4,
+		VGT_STRMOUT_BASE_OFFSET_1			= 0xA2C5,
+		VGT_STRMOUT_BASE_OFFSET_2			= 0xA2C6,
+		VGT_STRMOUT_BASE_OFFSET_3			= 0xA2C7,
+		VGT_STRMOUT_BUFFER_EN				= 0xA2C8,
 
 		// HiZ early stencil test?
 		DB_SRESULTS_COMPARE_STATE0			= 0xA34A,
@@ -842,6 +894,12 @@ float get_##__regname() const \
 		LATTE_BITFIELD_BOOL(VTX_W0_FMT, 10);
 	};
 
+	struct LATTE_PA_CL_VS_OUT_CNTL : LATTEREG // 0xA207
+	{
+		LATTE_BITFIELD(CLIP_DIST_ENA_MASK, 0, 8);
+		LATTE_BITFIELD(CULL_DIST_ENA_MASK, 8, 8);
+	};
+
 	struct LATTE_PA_SU_POINT_SIZE : LATTEREG // 0xA280
 	{
 		LATTE_BITFIELD(HEIGHT, 0, 16);
@@ -909,6 +967,54 @@ float get_##__regname() const \
 		LATTE_BITFIELD_FULL_TYPED(INDEX_TYPE, E_INDEX_TYPE);
 	};
 
+	struct LATTE_VGT_PRIMITIVEID_EN : LATTEREG // 0xA2A1
+	{
+		LATTE_BITFIELD_BOOL(PRIMITIVEID_EN, 0);
+	};
+
+	struct LATTE_VGT_MULTI_PRIM_IB_RESET_EN : LATTEREG // 0xA2A5
+	{
+		LATTE_BITFIELD_BOOL(RESET_EN, 0);
+	};
+
+	struct LATTE_VGT_INSTANCE_STEP_RATE_X : LATTEREG // 0xA2A8-0xA2A9
+	{
+		LATTE_BITFIELD_FULL_TYPED(STEP_RATE, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_BUFFER_SIZE_X : LATTEREG // 0xA2B4 + index * 4
+	{
+		LATTE_BITFIELD_FULL_TYPED(SIZE, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_STRIDE_X : LATTEREG // 0xA2B5 + index * 4
+	{
+		LATTE_BITFIELD_FULL_TYPED(STRIDE, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_BUFFER_BASE_X : LATTEREG // 0xA2B6 + index * 4
+	{
+		LATTE_BITFIELD_FULL_TYPED(BASE, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_BUFFER_OFFSET_X : LATTEREG // 0xA2B7 + index * 4
+	{
+		LATTE_BITFIELD_FULL_TYPED(BUFFER_OFFSET, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_BASE_OFFSET_X : LATTEREG // 0xA2C4-0xA2C7
+	{
+		LATTE_BITFIELD_FULL_TYPED(BASE_OFFSET, uint32);
+	};
+
+	struct LATTE_VGT_STRMOUT_BUFFER_EN : LATTEREG // 0xA2C8
+	{
+		LATTE_BITFIELD_BOOL(BUFFER_ENABLE_0, 0);
+		LATTE_BITFIELD_BOOL(BUFFER_ENABLE_1, 1);
+		LATTE_BITFIELD_BOOL(BUFFER_ENABLE_2, 2);
+		LATTE_BITFIELD_BOOL(BUFFER_ENABLE_3, 3);
+	};
+
 	struct LATTE_PA_SU_POLY_OFFSET_CLAMP : LATTEREG // 0xA37F
 	{
 		LATTE_BITFIELD_FLOAT(CLAMP);
@@ -932,6 +1038,16 @@ float get_##__regname() const \
 	struct LATTE_PA_SU_POLY_OFFSET_BACK_OFFSET : LATTEREG // 0xA383
 	{
 		LATTE_BITFIELD_FLOAT(OFFSET);
+	};
+
+	struct LATTE_SQ_VTX_SEMANTIC_CLEAR : LATTEREG // 0xA238
+	{
+		LATTE_BITFIELD_FULL_TYPED(CLEAR_MASK, uint32); // probably a bitmask
+	};
+
+	struct LATTE_SQ_VTX_SEMANTIC_X : LATTEREG // 0xA0E0 - 0xA0FF
+	{
+		LATTE_BITFIELD(SEMANTIC_ID, 0, 8);
 	};
 
 	struct LATTE_SQ_TEX_RESOURCE_WORD0_N : LATTEREG // 0xE000 + index * 7
@@ -1154,6 +1270,65 @@ float get_##__regname() const \
 		LATTE_BITFIELD_TYPED(TYPE, 31, 1, E_SAMPLER_TYPE);
 	};
 
+	struct LATTE_SQ_PGM_START_X : LATTEREG // 0xA210 / 0xA216 / 0xA21B / 0xA220 / 0xA225
+	{
+		LATTE_BITFIELD_FULL_TYPED(PGM_START, uint32);
+	};
+
+	struct LATTE_SQ_PGM_RESOURCES_PS : LATTEREG // 0xA214
+	{
+		LATTE_BITFIELD(NUM_GPRS, 0, 8);
+		LATTE_BITFIELD(NUM_STACK_ENTRIES, 8, 8);
+		LATTE_BITFIELD_BOOL(DX10_CLAMP, 21); // if true, CLAMP modifier in shaders will return 0 for NaN
+		LATTE_BITFIELD(FETCH_CACHE_LINES, 24, 3);
+		LATTE_BITFIELD_BOOL(UNCACHED_FIRST_INST, 28);
+		LATTE_BITFIELD_BOOL(CLAMP_CONSTS, 31);
+	};
+
+	struct LATTE_SQ_PGM_RESOURCES_VS : LATTEREG // 0xA21A
+	{
+		LATTE_BITFIELD(NUM_GPRS, 0, 8);
+		LATTE_BITFIELD(NUM_STACK_ENTRIES, 8, 8);
+		LATTE_BITFIELD_BOOL(DX10_CLAMP, 21); // if true, CLAMP modifier in shaders will return 0 for NaN
+		LATTE_BITFIELD(FETCH_CACHE_LINES, 24, 3);
+		LATTE_BITFIELD_BOOL(UNCACHED_FIRST_INST, 28);
+	};
+
+	struct LATTE_SQ_PGM_RESOURCES_GS : LATTEREG // 0xA21F
+	{
+		LATTE_BITFIELD(NUM_GPRS, 0, 8);
+		LATTE_BITFIELD(NUM_STACK_ENTRIES, 8, 8);
+		LATTE_BITFIELD_BOOL(DX10_CLAMP, 21); // if true, CLAMP modifier in shaders will return 0 for NaN
+	};
+
+	struct LATTE_SQ_PGM_RESOURCES_ES : LATTEREG // 0xA224
+	{
+		LATTE_BITFIELD(NUM_GPRS, 0, 8);
+		LATTE_BITFIELD(NUM_STACK_ENTRIES, 8, 8);
+		LATTE_BITFIELD_BOOL(DX10_CLAMP, 21); // if true, CLAMP modifier in shaders will return 0 for NaN
+	};
+
+	struct LATTE_SQ_PGM_RESOURCES_FS : LATTEREG // 0xA229
+	{
+		LATTE_BITFIELD(NUM_GPRS, 0, 8);
+		LATTE_BITFIELD(NUM_STACK_ENTRIES, 8, 8);
+		LATTE_BITFIELD_BOOL(DX10_CLAMP, 21); // if true, CLAMP modifier in shaders will return 0 for NaN
+	};
+
+	struct LATTE_SQ_XX_ITEMSIZE : LATTEREG // 0xA227 - 0xA2XX
+	{
+		// used by:
+		// SQ_ESGS_RING_ITEMSIZE
+		// SQ_GSVS_RING_ITEMSIZE
+		// SQ_ESTMP_RING_ITEMSIZE
+		// SQ_GSTMP_RING_ITEMSIZE
+		// SQ_VSTMP_RING_ITEMSIZE
+		// SQ_PSTMP_RING_ITEMSIZE
+		// SQ_FBUF_RING_ITEMSIZE
+		// SQ_REDUC_RING_ITEMSIZE
+		LATTE_BITFIELD(ITEMSIZE, 0, 15);
+	};
+
 	struct LATTE_PA_SU_SC_MODE_CNTL : LATTEREG // 0xA205
 	{
 		enum class E_FRONTFACE
@@ -1185,7 +1360,32 @@ float get_##__regname() const \
 		LATTE_BITFIELD_BOOL(OFFSET_PARA_ENABLED, 13); // offset enable for lines and points?
 		// additional fields?
 	};
-}
+
+	struct LATTE_SPI_VS_OUT_CONFIG : LATTEREG // 0xA1B1
+	{
+		LATTE_BITFIELD_BOOL(VS_PER_COMPONENT, 0);
+		LATTE_BITFIELD(VS_EXPORT_COUNT, 1, 5);
+		LATTE_BITFIELD_BOOL(EXPORTS_FOG, 8);
+		LATTE_BITFIELD(VS_OUT_FOG_VEC_ADDR, 9, 5);
+	};
+
+	struct LATTE_SPI_VS_OUT_ID_N : LATTEREG // 0xA185 - 0xA18E(?) - 0xA1B2 - 0xA1B3
+	{
+		uint8 get_SEMANTIC(sint32 index)
+		{
+			cemu_assert_debug(index < 4);
+			return (uint8)((v >> (index * 8)) & 0xFF);
+		}
+
+		void set_SEMANTIC(sint32 index, uint8 value)
+		{
+			cemu_assert_debug(index < 4);
+			v &= ~(0xFF << (index * 8));
+			v |= (value & 0xFF) << (index * 8);
+		}
+	};
+
+};
 
 struct _LatteRegisterSetTextureUnit
 {
@@ -1219,6 +1419,16 @@ struct _LatteRegisterSetSamplerBorderColor
 
 static_assert(sizeof(_LatteRegisterSetSamplerBorderColor) == 16);
 
+struct _LatteRegisterSetStreamoutBuffer
+{
+	Latte::LATTE_VGT_STRMOUT_BUFFER_SIZE_X SIZE;
+	Latte::LATTE_VGT_STRMOUT_STRIDE_X STRIDE;
+	Latte::LATTE_VGT_STRMOUT_BUFFER_BASE_X BASE;
+	Latte::LATTE_VGT_STRMOUT_BUFFER_OFFSET_X BUFFER_OFFSET;
+};
+
+static_assert(sizeof(_LatteRegisterSetStreamoutBuffer) == 16);
+
 struct LatteContextRegister
 {
 	uint8 padding0[0x08958];
@@ -1235,7 +1445,9 @@ struct LatteContextRegister
 	uint8 padding_2823C[4];
 	/* +0x28240 */ Latte::LATTE_PA_SC_GENERIC_SCISSOR_TL PA_SC_GENERIC_SCISSOR_TL;
 	/* +0x28244 */ Latte::LATTE_PA_SC_GENERIC_SCISSOR_BR PA_SC_GENERIC_SCISSOR_BR;
-	uint8 padding_28248[0x2840C - 0x28248];
+	uint8 padding_28248[0x28380 - 0x28248];
+	/* +0x28380 */ Latte::LATTE_SQ_VTX_SEMANTIC_X SQ_VTX_SEMANTIC_X[32];
+	/* +0x28400 */ uint8 padding_28400[0x2840C - 0x28400];
 	/* +0x2840C */ Latte::LATTE_VGT_MULTI_PRIM_IB_RESET_INDX VGT_MULTI_PRIM_IB_RESET_INDX;
 	/* +0x28410 */ Latte::LATTE_SX_ALPHA_TEST_CONTROL SX_ALPHA_TEST_CONTROL;
 	/* +0x28414 */ Latte::LATTE_CB_BLEND_RED CB_BLEND_RED;
@@ -1253,7 +1465,15 @@ struct LatteContextRegister
 	/* +0x2844C */ Latte::LATTE_PA_CL_VPORT_ZSCALE	PA_CL_VPORT_ZSCALE;
 	/* +0x28450 */ Latte::LATTE_PA_CL_VPORT_ZOFFSET PA_CL_VPORT_ZOFFSET;
 
-	uint8 padding_28450[0x28780 - 0x28454];
+	uint8 padding_28450[0x28614 - 0x28454];
+
+	/* +0x28614 */ Latte::LATTE_SPI_VS_OUT_ID_N LATTE_SPI_VS_OUT_ID_N[10];
+
+	uint8 padding_2863C[0x286C4 - 0x2863C];
+
+	/* +0x286C4 */ Latte::LATTE_SPI_VS_OUT_CONFIG SPI_VS_OUT_CONFIG;
+
+	uint8 padding_286C8[0x28780 - 0x286C8];
 
 	/* +0x28780 */ Latte::LATTE_CB_BLENDN_CONTROL CB_BLENDN_CONTROL[8];
 
@@ -1266,9 +1486,44 @@ struct LatteContextRegister
 	/* +0x28810 */ Latte::LATTE_PA_CL_CLIP_CNTL PA_CL_CLIP_CNTL;
 	/* +0x28814 */ Latte::LATTE_PA_SU_SC_MODE_CNTL PA_SU_SC_MODE_CNTL;
 	/* +0x28818 */ Latte::LATTE_PA_CL_VTE_CNTL PA_CL_VTE_CNTL;
+	/* +0x2881C */ Latte::LATTE_PA_CL_VS_OUT_CNTL PA_CL_VS_OUT_CNTL;
 
-	uint8 padding_2881C[0x28A00 - 0x2881C];
+	uint8 padding_2881C[0x28840 - 0x28820];
 
+	/* +0x28840 */ Latte::LATTE_SQ_PGM_START_X SQ_PGM_START_PS;
+	/* +0x28844 */ uint32 ukn28844; // PS size
+	/* +0x28848 */ uint32 ukn28848;
+	/* +0x2884C */ uint32 ukn2884C;
+	/* +0x28850 */ Latte::LATTE_SQ_PGM_RESOURCES_PS SQ_PGM_RESOURCES_PS;
+	/* +0x28854 */ uint32 ukn28854; // SQ_PGM_EXPORTS_PS
+	/* +0x28858 */ Latte::LATTE_SQ_PGM_START_X SQ_PGM_START_VS;
+	/* +0x2885C */ uint32 ukn2885C; // VS size
+	/* +0x28860 */ uint32 ukn28860;
+	/* +0x28864 */ uint32 ukn28864;
+	/* +0x28868 */ Latte::LATTE_SQ_PGM_RESOURCES_VS SQ_PGM_RESOURCES_VS;
+	/* +0x2886C */ Latte::LATTE_SQ_PGM_START_X SQ_PGM_START_GS;
+	/* +0x28870 */ uint32 ukn28870; // GS size
+	/* +0x28874 */ uint32 ukn28874;
+	/* +0x28878 */ uint32 ukn28878;
+	/* +0x2887C */ Latte::LATTE_SQ_PGM_RESOURCES_GS SQ_PGM_RESOURCES_GS;
+	/* +0x28880 */ Latte::LATTE_SQ_PGM_START_X SQ_PGM_START_ES;
+	/* +0x28884 */ uint32 ukn28884; // ES size
+	/* +0x28888 */ uint32 ukn28888;
+	/* +0x2888C */ uint32 ukn2888C;
+	/* +0x28890 */ Latte::LATTE_SQ_PGM_RESOURCES_ES SQ_PGM_RESOURCES_ES;
+	/* +0x28894 */ Latte::LATTE_SQ_PGM_START_X SQ_PGM_START_FS;
+	/* +0x28898 */ uint32 ukn28898; // FS size
+	/* +0x2889C */ uint32 ukn2889C;
+	/* +0x288A0 */ uint32 ukn288A0;
+	/* +0x288A4 */ Latte::LATTE_SQ_PGM_RESOURCES_FS SQ_PGM_RESOURCES_FS;
+	/* +0x288A8 */ Latte::LATTE_SQ_XX_ITEMSIZE SQ_ESGS_RING_ITEMSIZE;
+	/* +0x288AC */ Latte::LATTE_SQ_XX_ITEMSIZE SQ_GSVS_RING_ITEMSIZE;
+	/* +0x288B0 */ Latte::LATTE_SQ_XX_ITEMSIZE SQ_ESTMP_RING_ITEMSIZE;
+	/* +0x288B4 */ Latte::LATTE_SQ_XX_ITEMSIZE SQ_GSTMP_RING_ITEMSIZE;
+	/* +0x288B8 */ Latte::LATTE_SQ_XX_ITEMSIZE SQ_VSTMP_RING_ITEMSIZE;
+	uint8 padding_288BC[0x288E0 - 0x288BC];
+	/* +0x288E0 */ Latte::LATTE_SQ_VTX_SEMANTIC_CLEAR SQ_VTX_SEMANTIC_CLEAR;
+	uint8 padding_288E4[0x28A00 - 0x288E4];
 	/* +0x28A00 */ Latte::LATTE_PA_SU_POINT_SIZE PA_SU_POINT_SIZE;
 	/* +0x28A04 */ Latte::LATTE_PA_SU_POINT_MINMAX PA_SU_POINT_MINMAX;
 
@@ -1279,8 +1534,24 @@ struct LatteContextRegister
 	uint8 padding_28A44[0x28A7C - 0x28A44];
 
 	/* +0x28A7C */ Latte::LATTE_VGT_DMA_INDEX_TYPE VGT_DMA_INDEX_TYPE;
+	/* +0x28A80 */ uint32 ukn28A80;
+	/* +0x28A84 */ Latte::LATTE_VGT_PRIMITIVEID_EN VGT_PRIMITIVEID_EN;
+	/* +0x28A88 */ uint32 ukn28A88;
+	/* +0x28A8C */ uint32 ukn28A8C;
+	/* +0x28A90 */ uint32 ukn28A90;
+	/* +0x28A94 */ Latte::LATTE_VGT_MULTI_PRIM_IB_RESET_EN VGT_MULTI_PRIM_IB_RESET_EN;
+	/* +0x28A98 */ uint32 ukn28A98;
+	/* +0x28A9C */ uint32 ukn28A9C;
+	/* +0x28AA0 */ Latte::LATTE_VGT_INSTANCE_STEP_RATE_X VGT_INSTANCE_STEP_RATE_0;
+	/* +0x28AA4 */ Latte::LATTE_VGT_INSTANCE_STEP_RATE_X VGT_INSTANCE_STEP_RATE_1;
 
-	uint8 padding_28A80[0x28DFC - 0x28A80];
+	uint8 padding_28AA8[0x28AD0 - 0x28AA8];
+
+	/* +0x28AD0 */ _LatteRegisterSetStreamoutBuffer VGT_STRMOUT_BUFFER_X[4];
+	/* +0x28B10 */ Latte::LATTE_VGT_STRMOUT_BASE_OFFSET_X VGT_STRMOUT_BASE_OFFSET_X[4];
+	/* +0x28B20 */ Latte::LATTE_VGT_STRMOUT_BUFFER_EN VGT_STRMOUT_BUFFER_EN;
+
+	uint8 padding_28B24[0x28DFC - 0x28B24];
 
 	/* +0x28DFC */ Latte::LATTE_PA_SU_POLY_OFFSET_CLAMP PA_SU_POLY_OFFSET_CLAMP;
 	/* +0x28E00 */ Latte::LATTE_PA_SU_POLY_OFFSET_FRONT_SCALE PA_SU_POLY_OFFSET_FRONT_SCALE;
@@ -1334,6 +1605,13 @@ static_assert(offsetof(LatteContextRegister, CB_TARGET_MASK) == Latte::REGADDR::
 static_assert(offsetof(LatteContextRegister, PA_SC_GENERIC_SCISSOR_TL) == Latte::REGADDR::PA_SC_GENERIC_SCISSOR_TL * 4);
 static_assert(offsetof(LatteContextRegister, PA_SC_GENERIC_SCISSOR_BR) == Latte::REGADDR::PA_SC_GENERIC_SCISSOR_BR * 4);
 static_assert(offsetof(LatteContextRegister, VGT_MULTI_PRIM_IB_RESET_INDX) == Latte::REGADDR::VGT_MULTI_PRIM_IB_RESET_INDX * 4);
+static_assert(offsetof(LatteContextRegister, VGT_PRIMITIVEID_EN) == Latte::REGADDR::VGT_PRIMITIVEID_EN * 4);
+static_assert(offsetof(LatteContextRegister, VGT_MULTI_PRIM_IB_RESET_EN) == Latte::REGADDR::VGT_MULTI_PRIM_IB_RESET_EN * 4);
+static_assert(offsetof(LatteContextRegister, VGT_INSTANCE_STEP_RATE_0) == Latte::REGADDR::VGT_INSTANCE_STEP_RATE_0 * 4);
+static_assert(offsetof(LatteContextRegister, VGT_INSTANCE_STEP_RATE_1) == Latte::REGADDR::VGT_INSTANCE_STEP_RATE_1 * 4);
+static_assert(offsetof(LatteContextRegister, VGT_STRMOUT_BUFFER_X) == Latte::REGADDR::VGT_STRMOUT_BUFFER_SIZE_0 * 4);
+static_assert(offsetof(LatteContextRegister, VGT_STRMOUT_BASE_OFFSET_X) == Latte::REGADDR::VGT_STRMOUT_BASE_OFFSET_0 * 4);
+static_assert(offsetof(LatteContextRegister, VGT_STRMOUT_BUFFER_EN) == Latte::REGADDR::VGT_STRMOUT_BUFFER_EN * 4);
 static_assert(offsetof(LatteContextRegister, SX_ALPHA_TEST_CONTROL) == Latte::REGADDR::SX_ALPHA_TEST_CONTROL * 4);
 static_assert(offsetof(LatteContextRegister, DB_STENCILREFMASK) == Latte::REGADDR::DB_STENCILREFMASK * 4);
 static_assert(offsetof(LatteContextRegister, DB_STENCILREFMASK_BF) == Latte::REGADDR::DB_STENCILREFMASK_BF * 4);
@@ -1351,6 +1629,7 @@ static_assert(offsetof(LatteContextRegister, PA_CL_VPORT_ZOFFSET) == Latte::REGA
 static_assert(offsetof(LatteContextRegister, PA_CL_CLIP_CNTL) == Latte::REGADDR::PA_CL_CLIP_CNTL * 4);
 static_assert(offsetof(LatteContextRegister, PA_SU_SC_MODE_CNTL) == Latte::REGADDR::PA_SU_SC_MODE_CNTL * 4);
 static_assert(offsetof(LatteContextRegister, PA_CL_VTE_CNTL) == Latte::REGADDR::PA_CL_VTE_CNTL * 4);
+static_assert(offsetof(LatteContextRegister, PA_CL_VS_OUT_CNTL) == Latte::REGADDR::PA_CL_VS_OUT_CNTL * 4);
 static_assert(offsetof(LatteContextRegister, PA_SU_POINT_SIZE) == Latte::REGADDR::PA_SU_POINT_SIZE * 4);
 static_assert(offsetof(LatteContextRegister, PA_SU_POINT_MINMAX) == Latte::REGADDR::PA_SU_POINT_MINMAX * 4);
 static_assert(offsetof(LatteContextRegister, CB_BLENDN_CONTROL) == Latte::REGADDR::CB_BLEND0_CONTROL * 4);
@@ -1363,7 +1642,21 @@ static_assert(offsetof(LatteContextRegister, PA_SU_POLY_OFFSET_FRONT_SCALE) == L
 static_assert(offsetof(LatteContextRegister, PA_SU_POLY_OFFSET_FRONT_OFFSET) == Latte::REGADDR::PA_SU_POLY_OFFSET_FRONT_OFFSET * 4);
 static_assert(offsetof(LatteContextRegister, PA_SU_POLY_OFFSET_BACK_SCALE) == Latte::REGADDR::PA_SU_POLY_OFFSET_BACK_SCALE * 4);
 static_assert(offsetof(LatteContextRegister, PA_SU_POLY_OFFSET_BACK_OFFSET) == Latte::REGADDR::PA_SU_POLY_OFFSET_BACK_OFFSET * 4);
+static_assert(offsetof(LatteContextRegister, SQ_VTX_SEMANTIC_X) == Latte::REGADDR::SQ_VTX_SEMANTIC_0 * 4);
+static_assert(offsetof(LatteContextRegister, SQ_VTX_SEMANTIC_CLEAR) == Latte::REGADDR::SQ_VTX_SEMANTIC_CLEAR * 4);
 static_assert(offsetof(LatteContextRegister, SQ_TEX_START_PS) == Latte::REGADDR::SQ_TEX_RESOURCE_WORD0_N_PS * 4);
 static_assert(offsetof(LatteContextRegister, SQ_TEX_START_VS) == Latte::REGADDR::SQ_TEX_RESOURCE_WORD0_N_VS * 4);
 static_assert(offsetof(LatteContextRegister, SQ_TEX_START_GS) == Latte::REGADDR::SQ_TEX_RESOURCE_WORD0_N_GS * 4);
 static_assert(offsetof(LatteContextRegister, SQ_TEX_SAMPLER) == Latte::REGADDR::SQ_TEX_SAMPLER_WORD0_0 * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_START_PS) == Latte::REGADDR::SQ_PGM_START_PS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_RESOURCES_PS) == Latte::REGADDR::SQ_PGM_RESOURCES_PS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_START_VS) == Latte::REGADDR::SQ_PGM_START_VS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_RESOURCES_VS) == Latte::REGADDR::SQ_PGM_RESOURCES_VS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_START_FS) == Latte::REGADDR::SQ_PGM_START_FS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_RESOURCES_FS) == Latte::REGADDR::SQ_PGM_RESOURCES_FS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_START_ES) == Latte::REGADDR::SQ_PGM_START_ES * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_RESOURCES_ES) == Latte::REGADDR::SQ_PGM_RESOURCES_ES * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_START_GS) == Latte::REGADDR::SQ_PGM_START_GS * 4);
+static_assert(offsetof(LatteContextRegister, SQ_PGM_RESOURCES_GS) == Latte::REGADDR::SQ_PGM_RESOURCES_GS * 4);
+static_assert(offsetof(LatteContextRegister, SPI_VS_OUT_CONFIG) == Latte::REGADDR::SPI_VS_OUT_CONFIG * 4);
+static_assert(offsetof(LatteContextRegister, LATTE_SPI_VS_OUT_ID_N) == Latte::REGADDR::SPI_VS_OUT_ID_0 * 4);

--- a/src/Cafe/HW/Latte/ISA/RegDefines.h
+++ b/src/Cafe/HW/Latte/ISA/RegDefines.h
@@ -50,8 +50,6 @@
 #define mmVGT_PRIMITIVEID_EN                            0xA2A1
 #define mmVGT_VTX_CNT_EN                                0xA2AE
 #define mmVGT_REUSE_OFF                                 0xA2AD
-#define mmVGT_INSTANCE_STEP_RATE_0                      0xA2A8
-#define mmVGT_INSTANCE_STEP_RATE_1                      0xA2A9
 #define mmVGT_MAX_VTX_INDX                              0xA100
 #define mmVGT_MIN_VTX_INDX                              0xA101
 #define mmVGT_INDX_OFFSET                               0xA102

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSL.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSL.cpp
@@ -4037,8 +4037,8 @@ void LatteDecompiler_emitGLSLShader(LatteDecompilerShaderContext* shaderContext,
 		for (auto& subroutineInfo : shaderContext->list_subroutines)
 		{
 			sint32 subroutineMaxStackDepth = 0;
-			src->addFmt("bool activeMaskStackSub%04x[{}];" _CRLF, subroutineInfo.cfAddr, subroutineMaxStackDepth + 1);
-			src->addFmt("bool activeMaskStackCSub%04x[{}];" _CRLF, subroutineInfo.cfAddr, subroutineMaxStackDepth + 2);
+			src->addFmt("bool activeMaskStackSub{:04x}[{}];" _CRLF, subroutineInfo.cfAddr, subroutineMaxStackDepth + 1);
+			src->addFmt("bool activeMaskStackCSub{:04x}[{}];" _CRLF, subroutineInfo.cfAddr, subroutineMaxStackDepth + 2);
 		}
 	}
 	// helper variables for cube maps (todo: Only emit when used)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -335,6 +335,7 @@ void RendererShaderVk::CompileInternal(bool isRenderThread)
 	if (!Shader.parse(&Resources, 100, false, messagesParseLink))
 	{
 		cemuLog_log(LogType::Force, fmt::format("GLSL parsing failed for {:016x}_{:016x}: \"{}\"", m_baseHash, m_auxHash, Shader.getInfoLog()));
+		cemuLog_logDebug(LogType::Force, "GLSL source:\n{}", m_glslCode);
 		cemu_assert_debug(false);
 		FinishCompilation();
 		return;

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -39,20 +39,22 @@ VHeap rplLoaderHeap_workarea(nullptr, MEMORY_RPLLOADER_AREA_SIZE);
 PPCCodeHeap rplLoaderHeap_lowerAreaCodeMem2(nullptr, MEMORY_CODE_TRAMPOLINE_AREA_SIZE);
 PPCCodeHeap rplLoaderHeap_codeArea2(nullptr, MEMORY_CODEAREA_SIZE);
 
-bool rplLoader_applicationHasMemoryControl = false;
-uint32 rplLoader_maxCodeAddress = 0; // highest used code address
-
 ChunkedFlatAllocator<64 * 1024> g_heapTrampolineArea;
 
-std::vector<rplDependency_t*> rplDependencyList = std::vector<rplDependency_t*>();
+std::vector<RPLDependency*> rplDependencyList;
 
 RPLModule* rplModuleList[256];
 sint32 rplModuleCount = 0;
 
-uint32 _currentTLSModuleIndex = 1; // value 0 is reserved
-
+bool rplLoader_applicationHasMemoryControl = false;
+uint32 rplLoader_maxCodeAddress = 0; // highest used code address
+uint32 rplLoader_currentTLSModuleIndex = 1; // value 0 is reserved
+uint32 rplLoader_currentHandleCounter = 0x00001000;
+sint16 rplLoader_currentTlsModuleIndex = 0x0001;
+RPLModule* rplLoader_mainModule = nullptr;
 uint32 rplLoader_sdataAddr = MPTR_NULL; // r13
 uint32 rplLoader_sdata2Addr = MPTR_NULL; // r2
+uint32 rplLoader_currentDataAllocatorAddr = 0x10000000;
 
 std::map<void(*)(PPCInterpreter_t* hCPU), uint32> g_map_callableExports;
 
@@ -110,8 +112,6 @@ MPTR RPLLoader_AllocateCodeSpace(uint32 size, uint32 alignment)
 	return codeAddr;
 }
 
-uint32 rpl3_currentDataAllocatorAddr = 0x10000000;
-
 uint32 RPLLoader_AllocateDataSpace(RPLModule* rpl, uint32 size, uint32 alignment)
 {
 	if (rplLoader_applicationHasMemoryControl)
@@ -121,9 +121,9 @@ uint32 RPLLoader_AllocateDataSpace(RPLModule* rpl, uint32 size, uint32 alignment
 		PPCCoreCallback(rpl->funcAlloc.value(), size, alignment, memPtr.GetPointer());
 		return (uint32)*(memPtr.GetPointer());
 	}
-	rpl3_currentDataAllocatorAddr = (rpl3_currentDataAllocatorAddr + alignment - 1)&~(alignment-1);
-	uint32 mem = rpl3_currentDataAllocatorAddr;
-	rpl3_currentDataAllocatorAddr += size;
+	rplLoader_currentDataAllocatorAddr = (rplLoader_currentDataAllocatorAddr + alignment - 1) & ~(alignment - 1);
+	uint32 mem = rplLoader_currentDataAllocatorAddr;
+	rplLoader_currentDataAllocatorAddr += size;
 	return mem;
 }
 
@@ -134,7 +134,7 @@ void RPLLoader_FreeData(RPLModule* rpl, void* ptr)
 
 uint32 RPLLoader_GetDataAllocatorAddr()
 {
-	return (rpl3_currentDataAllocatorAddr + 0xFFF)&(~0xFFF);
+	return (rplLoader_currentDataAllocatorAddr + 0xFFF) & (~0xFFF);
 }
 
 uint32 RPLLoader_GetMaxCodeOffset()
@@ -1385,12 +1385,11 @@ bool RPLLoader_HandleRelocs(RPLModule* rplLoaderContext, std::span<RPLSharedImpo
 	return true;
 }
 
-void _RPLLoader_ExtractModuleNameFromPath(char* output, const char* input)
+void _RPLLoader_ExtractModuleNameFromPath(char* output, std::string_view input)
 {
 	// scan to last '/'
-	sint32 inputLen = (sint32)strlen(input);
-	cemu_assert(inputLen > 0);
-	sint32 startIndex = inputLen - 1;
+	cemu_assert(!input.empty());
+	size_t startIndex = input.size() - 1;
 	while (startIndex > 0)
 	{
 		if (input[startIndex] == '/')
@@ -1401,23 +1400,20 @@ void _RPLLoader_ExtractModuleNameFromPath(char* output, const char* input)
 		startIndex--;
 	}
 	// cut off after '.'
-	sint32 endIndex = startIndex;
-	while (endIndex <= inputLen)
+	size_t endIndex = startIndex;
+	while (endIndex < input.size())
 	{
 		if (input[endIndex] == '.')
 			break;
 		endIndex++;
 	}
-	sint32 nameLen = endIndex - startIndex;
+	size_t nameLen = endIndex - startIndex;
 	cemu_assert(nameLen != 0);
-	nameLen = std::min(nameLen, RPL_MODULE_NAME_LENGTH-1);
-	memcpy(output, input + startIndex, nameLen);
+	nameLen = std::min<size_t>(nameLen, RPL_MODULE_NAME_LENGTH-1);
+	memcpy(output, input.data() + startIndex, nameLen);
 	output[nameLen] = '\0';
 	// convert to lower case
-	for (sint32 i = 0; i < nameLen; i++)
-	{
-		output[i] = _ansiToLower(output[i]);
-	}
+	std::for_each(output, output + nameLen, [](char& c) {c = _ansiToLower(c);});
 }
 
 void RPLLoader_InitState()
@@ -1430,27 +1426,6 @@ void RPLLoader_InitState()
 	rplLoaderHeap_workarea.setHeapBase(memory_getPointerFromVirtualOffset(MEMORY_RPLLOADER_AREA_ADDR));
 	g_heapTrampolineArea.setBaseAllocator(&rplLoaderHeap_lowerAreaCodeMem2);
     RPLLoader_ResetState();
-}
-
-void RPLLoader_ResetState()
-{
-	// unload all RPL modules
-	while (rplModuleCount > 0)
-		RPLLoader_UnloadModule(rplModuleList[0]);
-    rplDependencyList.clear();
-	// unload all remaining symbols
-	rplSymbolStorage_unloadAll();
-	// free all code imports
-	g_heapTrampolineArea.releaseAll();
-	list_mappedFunctionImports.clear();
-	g_map_callableExports.clear();
-
-	rplLoader_applicationHasMemoryControl = false;
-	rplLoader_maxCodeAddress = 0;
-	rpl3_currentDataAllocatorAddr = 0x10000000;
-	_currentTLSModuleIndex = 1;
-	rplLoader_sdataAddr = MPTR_NULL;
-	rplLoader_sdata2Addr = MPTR_NULL;
 }
 
 void RPLLoader_BeginCemuhookCRC(RPLModule* rpl)
@@ -1610,7 +1585,7 @@ void RPLLoader_InitModuleAllocator(RPLModule* rpl)
 }
 
 // map rpl into memory, but do not resolve relocs and imports yet
-RPLModule* rpl_loadFromMem(uint8* rplData, sint32 size, char* name)
+RPLModule* RPLLoader_LoadFromMemory(uint8* rplData, sint32 size, char* name)
 {
 	char moduleName[RPL_MODULE_NAME_LENGTH];
 	_RPLLoader_ExtractModuleNameFromPath(moduleName, name);
@@ -1699,7 +1674,7 @@ RPLModule* rpl_loadFromMem(uint8* rplData, sint32 size, char* name)
 	return rpl;
 }
 
-void RPLLoader_flushMemory(RPLModule* rpl)
+void RPLLoader_FlushMemory(RPLModule* rpl)
 {
 	// invalidate recompiler cache
 	PPCRecompiler_invalidateRange(rpl->regionMappingBase_text.GetMPTR(), rpl->regionMappingBase_text.GetMPTR() + rpl->regionSize_text);
@@ -1755,7 +1730,7 @@ void RPLLoader_LinkSingleModule(RPLModule* rplLoaderContext, bool resolveOnlyExp
 	else
 		RPLLoader_HandleRelocs(rplLoaderContext, sharedImportTracking, 0);
 
-	RPLLoader_flushMemory(rplLoaderContext);
+	RPLLoader_FlushMemory(rplLoaderContext);
 }
 
 void RPLLoader_LoadSectionDebugSymbols(RPLModule* rplLoaderContext, rplSectionEntryNew_t* section, int symtabSectionIndex)
@@ -1919,8 +1894,24 @@ uint32 RPLLoader_GetModuleEntrypoint(RPLModule* rplLoaderContext)
 	return rplLoaderContext->entrypoint;
 }
 
-uint32 rplLoader_currentHandleCounter = 0x00001000;
-sint16 rplLoader_currentTlsModuleIndex = 0x0001;
+// takes a module name without extension, returns true if the RPL module is a known Cafe OS module
+bool RPLLoader_IsKnownCafeOSModule(std::string_view name)
+{
+	static std::unordered_set<std::string> s_systemModules556 = {
+			"avm","camera","coreinit","dc","dmae","drmapp","erreula",
+			"gx2","h264","lzma920","mic","nfc","nio_prof","nlibcurl",
+			"nlibnss","nlibnss2","nn_ac","nn_acp","nn_act","nn_aoc","nn_boss",
+			"nn_ccr","nn_cmpt","nn_dlp","nn_ec","nn_fp","nn_hai","nn_hpad",
+			"nn_idbe","nn_ndm","nn_nets2","nn_nfp","nn_nim","nn_olv","nn_pdm",
+			"nn_save","nn_sl","nn_spm","nn_temp","nn_uds","nn_vctl","nsysccr",
+			"nsyshid","nsyskbd","nsysnet","nsysuhs","nsysuvd","ntag","padscore",
+			"proc_ui","sndcore2","snduser2","snd_core","snd_user","swkbd","sysapp",
+			"tcl","tve","uac","uac_rpl","usb_mic","uvc","uvd","vpad","vpadbase",
+			"zlib125"};
+	std::string nameLower{name};
+	std::transform(nameLower.begin(), nameLower.end(), nameLower.begin(), _ansiToLower);
+	return s_systemModules556.contains(nameLower);
+}
 
 // increment reference counter for module
 void RPLLoader_AddDependency(const char* name)
@@ -1946,18 +1937,18 @@ void RPLLoader_AddDependency(const char* name)
 	{
 		if (strcmp(moduleName, dep->modulename) == 0)
 		{
-			// entry already exists, increment reference counter
 			dep->referenceCount++;
 			return;
 		}
 	}
 	// add new entry
-	rplDependency_t* newDependency = new rplDependency_t();
+	RPLDependency* newDependency = new RPLDependency();
 	strcpy(newDependency->modulename, moduleName);
 	newDependency->referenceCount = 1;
 	newDependency->coreinitHandle = rplLoader_currentHandleCounter;
 	newDependency->tlsModuleIndex = rplLoader_currentTlsModuleIndex;
-	rplLoader_currentTlsModuleIndex++;
+	newDependency->isCafeOSModule = RPLLoader_IsKnownCafeOSModule(moduleName);
+	rplLoader_currentTlsModuleIndex++; // todo - delay handle and tls allocation until the module is actually loaded. It may not exist
 	rplLoader_currentHandleCounter++;
 	if (rplLoader_currentTlsModuleIndex == 0x7FFF)
 		cemuLog_log(LogType::Force, "RPLLoader: Exhausted TLS module indices pool");
@@ -2005,6 +1996,18 @@ void RPLLoader_RemoveDependency(const char* name)
 	}
 }
 
+bool RPLLoader_HasDependency(std::string_view name)
+{
+	char moduleName[RPL_MODULE_NAME_LENGTH];
+	_RPLLoader_ExtractModuleNameFromPath(moduleName, name);
+	for (const auto& dep : rplDependencyList)
+	{
+		if (strcmp(moduleName, dep->modulename) == 0)
+			return true;
+	}
+	return false;
+}
+
 // decrement reference counter for dependency by module handle
 void RPLLoader_RemoveDependency(uint32 handle)
 {
@@ -2030,6 +2033,9 @@ uint32 RPLLoader_GetHandleByModuleName(const char* name)
 	{
 		if (strcmp(moduleName, dep->modulename) == 0)
 		{
+			cemu_assert_debug(dep->loadAttempted);
+			if (!dep->isCafeOSModule && !dep->rplLoaderContext)
+				return RPL_INVALID_HANDLE; // module not found
 			return dep->coreinitHandle;
 		}
 	}
@@ -2062,21 +2068,21 @@ bool RPLLoader_GetTLSDataByTLSIndex(sint16 tlsModuleIndex, uint8** tlsData, sint
 	return true;
 }
 
-bool RPLLoader_LoadFromVirtualPath(rplDependency_t* dependency, char* filePath)
+bool RPLLoader_LoadFromVirtualPath(RPLDependency* dependency, char* filePath)
 {
 	uint32 rplSize = 0;
 	uint8* rplData = fsc_extractFile(filePath, &rplSize);
 	if (rplData)
 	{
 		cemuLog_logDebug(LogType::Force, "Loading: {}", filePath);
-		dependency->rplLoaderContext = rpl_loadFromMem(rplData, rplSize, filePath);
+		dependency->rplLoaderContext = RPLLoader_LoadFromMemory(rplData, rplSize, filePath);
 		free(rplData);
 		return true;
 	}
 	return false;
 }
 
-void RPLLoader_LoadDependency(rplDependency_t* dependency)
+void RPLLoader_LoadDependency(RPLDependency* dependency)
 {
 	dependency->loadAttempted = true;
 	// check if module is already loaded
@@ -2084,11 +2090,9 @@ void RPLLoader_LoadDependency(rplDependency_t* dependency)
 	{
 		if(!boost::iequals(rplModuleList[i]->moduleName2, dependency->modulename))
 			continue;
-		// already loaded
 		dependency->rplLoaderContext = rplModuleList[i];
 		return;
 	}
-	// attempt to load rpl from various locations
 	char filePath[RPL_MODULE_PATH_LENGTH];
 	// check if path is absolute
 	if (dependency->filepath[0] == '/')
@@ -2097,7 +2101,7 @@ void RPLLoader_LoadDependency(rplDependency_t* dependency)
 		RPLLoader_LoadFromVirtualPath(dependency, filePath);
 		return;
 	}
-	// attempt to load rpl from internal folder
+	// attempt to load rpl from code directory of current title
 	strcpy_s(filePath, "/internal/current_title/code/");
 	strcat_s(filePath, dependency->filepath);
 	// except if it is blacklisted
@@ -2119,7 +2123,8 @@ void RPLLoader_LoadDependency(rplDependency_t* dependency)
 		if (fileData)
 		{
 			cemuLog_log(LogType::Force, "Loading RPL: /cafeLibs/{}", dependency->filepath);
-			dependency->rplLoaderContext = rpl_loadFromMem(fileData->data(), fileData->size(), dependency->filepath);
+			dependency->rplLoaderContext = RPLLoader_LoadFromMemory(fileData->data(), fileData->size(),
+																	dependency->filepath);
 			return;
 		}
 	}
@@ -2167,8 +2172,6 @@ void RPLLoader_UpdateDependencies()
 	}
 	RPLLoader_Link();
 }
-
-RPLModule* rplLoader_mainModule = nullptr;
 
 void RPLLoader_SetMainModule(RPLModule* rplLoaderContext)
 {
@@ -2250,7 +2253,7 @@ uint32 RPLLoader_FindModuleOrHLEExport(uint32 moduleHandle, bool isData, const c
 {
 	// find dependency from handle
 	RPLModule* rplLoaderContext = nullptr;
-	rplDependency_t* dependency = nullptr;
+	RPLDependency* dependency = nullptr;
 	for (auto& dep : rplDependencyList)
 	{
 		if (dep->coreinitHandle == moduleHandle)
@@ -2378,4 +2381,25 @@ MEMPTR<void> RPLLoader_AllocateCodeCaveMem(uint32 alignment, uint32 size)
 void RPLLoader_ReleaseCodeCaveMem(MEMPTR<void> addr)
 {
 	heapCodeCaveArea.free(addr.GetMPTR());
+}
+
+void RPLLoader_ResetState()
+{
+	// unload all RPL modules
+	while (rplModuleCount > 0)
+		RPLLoader_UnloadModule(rplModuleList[0]);
+	rplDependencyList.clear();
+	// unload all remaining symbols
+	rplSymbolStorage_unloadAll();
+	// free all code imports
+	g_heapTrampolineArea.releaseAll();
+	list_mappedFunctionImports.clear();
+	g_map_callableExports.clear();
+	rplLoader_applicationHasMemoryControl = false;
+	rplLoader_maxCodeAddress = 0;
+	rplLoader_currentDataAllocatorAddr = 0x10000000;
+	rplLoader_currentTLSModuleIndex = 1;
+	rplLoader_sdataAddr = MPTR_NULL;
+	rplLoader_sdata2Addr = MPTR_NULL;
+	rplLoader_mainModule = nullptr;
 }

--- a/src/Cafe/OS/RPL/rpl.h
+++ b/src/Cafe/OS/RPL/rpl.h
@@ -2,7 +2,7 @@
 
 struct RPLModule;
 
-#define RPL_INVALID_HANDLE	(0xFFFFFFFF)
+#define RPL_INVALID_HANDLE		0xFFFFFFFF
 
 void RPLLoader_InitState();
 void RPLLoader_ResetState();
@@ -14,7 +14,7 @@ MPTR RPLLoader_AllocateCodeSpace(uint32 size, uint32 alignment);
 uint32 RPLLoader_GetMaxCodeOffset();
 uint32 RPLLoader_GetDataAllocatorAddr();
 
-RPLModule* rpl_loadFromMem(uint8* rplData, sint32 size, char* name);
+RPLModule* RPLLoader_LoadFromMemory(uint8* rplData, sint32 size, char* name);
 uint32 rpl_mapHLEImport(RPLModule* rplLoaderContext, const char* rplName, const char* funcName, bool functionMustExist);
 void RPLLoader_Link();
 
@@ -29,6 +29,7 @@ void RPLLoader_NotifyControlPassedToApplication();
 
 void RPLLoader_AddDependency(const char* name);
 void RPLLoader_RemoveDependency(uint32 handle);
+bool RPLLoader_HasDependency(std::string_view name);
 void RPLLoader_UpdateDependencies();
 
 uint32 RPLLoader_GetHandleByModuleName(const char* name);

--- a/src/Cafe/OS/RPL/rpl_structs.h
+++ b/src/Cafe/OS/RPL/rpl_structs.h
@@ -225,17 +225,17 @@ struct RPLModule
 
 };
 
-typedef struct
+struct RPLDependency
 {
 	char modulename[RPL_MODULE_NAME_LENGTH];
 	char filepath[RPL_MODULE_PATH_LENGTH];
 	bool loadAttempted;
-	//bool isHLEModule; // determined to be a HLE module
-	RPLModule* rplLoaderContext; // context of loaded module
+	bool isCafeOSModule; // name is a known Cafe OS RPL
+	RPLModule* rplLoaderContext; // context of loaded module, can be nullptr for HLE COS modules
 	sint32 referenceCount;
 	uint32 coreinitHandle; // fake handle for coreinit
 	sint16 tlsModuleIndex; // tls module index assigned to this dependency
-}rplDependency_t;
+};
 
 RPLModule* RPLLoader_FindModuleByCodeAddr(uint32 addr);
 RPLModule* RPLLoader_FindModuleByDataAddr(uint32 addr);

--- a/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
@@ -86,8 +86,7 @@ namespace coreinit
 		}
 		// search for loaded modules with matching name
 		uint32 rplHandle = RPLLoader_GetHandleByModuleName(libName);
-
-		if (rplHandle == RPL_INVALID_HANDLE)
+		if (rplHandle == RPL_INVALID_HANDLE && !RPLLoader_HasDependency(libName))
 		{
 			RPLLoader_AddDependency(libName);
 			RPLLoader_UpdateDependencies();
@@ -100,7 +99,10 @@ namespace coreinit
 		else
 			*moduleHandleOut = rplHandle;
 		if (rplHandle == RPL_INVALID_HANDLE)
+		{
+			cemuLog_logDebug(LogType::Force, "OSDynLoad_Acquire() failed to load module '{}'", libName);
 			return 0xFFFCFFE9; // module not found
+		}
 		return 0;
 	}
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.h
@@ -42,13 +42,15 @@ namespace coreinit
 
 		/* +0x00 */ MPTR firstMPTR;
 		/* +0x04 */ MPTR lastMPTR;
-		/* +0x08 */ OSMutex mutex;
+		/* +0x08 */ OSFastMutex fastMutex;
 		/* +0x34 */ MPTR dequeueHandlerFuncMPTR;
 		/* +0x38 */ uint32be numCommandsInFlight;
 		/* +0x3C */ uint32 numMaxCommandsInFlight;
 		/* +0x40 */ betype<QUEUE_FLAG> queueFlags;
 	};
 	DEFINE_ENUM_FLAG_OPERATORS(FSCmdQueue::QUEUE_FLAG);
+
+	static_assert(sizeof(FSCmdQueue) == 0x44);
 
 #define FS_CLIENT_BUFFER_SIZE (5888)
 #define FS_CMD_BLOCK_SIZE (2688)

--- a/src/Cafe/OS/libs/coreinit/coreinit_Synchronization.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Synchronization.cpp
@@ -621,49 +621,49 @@ namespace coreinit
 		OSInitEvent(g_rendezvousEvent.GetPtr(), OSEvent::EVENT_STATE::STATE_NOT_SIGNALED, OSEvent::EVENT_MODE::MODE_AUTO);
 
 		// OSEvent
-		cafeExportRegister("coreinit", OSInitEvent, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSInitEventEx, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSResetEvent, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSWaitEvent, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSWaitEventWithTimeout, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSSignalEvent, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSSignalEventAll, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSInitEvent, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSInitEventEx, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSResetEvent, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSWaitEvent, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSWaitEventWithTimeout, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSSignalEvent, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSSignalEventAll, LogType::CoreinitThreadSync);
 
 		// OSRendezvous
-		cafeExportRegister("coreinit", OSInitRendezvous, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSWaitRendezvous, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSInitRendezvous, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSWaitRendezvous, LogType::CoreinitThreadSync);
 
 		// OSMutex
-		cafeExportRegister("coreinit", OSInitMutex, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSInitMutexEx, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSLockMutex, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSTryLockMutex, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSUnlockMutex, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSInitMutex, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSInitMutexEx, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSLockMutex, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSTryLockMutex, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSUnlockMutex, LogType::CoreinitThreadSync);
 
 		// OSCond
-		cafeExportRegister("coreinit", OSInitCond, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSInitCondEx, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSSignalCond, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSWaitCond, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSInitCond, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSInitCondEx, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSSignalCond, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSWaitCond, LogType::CoreinitThreadSync);
 
 		// OSSemaphore
-		cafeExportRegister("coreinit", OSInitSemaphore, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSInitSemaphoreEx, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSWaitSemaphore, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSTryWaitSemaphore, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSSignalSemaphore, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSGetSemaphoreCount, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSInitSemaphore, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSInitSemaphoreEx, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSWaitSemaphore, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSTryWaitSemaphore, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSSignalSemaphore, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSGetSemaphoreCount, LogType::CoreinitThreadSync);
 
 		// OSFastMutex
-		cafeExportRegister("coreinit", OSFastMutex_Init, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSFastMutex_Lock, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSFastMutex_TryLock, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSFastMutex_Unlock, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSFastMutex_Init, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSFastMutex_Lock, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSFastMutex_TryLock, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSFastMutex_Unlock, LogType::CoreinitThreadSync);
 
 		// OSFastCond
-		cafeExportRegister("coreinit", OSFastCond_Init, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSFastCond_Wait, LogType::ThreadSync);
-		cafeExportRegister("coreinit", OSFastCond_Signal, LogType::ThreadSync);
+		cafeExportRegister("coreinit", OSFastCond_Init, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSFastCond_Wait, LogType::CoreinitThreadSync);
+		cafeExportRegister("coreinit", OSFastCond_Signal, LogType::CoreinitThreadSync);
 	}
 
 };

--- a/src/Cafe/OS/libs/gx2/GX2.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2.cpp
@@ -396,12 +396,7 @@ void gx2_load()
 	osLib_addFunction("gx2", "GX2GetCurrentScanBuffer", gx2Export_GX2GetCurrentScanBuffer);
 
 	// shader stuff
-	osLib_addFunction("gx2", "GX2GetVertexShaderGPRs", gx2Export_GX2GetVertexShaderGPRs);
-	osLib_addFunction("gx2", "GX2GetVertexShaderStackEntries", gx2Export_GX2GetVertexShaderStackEntries);
-	osLib_addFunction("gx2", "GX2GetPixelShaderGPRs", gx2Export_GX2GetPixelShaderGPRs);
-	osLib_addFunction("gx2", "GX2GetPixelShaderStackEntries", gx2Export_GX2GetPixelShaderStackEntries);
-	osLib_addFunction("gx2", "GX2SetFetchShader", gx2Export_GX2SetFetchShader);
-	osLib_addFunction("gx2", "GX2SetVertexShader", gx2Export_GX2SetVertexShader);
+	//osLib_addFunction("gx2", "GX2SetVertexShader", gx2Export_GX2SetVertexShader);
 	osLib_addFunction("gx2", "GX2SetPixelShader", gx2Export_GX2SetPixelShader);
 	osLib_addFunction("gx2", "GX2SetGeometryShader", gx2Export_GX2SetGeometryShader);
 	osLib_addFunction("gx2", "GX2SetComputeShader", gx2Export_GX2SetComputeShader);

--- a/src/Cafe/OS/libs/gx2/GX2.h
+++ b/src/Cafe/OS/libs/gx2/GX2.h
@@ -20,12 +20,6 @@ void gx2_load();
 
 // shader
 
-void gx2Export_GX2SetFetchShader(PPCInterpreter_t* hCPU);
-void gx2Export_GX2GetVertexShaderGPRs(PPCInterpreter_t* hCPU);
-void gx2Export_GX2GetVertexShaderStackEntries(PPCInterpreter_t* hCPU);
-void gx2Export_GX2GetPixelShaderGPRs(PPCInterpreter_t* hCPU);
-void gx2Export_GX2GetPixelShaderStackEntries(PPCInterpreter_t* hCPU);
-void gx2Export_GX2SetVertexShader(PPCInterpreter_t* hCPU);
 void gx2Export_GX2SetPixelShader(PPCInterpreter_t* hCPU);
 void gx2Export_GX2SetGeometryShader(PPCInterpreter_t* hCPU);
 void gx2Export_GX2SetComputeShader(PPCInterpreter_t* hCPU);

--- a/src/Cafe/OS/libs/gx2/GX2_Command.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Command.cpp
@@ -263,7 +263,7 @@ namespace GX2
 
 		if (patchType == GX2_PATCH_TYPE::VERTEX_SHADER)
 		{
-			GX2VertexShader_t* vertexShader = (GX2VertexShader_t*)obj;
+			GX2VertexShader* vertexShader = (GX2VertexShader*)obj;
 			displayData[patchOffset / 4 + 2] = memory_virtualToPhysical(vertexShader->GetProgramAddr()) >> 8;
 		}
 		else if (patchType == GX2_PATCH_TYPE::PIXEL_SHADER)
@@ -273,7 +273,7 @@ namespace GX2
 		}
 		else if (patchType == GX2_PATCH_TYPE::FETCH_SHADER)
 		{
-			GX2FetchShader_t* fetchShader = (GX2FetchShader_t*)obj;
+			GX2FetchShader* fetchShader = (GX2FetchShader*)obj;
 			displayData[patchOffset / 4 + 2] = memory_virtualToPhysical(fetchShader->GetProgramAddr()) >> 8;
 		}
 		else if (patchType == GX2_PATCH_TYPE::GEOMETRY_COPY_SHADER)

--- a/src/Cafe/OS/libs/gx2/GX2_Shader.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Shader.cpp
@@ -3,6 +3,7 @@
 #include "GX2_Shader.h"
 #include "Cafe/HW/Latte/Core/LatteConst.h"
 #include "Cafe/HW/Latte/Core/LattePM4.h"
+#include "Cafe/HW/Latte/ISA/LatteReg.h"
 #include "Cafe/HW/Latte/ISA/LatteInstructions.h"
 
 uint32 memory_getVirtualOffsetFromPointer(void* ptr); // remove once we updated everything to MEMPTR
@@ -70,9 +71,9 @@ namespace GX2
 	static_assert(sizeof(betype<LatteConst::VertexFetchEndianMode>) == 0x4);
 
 	// calculate size of CF program subpart, includes alignment padding for clause instructions
-	size_t _calcFetchShaderCFCodeSize(uint32 attributeCount, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	size_t _calcFetchShaderCFCodeSize(uint32 attributeCount, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
-		cemu_assert_debug(fetchShaderType == GX2FetchShader_t::FetchShaderType::NO_TESSELATION);
+		cemu_assert_debug(fetchShaderType == GX2FetchShader::FetchShaderType::NO_TESSELATION);
 		cemu_assert_debug(tessellationMode == 0);
 		uint32 numCFInstructions = ((attributeCount + 15) / 16) + 1; // one VTX clause can have up to 16 instructions + final CF instruction is RETURN
 		size_t cfSize = numCFInstructions * 8;
@@ -80,16 +81,16 @@ namespace GX2
 		return cfSize;
 	}
 
-	size_t _calcFetchShaderClauseCodeSize(uint32 attributeCount, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	size_t _calcFetchShaderClauseCodeSize(uint32 attributeCount, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
-		cemu_assert_debug(fetchShaderType == GX2FetchShader_t::FetchShaderType::NO_TESSELATION);
+		cemu_assert_debug(fetchShaderType == GX2FetchShader::FetchShaderType::NO_TESSELATION);
 		cemu_assert_debug(tessellationMode == 0);
 		uint32 numClauseInstructions = attributeCount;
 		size_t clauseSize = numClauseInstructions * 16;
 		return clauseSize;
 	}
 
-	void _writeFetchShaderCFCode(void* programBufferOut, uint32 attributeCount, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	void _writeFetchShaderCFCode(void* programBufferOut, uint32 attributeCount, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
 		LatteCFInstruction* cfInstructionWriter = (LatteCFInstruction*)programBufferOut;
 		uint32 attributeIndex = 0;
@@ -111,7 +112,7 @@ namespace GX2
 		memcpy(cfInstructionWriter, &returnInstr, sizeof(LatteCFInstruction));
 	}
 
-	void _writeFetchShaderVTXCode(GX2FetchShader_t* fetchShader, void* programOut, uint32 attributeCount, GX2AttribDescription* attributeDescription, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	void _writeFetchShaderVTXCode(GX2FetchShader* fetchShader, void* programOut, uint32 attributeCount, GX2AttribDescription* attributeDescription, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
 		uint8* writePtr = (uint8*)programOut;
 		// one instruction per attribute (hardcoded into _writeFetchShaderCFCode)
@@ -151,7 +152,7 @@ namespace GX2
 					bool divisorFound = false;
 					for (uint32 i = 0; i < numDivisors; i++)
 					{
-						if (_swapEndianU32(fetchShader->divisors[i]) == attrAluDivisor)
+						if (fetchShader->divisors[i] == attrAluDivisor)
 						{
 							srcSelX = i != 0 ? 2 : 1;
 							divisorFound = true;
@@ -168,7 +169,7 @@ namespace GX2
 						else
 						{
 							srcSelX = numDivisors != 0 ? 2 : 1;
-							fetchShader->divisors[numDivisors] = _swapEndianU32(attrAluDivisor);
+							fetchShader->divisors[numDivisors] = attrAluDivisor;
 							numDivisors++;
 							fetchShader->divisorCount = _swapEndianU32(numDivisors);
 						}
@@ -213,9 +214,9 @@ namespace GX2
 		}
 	}
 
-	uint32 GX2CalcFetchShaderSizeEx(uint32 attributeCount, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	uint32 GX2CalcFetchShaderSizeEx(uint32 attributeCount, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
-		cemu_assert_debug(fetchShaderType == GX2FetchShader_t::FetchShaderType::NO_TESSELATION); // other types are todo
+		cemu_assert_debug(fetchShaderType == GX2FetchShader::FetchShaderType::NO_TESSELATION); // other types are todo
 		cemu_assert_debug(tessellationMode == 0); // other modes are todo
 
 		uint32 finalSize =
@@ -225,9 +226,9 @@ namespace GX2
 		return finalSize;
 	}
 
-	void GX2InitFetchShaderEx(GX2FetchShader_t* fetchShader, void* programBufferOut, uint32 attributeCount, GX2AttribDescription* attributeDescription, GX2FetchShader_t::FetchShaderType fetchShaderType, uint32 tessellationMode)
+	void GX2InitFetchShaderEx(GX2FetchShader* fetchShader, void* programBufferOut, uint32 attributeCount, GX2AttribDescription* attributeDescription, GX2FetchShader::FetchShaderType fetchShaderType, uint32 tessellationMode)
 	{
-		cemu_assert_debug(fetchShaderType == GX2FetchShader_t::FetchShaderType::NO_TESSELATION);
+		cemu_assert_debug(fetchShaderType == GX2FetchShader::FetchShaderType::NO_TESSELATION);
 		cemu_assert_debug(tessellationMode == 0);
 
 		/*
@@ -238,7 +239,7 @@ namespace GX2
 			[CLAUSES]
 		*/
 
-		memset(fetchShader, 0x00, sizeof(GX2FetchShader_t));
+		memset(fetchShader, 0x00, sizeof(GX2FetchShader));
 		fetchShader->attribCount = _swapEndianU32(attributeCount);
 		fetchShader->shaderPtr = (MPTR)_swapEndianU32(memory_getVirtualOffsetFromPointer(programBufferOut));
 
@@ -251,14 +252,181 @@ namespace GX2
 		shaderOutput += _calcFetchShaderClauseCodeSize(attributeCount, fetchShaderType, tessellationMode);
 
 		uint32 shaderSize = (uint32)(shaderOutput - shaderStart);
-		cemu_assert_debug(shaderSize == GX2CalcFetchShaderSizeEx(attributeCount, GX2FetchShader_t::FetchShaderType::NO_TESSELATION, tessellationMode));
+		cemu_assert_debug(shaderSize == GX2CalcFetchShaderSizeEx(attributeCount, GX2FetchShader::FetchShaderType::NO_TESSELATION, tessellationMode));
 
 		fetchShader->shaderSize = _swapEndianU32((uint32)(shaderOutput - shaderStart));
+
+		fetchShader->reg_SQ_PGM_RESOURCES_FS = Latte::LATTE_SQ_PGM_RESOURCES_FS().set_NUM_GPRS(2); // todo - affected by tesselation params?
+	}
+
+	uint32 GX2GetVertexShaderGPRs(GX2VertexShader* vertexShader)
+	{
+		return vertexShader->regs.SQ_PGM_RESOURCES_VS.value().get_NUM_GPRS();
+	}
+
+	uint32 GX2GetVertexShaderStackEntries(GX2VertexShader* vertexShader)
+	{
+		return vertexShader->regs.SQ_PGM_RESOURCES_VS.value().get_NUM_STACK_ENTRIES();
+	}
+
+	uint32 GX2GetPixelShaderGPRs(GX2PixelShader_t* pixelShader)
+	{
+		return _swapEndianU32(pixelShader->regs[0])&0xFF;
+	}
+
+	uint32 GX2GetPixelShaderStackEntries(GX2PixelShader_t* pixelShader)
+	{
+		return (_swapEndianU32(pixelShader->regs[0]>>8))&0xFF;
+	}
+
+	void GX2SetFetchShader(GX2FetchShader* fetchShaderPtr)
+	{
+		GX2ReserveCmdSpace(11);
+		cemu_assert_debug((_swapEndianU32(fetchShaderPtr->shaderPtr) & 0xFF) == 0);
+
+		gx2WriteGather_submit(
+				// setup fetch shader
+				pm4HeaderType3(IT_SET_CONTEXT_REG, 1+5),
+				Latte::REGADDR::SQ_PGM_START_FS-0xA000,
+				_swapEndianU32(fetchShaderPtr->shaderPtr)>>8,
+				_swapEndianU32(fetchShaderPtr->shaderSize)>>3,
+				0x10000, // ukn (ring buffer size?)
+				0x10000, // ukn (ring buffer size?)
+				fetchShaderPtr->reg_SQ_PGM_RESOURCES_FS,
+
+				// write instance step
+				pm4HeaderType3(IT_SET_CONTEXT_REG, 1+2),
+				Latte::REGADDR::VGT_INSTANCE_STEP_RATE_0-0xA000,
+				fetchShaderPtr->divisors[0],
+				fetchShaderPtr->divisors[1]);
+	}
+
+	void GX2SetVertexShader(GX2VertexShader* vertexShader)
+	{
+		GX2ReserveCmdSpace(100);
+
+		MPTR shaderProgramAddr;
+		uint32 shaderProgramSize;
+		if (vertexShader->shaderPtr)
+		{
+			// without R API
+			shaderProgramAddr = vertexShader->shaderPtr.GetMPTR();
+			shaderProgramSize = vertexShader->shaderSize;
+		}
+		else
+		{
+			shaderProgramAddr = vertexShader->rBuffer.GetVirtualAddr();
+			shaderProgramSize = vertexShader->rBuffer.GetSize();
+		}
+
+		cemu_assert_debug(shaderProgramAddr != 0);
+		cemu_assert_debug(shaderProgramSize != 0);
+
+		if (vertexShader->shaderMode == GX2_SHADER_MODE::GEOMETRY_SHADER)
+		{
+			// in geometry shader mode the vertex shader is written to _ES register and almost all vs control registers are set by GX2SetGeometryShader
+			gx2WriteGather_submit(
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 6),
+					Latte::REGADDR::SQ_PGM_START_ES-0xA000,
+					memory_virtualToPhysical(shaderProgramAddr)>>8,
+					shaderProgramSize>>3,
+					0x100000,
+					0x100000,
+					vertexShader->regs.SQ_PGM_RESOURCES_VS); // SQ_PGM_RESOURCES_VS/SQ_PGM_RESOURCES_ES
+		}
+		else
+		{
+			gx2WriteGather_submit(
+					/* vertex shader program */
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 6),
+					Latte::REGADDR::SQ_PGM_START_VS-0xA000,
+					memory_virtualToPhysical(shaderProgramAddr)>>8, // physical address
+					shaderProgramSize>>3,
+					0x100000,
+					0x100000,
+					vertexShader->regs.SQ_PGM_RESOURCES_VS, // SQ_PGM_RESOURCES_VS/ES
+					/* primitive id enable */
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+					Latte::REGADDR::VGT_PRIMITIVEID_EN-0xA000,
+					vertexShader->regs.VGT_PRIMITIVEID_EN,
+					/* output config */
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+					Latte::REGADDR::SPI_VS_OUT_CONFIG-0xA000,
+					vertexShader->regs.SPI_VS_OUT_CONFIG,
+					/* PA_CL_VS_OUT_CNTL */
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+					Latte::REGADDR::PA_CL_VS_OUT_CNTL-0xA000,
+					vertexShader->regs.PA_CL_VS_OUT_CNTL
+					);
+
+			cemu_assert_debug(vertexShader->regs.SPI_VS_OUT_CONFIG.value().get_VS_PER_COMPONENT() == false); // not handled on the GPU side
+
+			uint32 numOutputIds = vertexShader->regs.vsOutIdTableSize;
+			numOutputIds = std::min<uint32>(numOutputIds, 0xA);
+			gx2WriteGather_submitU32AsBE(pm4HeaderType3(IT_SET_CONTEXT_REG, 1+numOutputIds));
+			gx2WriteGather_submitU32AsBE(Latte::REGADDR::SPI_VS_OUT_ID_0-0xA000);
+			for(uint32 i=0; i<numOutputIds; i++)
+				gx2WriteGather_submitU32AsBE(vertexShader->regs.LATTE_SPI_VS_OUT_ID_N[i].value().getRawValue());
+
+			// todo: SQ_PGM_CF_OFFSET_VS
+			// todo: VGT_STRMOUT_BUFFER_EN
+			// stream out
+			if (vertexShader->usesStreamOut != 0)
+			{
+				// stride 0
+				gx2WriteGather_submit(pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+				Latte::REGADDR::VGT_STRMOUT_VTX_STRIDE_0-0xA000,
+				vertexShader->streamOutVertexStride[0]>>2,
+				// stride 1
+				pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+				Latte::REGADDR::VGT_STRMOUT_VTX_STRIDE_1-0xA000,
+				vertexShader->streamOutVertexStride[1]>>2,
+				// stride 2
+				pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+				Latte::REGADDR::VGT_STRMOUT_VTX_STRIDE_2-0xA000,
+				vertexShader->streamOutVertexStride[2]>>2,
+				// stride 3
+				pm4HeaderType3(IT_SET_CONTEXT_REG, 2),
+				Latte::REGADDR::VGT_STRMOUT_VTX_STRIDE_3-0xA000,
+				vertexShader->streamOutVertexStride[3]>>2);
+			}
+		}
+		// update semantic table
+		uint32 vsSemanticTableSize = vertexShader->regs.semanticTableSize;
+		if (vsSemanticTableSize > 0)
+		{
+			gx2WriteGather_submit(
+					pm4HeaderType3(IT_SET_CONTEXT_REG, 1+1),
+					Latte::REGADDR::SQ_VTX_SEMANTIC_CLEAR-0xA000,
+					0xFFFFFFFF);
+			if (vsSemanticTableSize == 0)
+			{
+				gx2WriteGather_submit(
+						pm4HeaderType3(IT_SET_CONTEXT_REG, 1+1),
+						Latte::REGADDR::SQ_VTX_SEMANTIC_0-0xA000,
+						0xFFFFFFFF);
+			}
+			else
+			{
+				uint32* vsSemanticTable = (uint32*)vertexShader->regs.SQ_VTX_SEMANTIC_N;
+				vsSemanticTableSize = std::min<uint32>(vsSemanticTableSize, 32);
+				gx2WriteGather_submitU32AsBE(pm4HeaderType3(IT_SET_CONTEXT_REG, 1+vsSemanticTableSize));
+				gx2WriteGather_submitU32AsBE(Latte::REGADDR::SQ_VTX_SEMANTIC_0-0xA000);
+				gx2WriteGather_submitU32AsLEArray(vsSemanticTable, vsSemanticTableSize);
+			}
+		}
 	}
 
 	void GX2ShaderInit()
 	{
 		cafeExportRegister("gx2", GX2CalcFetchShaderSizeEx, LogType::GX2);
 		cafeExportRegister("gx2", GX2InitFetchShaderEx, LogType::GX2);
+
+		cafeExportRegister("gx2", GX2GetVertexShaderGPRs, LogType::GX2);
+		cafeExportRegister("gx2", GX2GetVertexShaderStackEntries, LogType::GX2);
+		cafeExportRegister("gx2", GX2GetPixelShaderGPRs, LogType::GX2);
+		cafeExportRegister("gx2", GX2GetPixelShaderStackEntries, LogType::GX2);
+		cafeExportRegister("gx2", GX2SetFetchShader, LogType::GX2);
+		cafeExportRegister("gx2", GX2SetVertexShader, LogType::GX2);
 	}
 }

--- a/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
+++ b/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
@@ -216,7 +216,7 @@ void nnNfpExport_SetDeactivateEvent(PPCInterpreter_t* hCPU)
 	ppcDefineParamStructPtr(osEvent, coreinit::OSEvent, 0);
 	ppcDefineParamMPTR(osEventMPTR, 0);
 
-	cemuLog_log(LogType::nn_nfp, "SetDeactivateEvent(0x{:08x})", osEventMPTR);
+	cemuLog_log(LogType::NN_NFP, "SetDeactivateEvent(0x{:08x})", osEventMPTR);
 
 	coreinit::OSInitEvent(osEvent, coreinit::OSEvent::EVENT_STATE::STATE_NOT_SIGNALED, coreinit::OSEvent::EVENT_MODE::MODE_AUTO);
 
@@ -241,7 +241,7 @@ void nnNfpExport_Initialize(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_StartDetection(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "StartDetection()");
+	cemuLog_log(LogType::NN_NFP, "StartDetection()");
 	nnNfpLock();
 	nfp_data.isDetecting = true;
 	nnNfpUnlock();
@@ -250,7 +250,7 @@ void nnNfpExport_StartDetection(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_StopDetection(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "StopDetection()");
+	cemuLog_log(LogType::NN_NFP, "StopDetection()");
 	nnNfpLock();
 	nfp_data.isDetecting = false;
 	nnNfpUnlock();
@@ -274,7 +274,7 @@ static_assert(sizeof(nfpTagInfo_t) == 0x54, "nfpTagInfo_t has invalid size");
 
 void nnNfpExport_GetTagInfo(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetTagInfo(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "GetTagInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(tagInfo, nfpTagInfo_t, 0);
 
 	nnNfpLock();
@@ -306,7 +306,7 @@ typedef struct
 
 uint32 NFCGetTagInfo(uint32 index, uint32 timeout, MPTR functionPtr, void* userParam)
 {
-	cemuLog_log(LogType::nn_nfp, "NFCGetTagInfo({},{},0x{:08x},0x{:08x})", index, timeout, functionPtr, userParam?memory_getVirtualOffsetFromPointer(userParam):0);
+	cemuLog_log(LogType::NN_NFP, "NFCGetTagInfo({},{},0x{:08x},0x{:08x})", index, timeout, functionPtr, userParam ? memory_getVirtualOffsetFromPointer(userParam) : 0);
 
 
 	cemu_assert(index == 0);
@@ -331,7 +331,7 @@ uint32 NFCGetTagInfo(uint32 index, uint32 timeout, MPTR functionPtr, void* userP
 
 void nnNfpExport_Mount(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "Mount()");
+	cemuLog_log(LogType::NN_NFP, "Mount()");
 	nnNfpLock();
 	if (nfp_data.hasActiveAmiibo == false)
 	{
@@ -348,14 +348,14 @@ void nnNfpExport_Mount(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_Unmount(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "Unmount()");
+	cemuLog_log(LogType::NN_NFP, "Unmount()");
 	nfp_data.hasOpenApplicationArea = false;
 	osLib_returnFromFunction(hCPU, BUILD_NN_RESULT(NN_RESULT_LEVEL_SUCCESS, NN_RESULT_MODULE_NN_NFP, 0));
 }
 
 void nnNfpExport_MountRom(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "MountRom()");
+	cemuLog_log(LogType::NN_NFP, "MountRom()");
 	nnNfpLock();
 	if (nfp_data.hasActiveAmiibo == false)
 	{
@@ -386,7 +386,7 @@ static_assert(sizeof(nfpRomInfo_t) == 0x36, "nfpRomInfo_t has invalid size");
 
 void nnNfpExport_GetNfpRomInfo(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetNfpRomInfo(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "GetNfpRomInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(romInfo, nfpRomInfo_t, 0);
 
 	nnNfpLock();
@@ -438,7 +438,7 @@ static_assert(offsetof(nfpCommonData_t, applicationAreaSize) == 0xE, "nfpCommonD
 
 void nnNfpExport_GetNfpCommonInfo(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetNfpCommonInfo(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "GetNfpCommonInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(commonInfo, nfpCommonData_t, 0);
 
 	nnNfpLock();
@@ -492,7 +492,7 @@ typedef struct
 
 void nnNfpExport_GetNfpRegisterInfo(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetNfpRegisterInfo(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "GetNfpRegisterInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(registerInfo, nfpRegisterInfo_t, 0);
 
 	if(!registerInfo)
@@ -515,7 +515,7 @@ void nnNfpExport_GetNfpRegisterInfo(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_InitializeRegisterInfoSet(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "InitializeRegisterInfoSet(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "InitializeRegisterInfoSet(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(registerInfoSet, nfpRegisterInfoSet_t, 0);
 
 	memset(registerInfoSet, 0, sizeof(nfpRegisterInfoSet_t));
@@ -525,7 +525,7 @@ void nnNfpExport_InitializeRegisterInfoSet(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_SetNfpRegisterInfo(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "SetNfpRegisterInfo(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "SetNfpRegisterInfo(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(registerInfoSet, nfpRegisterInfoSet_t, 0);
 
 	memcpy(nfp_data.amiiboInternal.amiiboSettings.mii, registerInfoSet->ownerMii, sizeof(nfp_data.amiiboInternal.amiiboSettings.mii));
@@ -538,7 +538,7 @@ void nnNfpExport_SetNfpRegisterInfo(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_IsExistApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "IsExistApplicationArea()");
+	cemuLog_log(LogType::NN_NFP, "IsExistApplicationArea()");
 	if (!nfp_data.hasActiveAmiibo || !nfp_data.isMounted)
 	{
 		osLib_returnFromFunction(hCPU, 0);
@@ -550,7 +550,7 @@ void nnNfpExport_IsExistApplicationArea(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_OpenApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "OpenApplicationArea(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "OpenApplicationArea(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamU32(appAreaId, 0);
 
 	// note - this API doesn't fail if the application area has already been opened?
@@ -575,7 +575,7 @@ void nnNfpExport_OpenApplicationArea(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_ReadApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "ReadApplicationArea(0x{:08x}, 0x{:x})", hCPU->gpr[3], hCPU->gpr[4]);
+	cemuLog_log(LogType::NN_NFP, "ReadApplicationArea(0x{:08x}, 0x{:x})", hCPU->gpr[3], hCPU->gpr[4]);
 	ppcDefineParamPtr(bufferPtr, uint8*, 0);
 	ppcDefineParamU32(len, 1);
 
@@ -592,7 +592,7 @@ void nnNfpExport_ReadApplicationArea(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_WriteApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "WriteApplicationArea(0x{:08x}, 0x{:x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
+	cemuLog_log(LogType::NN_NFP, "WriteApplicationArea(0x{:08x}, 0x{:x}, 0x{:08x})", hCPU->gpr[3], hCPU->gpr[4], hCPU->gpr[5]);
 	ppcDefineParamPtr(bufferPtr, uint8*, 0);
 	ppcDefineParamU32(len, 1);
 	
@@ -628,7 +628,7 @@ typedef struct
 
 void nnNfpExport_CreateApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "CreateApplicationArea(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "CreateApplicationArea(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamPtr(createInfo, NfpCreateInfo_t, 0);
 
 	if (nfp_data.hasOpenApplicationArea || (nfp_data.amiiboInternal.amiiboSettings.flags&0x20))
@@ -677,7 +677,7 @@ void nnNfpExport_CreateApplicationArea(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_DeleteApplicationArea(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "DeleteApplicationArea()");
+	cemuLog_log(LogType::NN_NFP, "DeleteApplicationArea()");
 
 	if (nfp_data.isReadOnly)
 	{
@@ -707,7 +707,7 @@ void nnNfpExport_DeleteApplicationArea(PPCInterpreter_t* hCPU)
 
 void nnNfpExport_Flush(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "Flush()");
+	cemuLog_log(LogType::NN_NFP, "Flush()");
 
 	// write Amiibo data
 	if (nfp_data.isReadOnly) 
@@ -748,7 +748,7 @@ static_assert(offsetof(AmiiboSettingsArgs_t, commonInfo) == 0x114);
 
 void nnNfpExport_GetAmiiboSettingsArgs(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetAmiiboSettingsArgs(0x{:08x})", hCPU->gpr[3]);
+	cemuLog_log(LogType::NN_NFP, "GetAmiiboSettingsArgs(0x{:08x})", hCPU->gpr[3]);
 	ppcDefineParamStructPtr(settingsArg, AmiiboSettingsArgs_t, 0);
 
 	memset(settingsArg, 0, sizeof(AmiiboSettingsArgs_t));
@@ -917,7 +917,7 @@ void nnNfp_update()
 
 void nnNfpExport_GetNfpState(PPCInterpreter_t* hCPU)
 {
-	cemuLog_log(LogType::nn_nfp, "GetNfpState()");
+	cemuLog_log(LogType::NN_NFP, "GetNfpState()");
 
 	// workaround for Mario Party 10 eating CPU cycles in an infinite loop (maybe due to incorrect NFP detection handling?)
 	uint64 titleId = CafeSystem::GetForegroundTitleId();

--- a/src/Cafe/OS/libs/nn_olv/nn_olv.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv.cpp
@@ -123,20 +123,20 @@ namespace nn
 			loadOliveUploadFavoriteTypes();
 			loadOlivePostAndTopicTypes();
 
-			cafeExportRegisterFunc(GetErrorCode, "nn_olv", "GetErrorCode__Q2_2nn3olvFRCQ2_2nn6Result", LogType::None);
+			cafeExportRegisterFunc(GetErrorCode, "nn_olv", "GetErrorCode__Q2_2nn3olvFRCQ2_2nn6Result", LogType::NN_OLV);
 
 			osLib_addFunction("nn_olv", "GetServiceToken__Q4_2nn3olv6hidden14PortalAppParamCFv", exportPortalAppParam_GetServiceToken);
 
-			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadPostDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv28UploadPostDataByPostAppParam", LogType::Force);
-			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadCommentDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv31UploadCommentDataByPostAppParam", LogType::Force);
-			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadDirectMessageDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv37UploadDirectMessageDataByPostAppParam", LogType::Force);
+			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadPostDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv28UploadPostDataByPostAppParam", LogType::NN_OLV);
+			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadCommentDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv31UploadCommentDataByPostAppParam", LogType::NN_OLV);
+			cafeExportRegisterFunc(StubPostApp, "nn_olv", "UploadDirectMessageDataByPostApp__Q2_2nn3olvFPCQ3_2nn3olv37UploadDirectMessageDataByPostAppParam", LogType::NN_OLV);
 
-			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultByPostApp__Q2_2nn3olvFv", LogType::Force);
-			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedPostDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv16UploadedPostData", LogType::Force);
-			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedDirectMessageDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv25UploadedDirectMessageData", LogType::Force);
-			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedCommentDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv19UploadedCommentData", LogType::Force);
+			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultByPostApp__Q2_2nn3olvFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedPostDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv16UploadedPostData", LogType::NN_OLV);
+			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedDirectMessageDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv25UploadedDirectMessageData", LogType::NN_OLV);
+			cafeExportRegisterFunc(StubPostAppResult, "nn_olv", "GetResultWithUploadedCommentDataByPostApp__Q2_2nn3olvFPQ3_2nn3olv19UploadedCommentData", LogType::NN_OLV);
 
-			cafeExportRegisterFunc(UploadedPostData_GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv16UploadedPostDataCFv", LogType::Force);
+			cafeExportRegisterFunc(UploadedPostData_GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv16UploadedPostDataCFv", LogType::NN_OLV);
 		}
 
 		void unload() // not called yet

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.h
@@ -501,30 +501,30 @@ namespace nn
 
 		static void loadOliveDownloadCommunityTypes()
 		{
-			cafeExportRegisterFunc(DownloadedCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv23DownloadedCommunityDataFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv23DownloadedCommunityDataCFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv23DownloadedCommunityDataCFPcUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv23DownloadedCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv23DownloadedCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv23DownloadedCommunityDataCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv23DownloadedCommunityDataCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerMiiData, "nn_olv", "GetOwnerMiiData__Q3_2nn3olv23DownloadedCommunityDataCFP12FFLStoreData", LogType::None);
-			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerMiiNickname, "nn_olv", "GetOwnerMiiNickname__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::None);
+			cafeExportRegisterFunc(DownloadedCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv23DownloadedCommunityDataFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv23DownloadedCommunityDataCFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv23DownloadedCommunityDataCFPcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv23DownloadedCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv23DownloadedCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv23DownloadedCommunityDataCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv23DownloadedCommunityDataCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerMiiData, "nn_olv", "GetOwnerMiiData__Q3_2nn3olv23DownloadedCommunityDataCFP12FFLStoreData", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedCommunityData::__GetOwnerMiiNickname, "nn_olv", "GetOwnerMiiNickname__Q3_2nn3olv23DownloadedCommunityDataCFv", LogType::NN_OLV);
 
-			cafeExportRegisterFunc(DownloadCommunityDataListParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv30DownloadCommunityDataListParamFv", LogType::None);
-			cafeExportRegisterFunc(DownloadCommunityDataListParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadCommunityDataListParam::__SetCommunityDataMaxNum, "nn_olv", "SetCommunityDataMaxNum__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadCommunityDataListParam::__GetRawDataUrl, "nn_olv", "GetRawDataUrl__Q3_2nn3olv30DownloadCommunityDataListParamCFPcUi", LogType::None);
+			cafeExportRegisterFunc(DownloadCommunityDataListParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv30DownloadCommunityDataListParamFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadCommunityDataListParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadCommunityDataListParam::__SetCommunityDataMaxNum, "nn_olv", "SetCommunityDataMaxNum__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadCommunityDataListParam::__GetRawDataUrl, "nn_olv", "GetRawDataUrl__Q3_2nn3olv30DownloadCommunityDataListParamCFPcUi", LogType::NN_OLV);
 
 			cafeExportRegisterFunc((sint32 (*)(DownloadCommunityDataListParam*, uint32))DownloadCommunityDataListParam::__SetCommunityId,
-				"nn_olv", "SetCommunityId__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::None);
+				"nn_olv", "SetCommunityId__Q3_2nn3olv30DownloadCommunityDataListParamFUi", LogType::NN_OLV);
 			cafeExportRegisterFunc((sint32(*)(DownloadCommunityDataListParam*, uint32, uint8))DownloadCommunityDataListParam::__SetCommunityId,
-				"nn_olv", "SetCommunityId__Q3_2nn3olv30DownloadCommunityDataListParamFUiUc", LogType::None);
+				"nn_olv", "SetCommunityId__Q3_2nn3olv30DownloadCommunityDataListParamFUiUc", LogType::NN_OLV);
 		
-			cafeExportRegisterFunc(DownloadCommunityDataList, "nn_olv", "DownloadCommunityDataList__Q2_2nn3olvFPQ3_2nn3olv23DownloadedCommunityDataPUiUiPCQ3_2nn3olv30DownloadCommunityDataListParam", LogType::None);
+			cafeExportRegisterFunc(DownloadCommunityDataList, "nn_olv", "DownloadCommunityDataList__Q2_2nn3olvFPQ3_2nn3olv23DownloadedCommunityDataPUiUiPCQ3_2nn3olv30DownloadCommunityDataListParam", LogType::NN_OLV);
 		}
 	}
 }

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_InitializeTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_InitializeTypes.h
@@ -113,16 +113,16 @@ namespace nn
 
 		static void loadOliveInitializeTypes()
 		{
-			cafeExportRegisterFunc(Initialize, "nn_olv", "Initialize__Q2_2nn3olvFPCQ3_2nn3olv15InitializeParam", LogType::None);
-			cafeExportRegisterFunc(IsInitialized, "nn_olv", "IsInitialized__Q2_2nn3olvFv", LogType::None);
-			cafeExportRegisterFunc(Report::GetReportTypes, "nn_olv", "GetReportTypes__Q3_2nn3olv6ReportFv", LogType::None);
-			cafeExportRegisterFunc(Report::SetReportTypes, "nn_olv", "SetReportTypes__Q3_2nn3olv6ReportFUi", LogType::None);
+			cafeExportRegisterFunc(Initialize, "nn_olv", "Initialize__Q2_2nn3olvFPCQ3_2nn3olv15InitializeParam", LogType::NN_OLV);
+			cafeExportRegisterFunc(IsInitialized, "nn_olv", "IsInitialized__Q2_2nn3olvFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(Report::GetReportTypes, "nn_olv", "GetReportTypes__Q3_2nn3olv6ReportFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(Report::SetReportTypes, "nn_olv", "SetReportTypes__Q3_2nn3olv6ReportFUi", LogType::NN_OLV);
 
-			cafeExportRegisterFunc(InitializeParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv15InitializeParamFv", LogType::None);
-			cafeExportRegisterFunc(InitializeParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv15InitializeParamFUi", LogType::None);
-			cafeExportRegisterFunc(InitializeParam::__SetWork, "nn_olv", "SetWork__Q3_2nn3olv15InitializeParamFPUcUi", LogType::None);
-			cafeExportRegisterFunc(InitializeParam::__SetReportTypes, "nn_olv", "SetReportTypes__Q3_2nn3olv15InitializeParamFUi", LogType::None);
-			cafeExportRegisterFunc(InitializeParam::__SetSysArgs, "nn_olv", "SetSysArgs__Q3_2nn3olv15InitializeParamFPCvUi", LogType::None);
+			cafeExportRegisterFunc(InitializeParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv15InitializeParamFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(InitializeParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv15InitializeParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(InitializeParam::__SetWork, "nn_olv", "SetWork__Q3_2nn3olv15InitializeParamFPUcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(InitializeParam::__SetReportTypes, "nn_olv", "SetReportTypes__Q3_2nn3olv15InitializeParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(InitializeParam::__SetSysArgs, "nn_olv", "SetSysArgs__Q3_2nn3olv15InitializeParamFPCvUi", LogType::NN_OLV);
 		}
 	}
 }

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.cpp
@@ -391,71 +391,71 @@ namespace nn
 
 		void loadOlivePostAndTopicTypes()
 		{
-			cafeExportRegisterFunc(GetSystemTopicDataListFromRawData, "nn_olv", "GetSystemTopicDataListFromRawData__Q3_2nn3olv6hiddenFPQ4_2nn3olv6hidden29DownloadedSystemTopicDataListPQ4_2nn3olv6hidden24DownloadedSystemPostDataPUiUiPCUcT4", LogType::None);
+			cafeExportRegisterFunc(GetSystemTopicDataListFromRawData, "nn_olv", "GetSystemTopicDataListFromRawData__Q3_2nn3olv6hiddenFPQ4_2nn3olv6hidden29DownloadedSystemTopicDataListPQ4_2nn3olv6hidden24DownloadedSystemPostDataPUiUiPCUcT4", LogType::NN_OLV);
 
 			// DownloadedDataBase getters
-			cafeExportRegisterFunc(DownloadedDataBase::TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv18DownloadedDataBaseCFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetUserPid, "nn_olv", "GetUserPid__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetPostDate, "nn_olv", "GetPostDate__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetFeeling, "nn_olv", "GetFeeling__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetRegionId, "nn_olv", "GetRegionId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetPlatformId, "nn_olv", "GetPlatformId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetLanguageId, "nn_olv", "GetLanguageId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetCountryId, "nn_olv", "GetCountryId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetExternalUrl, "nn_olv", "GetExternalUrl__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetMiiData1, "nn_olv", "GetMiiData__Q3_2nn3olv18DownloadedDataBaseCFP12FFLStoreData", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetMiiNickname, "nn_olv", "GetMiiNickname__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetBodyText, "nn_olv", "GetBodyText__Q3_2nn3olv18DownloadedDataBaseCFPwUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetBodyMemo, "nn_olv", "GetBodyMemo__Q3_2nn3olv18DownloadedDataBaseCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetTopicTag, "nn_olv", "GetTopicTag__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv18DownloadedDataBaseCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetMiiData2, "nn_olv", "GetMiiData__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::DownloadExternalImageData, "nn_olv", "DownloadExternalImageData__Q3_2nn3olv18DownloadedDataBaseCFPvPUiUi", LogType::None);
-			cafeExportRegisterFunc(DownloadedDataBase::GetExternalImageDataSize, "nn_olv", "GetExternalImageDataSize__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::None);
+			cafeExportRegisterFunc(DownloadedDataBase::TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv18DownloadedDataBaseCFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetUserPid, "nn_olv", "GetUserPid__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetPostDate, "nn_olv", "GetPostDate__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetFeeling, "nn_olv", "GetFeeling__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetRegionId, "nn_olv", "GetRegionId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetPlatformId, "nn_olv", "GetPlatformId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetLanguageId, "nn_olv", "GetLanguageId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetCountryId, "nn_olv", "GetCountryId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetExternalUrl, "nn_olv", "GetExternalUrl__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetMiiData1, "nn_olv", "GetMiiData__Q3_2nn3olv18DownloadedDataBaseCFP12FFLStoreData", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetMiiNickname, "nn_olv", "GetMiiNickname__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetBodyText, "nn_olv", "GetBodyText__Q3_2nn3olv18DownloadedDataBaseCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetBodyMemo, "nn_olv", "GetBodyMemo__Q3_2nn3olv18DownloadedDataBaseCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetTopicTag, "nn_olv", "GetTopicTag__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv18DownloadedDataBaseCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetMiiData2, "nn_olv", "GetMiiData__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::DownloadExternalImageData, "nn_olv", "DownloadExternalImageData__Q3_2nn3olv18DownloadedDataBaseCFPvPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedDataBase::GetExternalImageDataSize, "nn_olv", "GetExternalImageDataSize__Q3_2nn3olv18DownloadedDataBaseCFv", LogType::NN_OLV);
 
 			// DownloadedPostData getters
-			cafeExportRegisterFunc(DownloadedPostData::GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv18DownloadedPostDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedPostData::GetEmpathyCount, "nn_olv", "GetEmpathyCount__Q3_2nn3olv18DownloadedPostDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedPostData::GetCommentCount, "nn_olv", "GetCommentCount__Q3_2nn3olv18DownloadedPostDataCFv", LogType::None);
-			cafeExportRegisterFunc(DownloadedPostData::GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv18DownloadedPostDataCFv", LogType::None);
+			cafeExportRegisterFunc(DownloadedPostData::GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv18DownloadedPostDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedPostData::GetEmpathyCount, "nn_olv", "GetEmpathyCount__Q3_2nn3olv18DownloadedPostDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedPostData::GetCommentCount, "nn_olv", "GetCommentCount__Q3_2nn3olv18DownloadedPostDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadedPostData::GetPostId, "nn_olv", "GetPostId__Q3_2nn3olv18DownloadedPostDataCFv", LogType::NN_OLV);
 
 			// DownloadedSystemPostData getters
-			cafeExportRegisterFunc(hidden::DownloadedSystemPostData::GetTitleId, "nn_olv", "GetTitleId__Q4_2nn3olv6hidden24DownloadedSystemPostDataCFv", LogType::None);
+			cafeExportRegisterFunc(hidden::DownloadedSystemPostData::GetTitleId, "nn_olv", "GetTitleId__Q4_2nn3olv6hidden24DownloadedSystemPostDataCFv", LogType::NN_OLV);
 
 			// DownloadedTopicData getters
-			cafeExportRegisterFunc(DownloadedTopicData::GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv19DownloadedTopicDataCFv", LogType::None);
+			cafeExportRegisterFunc(DownloadedTopicData::GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv19DownloadedTopicDataCFv", LogType::NN_OLV);
 
 			// DownloadedSystemTopicData getters
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::TestFlags, "nn_olv", "TestFlags__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFUi", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleId, "nn_olv", "GetTitleId__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFv", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleIdNum, "nn_olv", "GetTitleIdNum__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFv", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleText, "nn_olv", "GetTitleText__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleIconData, "nn_olv", "GetTitleIconData__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFPUcPUiUi", LogType::None);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::TestFlags, "nn_olv", "TestFlags__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleId, "nn_olv", "GetTitleId__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleIdNum, "nn_olv", "GetTitleIdNum__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleText, "nn_olv", "GetTitleText__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicData::GetTitleIconData, "nn_olv", "GetTitleIconData__Q4_2nn3olv6hidden25DownloadedSystemTopicDataCFPUcPUiUi", LogType::NN_OLV);
 
 			// DownloadedSystemTopicDataList getters
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemTopicDataNum, "nn_olv", "GetDownloadedSystemTopicDataNum__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFv", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemPostDataNum, "nn_olv", "GetDownloadedSystemPostDataNum__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFi", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemTopicData, "nn_olv", "GetDownloadedSystemTopicData__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFi", LogType::None);
-			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemPostData, "nn_olv", "GetDownloadedSystemPostData__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFiT1", LogType::None);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemTopicDataNum, "nn_olv", "GetDownloadedSystemTopicDataNum__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemPostDataNum, "nn_olv", "GetDownloadedSystemPostDataNum__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFi", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemTopicData, "nn_olv", "GetDownloadedSystemTopicData__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFi", LogType::NN_OLV);
+			cafeExportRegisterFunc(hidden::DownloadedSystemTopicDataList::GetDownloadedSystemPostData, "nn_olv", "GetDownloadedSystemPostData__Q4_2nn3olv6hidden29DownloadedSystemTopicDataListCFiT1", LogType::NN_OLV);
 
 			// DownloadPostDataListParam constructor and getters
-			cafeExportRegisterFunc(DownloadPostDataListParam::Construct, "nn_olv", "__ct__Q3_2nn3olv25DownloadPostDataListParamFv", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetLanguageId, "nn_olv", "SetLanguageId__Q3_2nn3olv25DownloadPostDataListParamFUc", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchKey, "nn_olv", "SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCwUc", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchKeySingle, "nn_olv", "SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCw", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchPid, "nn_olv", "SetSearchPid__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostId, "nn_olv", "SetPostId__Q3_2nn3olv25DownloadPostDataListParamFPCcUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostDate, "nn_olv", "SetPostDate__Q3_2nn3olv25DownloadPostDataListParamFL", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostDataMaxNum, "nn_olv", "SetPostDataMaxNum__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataListParam::SetBodyTextMaxLength, "nn_olv", "SetBodyTextMaxLength__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::None);
+			cafeExportRegisterFunc(DownloadPostDataListParam::Construct, "nn_olv", "__ct__Q3_2nn3olv25DownloadPostDataListParamFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetLanguageId, "nn_olv", "SetLanguageId__Q3_2nn3olv25DownloadPostDataListParamFUc", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchKey, "nn_olv", "SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCwUc", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchKeySingle, "nn_olv", "SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCw", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetSearchPid, "nn_olv", "SetSearchPid__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostId, "nn_olv", "SetPostId__Q3_2nn3olv25DownloadPostDataListParamFPCcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostDate, "nn_olv", "SetPostDate__Q3_2nn3olv25DownloadPostDataListParamFL", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetPostDataMaxNum, "nn_olv", "SetPostDataMaxNum__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataListParam::SetBodyTextMaxLength, "nn_olv", "SetBodyTextMaxLength__Q3_2nn3olv25DownloadPostDataListParamFUi", LogType::NN_OLV);
 
 			// URL and downloading functions
-			cafeExportRegisterFunc(DownloadPostDataListParam::GetRawDataUrl, "nn_olv", "GetRawDataUrl__Q3_2nn3olv25DownloadPostDataListParamCFPcUi", LogType::None);
-			cafeExportRegisterFunc(DownloadPostDataList, "nn_olv", "DownloadPostDataList__Q2_2nn3olvFPQ3_2nn3olv19DownloadedTopicDataPQ3_2nn3olv18DownloadedPostDataPUiUiPCQ3_2nn3olv25DownloadPostDataListParam", LogType::None);
+			cafeExportRegisterFunc(DownloadPostDataListParam::GetRawDataUrl, "nn_olv", "GetRawDataUrl__Q3_2nn3olv25DownloadPostDataListParamCFPcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(DownloadPostDataList, "nn_olv", "DownloadPostDataList__Q2_2nn3olvFPQ3_2nn3olv19DownloadedTopicDataPQ3_2nn3olv18DownloadedPostDataPUiUiPCQ3_2nn3olv25DownloadPostDataListParam", LogType::NN_OLV);
 
 		}
 

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.h
@@ -402,30 +402,30 @@ namespace nn
 
 		static void loadOliveUploadCommunityTypes()
 		{
-			cafeExportRegisterFunc(UploadedCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv21UploadedCommunityDataFv", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv21UploadedCommunityDataCFUi", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv21UploadedCommunityDataCFPcUi", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv21UploadedCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv21UploadedCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv21UploadedCommunityDataCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv21UploadedCommunityDataCFPUcPUiUi", LogType::None);
+			cafeExportRegisterFunc(UploadedCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv21UploadedCommunityDataFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv21UploadedCommunityDataCFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv21UploadedCommunityDataCFPcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv21UploadedCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv21UploadedCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv21UploadedCommunityDataCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv21UploadedCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv21UploadedCommunityDataCFPUcPUiUi", LogType::NN_OLV);
 		
-			cafeExportRegisterFunc(UploadCommunityDataParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv24UploadCommunityDataParamFv", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv24UploadCommunityDataParamFUi", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv24UploadCommunityDataParamFUi", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetAppData, "nn_olv", "SetAppData__Q3_2nn3olv24UploadCommunityDataParamFPCUcUi", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetTitleText, "nn_olv", "SetTitleText__Q3_2nn3olv24UploadCommunityDataParamFPCw", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetDescriptionText, "nn_olv", "SetDescriptionText__Q3_2nn3olv24UploadCommunityDataParamFPCw", LogType::None);
-			cafeExportRegisterFunc(UploadCommunityDataParam::__SetIconData, "nn_olv", "SetIconData__Q3_2nn3olv24UploadCommunityDataParamFPCUcUi", LogType::None);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv24UploadCommunityDataParamFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv24UploadCommunityDataParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv24UploadCommunityDataParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetAppData, "nn_olv", "SetAppData__Q3_2nn3olv24UploadCommunityDataParamFPCUcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetTitleText, "nn_olv", "SetTitleText__Q3_2nn3olv24UploadCommunityDataParamFPCw", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetDescriptionText, "nn_olv", "SetDescriptionText__Q3_2nn3olv24UploadCommunityDataParamFPCw", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadCommunityDataParam::__SetIconData, "nn_olv", "SetIconData__Q3_2nn3olv24UploadCommunityDataParamFPCUcUi", LogType::NN_OLV);
 
 			cafeExportRegisterFunc((sint32(*)(UploadCommunityDataParam const*))UploadCommunityData,
-				"nn_olv", "UploadCommunityData__Q2_2nn3olvFPCQ3_2nn3olv24UploadCommunityDataParam", LogType::None);
+				"nn_olv", "UploadCommunityData__Q2_2nn3olvFPCQ3_2nn3olv24UploadCommunityDataParam", LogType::NN_OLV);
 		
 			cafeExportRegisterFunc((sint32(*)(UploadedCommunityData *, UploadCommunityDataParam const*))UploadCommunityData,
-				"nn_olv", "UploadCommunityData__Q2_2nn3olvFPQ3_2nn3olv21UploadedCommunityDataPCQ3_2nn3olv24UploadCommunityDataParam", LogType::None);
+				"nn_olv", "UploadCommunityData__Q2_2nn3olvFPQ3_2nn3olv21UploadedCommunityDataPCQ3_2nn3olv24UploadCommunityDataParam", LogType::NN_OLV);
 		}
 
 	}

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.h
@@ -315,27 +315,27 @@ namespace nn
 
 		static void loadOliveUploadFavoriteTypes()
 		{
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv31UploadedFavoriteToCommunityDataFv", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFUi", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPcUi", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPwUi", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPUcPUiUi", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::None);
-			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPUcPUiUi", LogType::None);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__ctor, "nn_olv", "__ct__Q3_2nn3olv31UploadedFavoriteToCommunityDataFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__TestFlags, "nn_olv", "TestFlags__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetCommunityId, "nn_olv", "GetCommunityId__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetCommunityCode, "nn_olv", "GetCommunityCode__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPcUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetOwnerPid, "nn_olv", "GetOwnerPid__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetTitleText, "nn_olv", "GetTitleText__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetDescriptionText, "nn_olv", "GetDescriptionText__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPwUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetAppData, "nn_olv", "GetAppData__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPUcPUiUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetAppDataSize, "nn_olv", "GetAppDataSize__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadedFavoriteToCommunityData::__GetIconData, "nn_olv", "GetIconData__Q3_2nn3olv31UploadedFavoriteToCommunityDataCFPUcPUiUi", LogType::NN_OLV);
 			
-			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFv", LogType::None);
-			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFUi", LogType::None);
-			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetCommunityCode, "nn_olv", "SetCommunityCode__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFPCc", LogType::None);
-			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFUi", LogType::None);
+			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__ctor, "nn_olv", "__ct__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFv", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetFlags, "nn_olv", "SetFlags__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFUi", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetCommunityCode, "nn_olv", "SetCommunityCode__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFPCc", LogType::NN_OLV);
+			cafeExportRegisterFunc(UploadFavoriteToCommunityDataParam::__SetCommunityId, "nn_olv", "SetCommunityId__Q3_2nn3olv34UploadFavoriteToCommunityDataParamFUi", LogType::NN_OLV);
 
 			cafeExportRegisterFunc((sint32(*)(const UploadFavoriteToCommunityDataParam*))UploadFavoriteToCommunityData,
-				"nn_olv", "UploadFavoriteToCommunityData__Q2_2nn3olvFPCQ3_2nn3olv34UploadFavoriteToCommunityDataParam", LogType::None);
+				"nn_olv", "UploadFavoriteToCommunityData__Q2_2nn3olvFPCQ3_2nn3olv34UploadFavoriteToCommunityDataParam", LogType::NN_OLV);
 
 			cafeExportRegisterFunc((sint32(*)(UploadedFavoriteToCommunityData*, const UploadFavoriteToCommunityDataParam*))UploadFavoriteToCommunityData,
-				"nn_olv", "UploadFavoriteToCommunityData__Q2_2nn3olvFPQ3_2nn3olv31UploadedFavoriteToCommunityDataPCQ3_2nn3olv34UploadFavoriteToCommunityDataParam", LogType::None);
+				"nn_olv", "UploadFavoriteToCommunityData__Q2_2nn3olvFPQ3_2nn3olv31UploadedFavoriteToCommunityDataPCQ3_2nn3olv34UploadFavoriteToCommunityDataParam", LogType::NN_OLV);
 		}
 
 	}

--- a/src/Cafe/OS/libs/swkbd/swkbd.cpp
+++ b/src/Cafe/OS/libs/swkbd/swkbd.cpp
@@ -276,7 +276,6 @@ void swkbdExport_SwkbdDisappearKeyboard(PPCInterpreter_t* hCPU)
 
 void swkbdExport_SwkbdGetInputFormString(PPCInterpreter_t* hCPU)
 {
-	debug_printf("SwkbdGetInputFormString__3RplFv LR: %08x\n", hCPU->spr.LR);
 	for(sint32 i=0; i<swkbdInternalState->formStringLength; i++)
 	{
 		swkbdInternalState->formStringBufferBE[i] = _swapEndianU16(swkbdInternalState->formStringBuffer[i]);
@@ -287,7 +286,6 @@ void swkbdExport_SwkbdGetInputFormString(PPCInterpreter_t* hCPU)
 
 void swkbdExport_SwkbdIsDecideOkButton(PPCInterpreter_t* hCPU)
 {
-	debug_printf("SwkbdIsDecideOkButton__3RplFPb LR: %08x\n", hCPU->spr.LR);
 	if (swkbdInternalState->decideButtonWasPressed)
 		osLib_returnFromFunction(hCPU, 1);
 	else

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -1,43 +1,44 @@
 #pragma once
 
+extern uint64 s_loggingFlagMask;
+
 enum class LogType : sint32
 {
-	// note: IDs must not exceed 63
-	Placeholder = -2,
-	None = -1,
-	Force = 0, // this logging type is always on
-	CoreinitFile = 1,
-	GX2 = 2,
-	UnsupportedAPI = 3,
-	ThreadSync = 4,
-	SoundAPI = 5, // any audio related API
-	InputAPI = 6, // any input related API
-	Socket = 7,
-	Save = 8,
-	CoreinitMem = 9, // coreinit memory functions
-	H264 = 10,
-	OpenGLLogging = 11, // OpenGL debug logging
-	TextureCache = 12, // texture cache warnings and info
-	VulkanValidation = 13, // Vulkan validation layer
-	nn_nfp = 14, // nn_nfp (Amiibo) API
-	Patches = 15,
-	CoreinitMP = 16,
-	CoreinitThread = 17,
-	CoreinitLogging = 18, // OSReport, OSConsoleWrite etc.
-	CoreinitMemoryMapping = 19, // OSGetAvailPhysAddrRange, OSAllocVirtAddr, OSMapMemory etc.
-	CoreinitAlarm = 23,
+	// note: IDs must be in range 1-64
+	Force = 63, // always enabled
+	Placeholder = 62, // always disabled
+	APIErrors = Force, // alias for Force. Logs bad parameters or other API errors in OS libs
 
-	PPC_IPC = 20,
-	NN_AOC = 21,
-	NN_PDM = 22,
-	
-	TextureReadback = 30,
+	CoreinitFile = 0,
+	GX2 = 1,
+	UnsupportedAPI = 2,
+	SoundAPI = 4, // any audio related API
+	InputAPI = 5, // any input related API
+	Socket = 6,
+	Save = 7,
+	H264 = 9,
+	OpenGLLogging = 10, // OpenGL debug logging
+	TextureCache = 11, // texture cache warnings and info
+	VulkanValidation = 12, // Vulkan validation layer
+	Patches = 14,
+	CoreinitMem = 8, // coreinit memory functions
+	CoreinitMP = 15,
+	CoreinitThread = 16,
+	CoreinitLogging = 17, // OSReport, OSConsoleWrite etc.
+	CoreinitMemoryMapping = 18, // OSGetAvailPhysAddrRange, OSAllocVirtAddr, OSMapMemory etc.
+	CoreinitAlarm = 22,
+	CoreinitThreadSync = 3,
 
-	ProcUi = 40,
+	PPC_IPC = 19,
+	NN_AOC = 20,
+	NN_PDM = 21,
+	NN_OLV = 23,
+	NN_NFP = 13,
 
-	APIErrors = 0, // alias for Force. Logs bad parameters or other API errors in OS libs
+	TextureReadback = 29,
 
-	
+	ProcUi = 39,
+
 };
 
 template <>
@@ -53,7 +54,17 @@ struct fmt::formatter<std::u8string_view> : formatter<string_view> {
 void cemuLog_writeLineToLog(std::string_view text, bool date = true, bool new_line = true);
 inline void cemuLog_writePlainToLog(std::string_view text) { cemuLog_writeLineToLog(text, false, false); }
 
-bool cemuLog_isLoggingEnabled(LogType type);
+void cemuLog_setActiveLoggingFlags(uint64 flagMask);
+
+inline uint64 cemuLog_getFlag(LogType type)
+{
+	return 1ULL << (uint64)type;
+}
+
+inline bool cemuLog_isLoggingEnabled(LogType type)
+{
+	return (s_loggingFlagMask & cemuLog_getFlag(type)) != 0;
+}
 
 bool cemuLog_log(LogType type, std::string_view text);
 bool cemuLog_log(LogType type, std::u8string_view text);
@@ -97,6 +108,8 @@ bool cemuLog_log(LogType type, std::basic_string<T> formatStr, TArgs&&... args)
 template<typename T, typename ... TArgs>
 bool cemuLog_log(LogType type, const T* format, TArgs&&... args)
 {
+	if (!cemuLog_isLoggingEnabled(type))
+		return false;
 	auto format_str = std::basic_string<T>(format);
 	return cemuLog_log(type, format_str, std::forward<TArgs>(args)...);
 }
@@ -116,7 +129,6 @@ bool cemuLog_logDebug(LogType type, TFmt format, TArgs&&... args)
 bool cemuLog_advancedPPCLoggingEnabled();
 
 uint64 cemuLog_getFlag(LogType type);
-void cemuLog_setFlag(LogType type, bool enabled);
 
 fs::path cemuLog_GetLogFilePath();
 void cemuLog_createLogFile(bool triggeredByCrash);

--- a/src/config/ActiveSettings.h
+++ b/src/config/ActiveSettings.h
@@ -69,12 +69,12 @@ private:
 	inline static fs::path s_executable_filename; // cemu.exe
 	inline static fs::path s_mlc_path;
 
-public:	
+public:
 	// general
 	[[nodiscard]] static bool LoadSharedLibrariesEnabled();
 	[[nodiscard]] static bool DisplayDRCEnabled();
 	[[nodiscard]] static bool FullscreenEnabled();
-	
+
 	// cpu
 	[[nodiscard]] static CPUMode GetCPUMode();
 	[[nodiscard]] static uint8 GetTimerShiftFactor();

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -43,6 +43,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 
 	// general settings
 	log_flag = parser.get("logflag", log_flag.GetInitValue());
+	cemuLog_setActiveLoggingFlags(GetConfig().log_flag.GetValue());
 	advanced_ppc_logging = parser.get("advanced_ppc_logging", advanced_ppc_logging.GetInitValue());
 
 	const char* mlc = parser.get("mlc_path", "");
@@ -53,7 +54,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	language = parser.get<sint32>("language", wxLANGUAGE_DEFAULT);
 	use_discord_presence = parser.get("use_discord_presence", true);
 	fullscreen_menubar = parser.get("fullscreen_menubar", false);
-    	feral_gamemode = parser.get("feral_gamemode", false);
+	feral_gamemode = parser.get("feral_gamemode", false);
 	check_update = parser.get("check_update", check_update);
 	save_screenshot = parser.get("save_screenshot", save_screenshot);
 	did_show_vulkan_warning = parser.get("vk_warning", did_show_vulkan_warning);
@@ -62,9 +63,6 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	fullscreen = parser.get("fullscreen", fullscreen);
 	proxy_server = parser.get("proxy_server", "");
 	disable_screensaver = parser.get("disable_screensaver", disable_screensaver);
-
-	// cpu_mode = parser.get("cpu_mode", cpu_mode.GetInitValue());
-	//console_region = parser.get("console_region", console_region.GetInitValue());
 	console_language = parser.get("console_language", console_language.GetInitValue());
 
 	window_position.x = parser.get("window_position").get("x", -1);

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -353,7 +353,6 @@ struct CemuConfig
 	};
 
 	CemuConfig(const CemuConfig&) = delete;
-	//
 
 	// sets mlc path, updates permanent config value, saves config
 	void SetMLCPath(fs::path path, bool save = true);
@@ -365,10 +364,10 @@ struct CemuConfig
 	
 	ConfigValue<sint32> language{ wxLANGUAGE_DEFAULT };
 	ConfigValue<bool> use_discord_presence{ true };
-	ConfigValue<std::string> mlc_path {};
+	ConfigValue<std::string> mlc_path{};
 	ConfigValue<bool> fullscreen_menubar{ false };
 	ConfigValue<bool> fullscreen{ false };
-    	ConfigValue<bool> feral_gamemode{false};
+	ConfigValue<bool> feral_gamemode{false};
 	ConfigValue<std::string> proxy_server{};
 
 	// temporary workaround because feature crashes on macOS

--- a/src/config/ConfigValue.h
+++ b/src/config/ConfigValue.h
@@ -39,7 +39,7 @@ public:
 		return *this;
 	}
 
-	[[nodiscard]] TType GetValue() const { return m_value.load(); }
+	[[nodiscard]] inline TType GetValue() const { return m_value.load(); }
 	void SetValue(const TType& v) { m_value = v; }
 
 	[[nodiscard]] const TType& GetInitValue() const { return m_init_value; }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1103,7 +1103,14 @@ void MainWindow::OnDebugLoggingToggleFlagGeneric(wxCommandEvent& event)
 	sint32 id = event.GetId();
 	if (id >= loggingIdBase && id < (MAINFRAME_MENU_ID_DEBUG_LOGGING0 + 64))
 	{
-		cemuLog_setFlag(static_cast<LogType>(id - loggingIdBase), event.IsChecked());
+		bool isEnable = event.IsChecked();
+		LogType loggingType = static_cast<LogType>(id - loggingIdBase);
+		if (isEnable)
+			GetConfig().log_flag = GetConfig().log_flag.GetValue() | cemuLog_getFlag(loggingType);
+		else
+			GetConfig().log_flag = GetConfig().log_flag.GetValue() & ~cemuLog_getFlag(loggingType);
+		cemuLog_setActiveLoggingFlags(GetConfig().log_flag.GetValue());
+		g_config.Save();
 	}
 }
 
@@ -2190,11 +2197,11 @@ void MainWindow::RecreateMenu()
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::UnsupportedAPI), _("&Unsupported API calls"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::UnsupportedAPI));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitLogging), _("&Coreinit Logging (OSReport/OSConsole)"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitLogging));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitFile), _("&Coreinit File-Access API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitFile));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::ThreadSync), _("&Coreinit Thread-Synchronization API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::ThreadSync));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitThreadSync), _("&Coreinit Thread-Synchronization API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitThreadSync));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitMem), _("&Coreinit Memory API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitMem));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitMP), _("&Coreinit MP API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitMP));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::CoreinitThread), _("&Coreinit Thread API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::CoreinitThread));
-	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::nn_nfp), _("&NN NFP"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::nn_nfp));
+	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::NN_NFP), _("&NN NFP"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::NN_NFP));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::GX2), _("&GX2 API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::GX2));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::SoundAPI), _("&Audio API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::SoundAPI));
 	debugLoggingMenu->AppendCheckItem(MAINFRAME_MENU_ID_DEBUG_LOGGING0 + stdx::to_underlying(LogType::InputAPI), _("&Input API"), wxEmptyString)->Check(cemuLog_isLoggingEnabled(LogType::InputAPI));

--- a/src/util/Fiber/FiberUnix.cpp
+++ b/src/util/Fiber/FiberUnix.cpp
@@ -1,5 +1,6 @@
 #include "Fiber.h"
 #include <ucontext.h>
+#include <atomic>
 
 thread_local Fiber* sCurrentFiber{};
 
@@ -44,7 +45,9 @@ void Fiber::Switch(Fiber& targetFiber)
 {
     Fiber* leavingFiber = sCurrentFiber;
     sCurrentFiber = &targetFiber;
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 	swapcontext((ucontext_t*)(leavingFiber->m_implData), (ucontext_t*)(targetFiber.m_implData));
+	std::atomic_thread_fence(std::memory_order_seq_cst);
 }
 
 void* Fiber::GetFiberPrivateData()


### PR DESCRIPTION
Changes in this PR:
- First draft of coding style guidelines and a `.clang-format` file
- Failing to open the Vulkan pipeline cache will no longer insta-crash, instead Cemu will try to create a new cache
- `coreinit.OSDynLoad_Acquire` now fails for .rpl files which don't exist instead of returning a ghost handle. This fixes the boot crash in Togabito no Senritsu (and maybe other games?). Togabito still seems to crash right afterwards during video playback.
- Small tweaks to make the h264 decoder a tiny bit faster
- Fixed a shader compilation failure in Tekken Tag Tournament 2. The characters should show with correct colors most of the time now, but the bug may not be 100% gone.
- An attempt to fix #781