### PR TITLE
Updated SetSearchKey function to handle null search

### DIFF
--- a/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
@@ -546,6 +546,10 @@ namespace nn
 			// SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCw
 			static nnResult SetSearchKeySingle(DownloadPostDataListParam* _this, const uint16be* searchKey)
 			{
+				if (searchKey == NULL)
+				{
+					return OLV_RESULT_INVALID_PARAMETER;
+				}
 				return SetSearchKey(_this, searchKey, 0);
 			}
 

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_PostTypes.h
@@ -546,8 +546,9 @@ namespace nn
 			// SetSearchKey__Q3_2nn3olv25DownloadPostDataListParamFPCw
 			static nnResult SetSearchKeySingle(DownloadPostDataListParam* _this, const uint16be* searchKey)
 			{
-				if (searchKey == NULL)
+				if (searchKey == nullptr)
 				{
+					cemuLog_logDebug(LogType::NN_OLV, "DownloadPostDataListParam::SetSearchKeySingle: searchKeySingle is Null\n");			
 					return OLV_RESULT_INVALID_PARAMETER;
 				}
 				return SetSearchKey(_this, searchKey, 0);


### PR DESCRIPTION
Updated SetSearchKey function to handle null search keys. If a null search key is provided, the function now clears the search key at the specified index and returns success.

Fixes #973 

