### PR TITLE
Catch exception in Nsyshid on Windows and log it in logDebug

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/BackendWindowsHID.cpp
+++ b/src/Cafe/OS/libs/nsyshid/BackendWindowsHID.cpp
@@ -446,8 +446,17 @@ namespace nsyshid::backend::windows
 		{
 			sprintf(debugOutput + i * 3, "%02x ", data[i]);
 		}
-		fmt::print("{} Data: {}\n", prefix, debugOutput);
-		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
+
+		try
+		{
+			fmt::print("{} Data: {}\n", prefix, debugOutput);
+			cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
+		} catch (const std::exception& e)
+		{
+			fmt::print("Error while logging: {}\n", e.what());
+			cemuLog_logDebug(LogType::Force, "Error while logging: {}", e.what());
+
+		}
 	}
 } // namespace nsyshid::backend::windows
 


### PR DESCRIPTION
This keeps Cemu from crashing when nsyshid's logging encounters an error on Windows and prints the type of exception encountered to the log.

Currently a bad descriptor error is occurring on some toypad accesses, I have not addressed this (Don't know how), but this makes cemu no longer crash when they happen.