### PR TITLE
Add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ bin/controllerProfiles/*
 bin/gameProfiles/*
 
 bin/graphicPacks/*
+
+# Ignore Finder view option files created by OS X
+.DS_Store


### PR DESCRIPTION
A finder config file only present on MacOS, adding to gitignore for any other Mac devs