### PR TITLE
NUS format support + Smaller Latte optimizations + Refactoring

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,20 +3,19 @@
 ## Windows
 
 Prerequisites:
-- A recent version of Visual Studio 2022 (recommended but not required) with the following additional components:
-  - C++ CMake tools for Windows
-  - Windows 10/11 SDK
 - git
+- A recent version of Visual Studio 2022 with the following additional components:
+   - C++ CMake tools for Windows
+   - Windows 10/11 SDK
 
-Instructions:
+Instructions for Visual Studio 2022:
 
 1. Run `git clone --recursive https://github.com/cemu-project/Cemu`
-2. Launch `Cemu/generate_vs_solution.bat`.
-    - If you installed VS to a custom location or use VS 2019, you may need to manually change the path inside the .bat file.
-3. Wait until it's done, then open `Cemu/build/Cemu.sln` in Visual Studio.
-4. Then build the solution and once finished you can run and debug it, or build it and check the /bin folder for the final Cemu_release.exe.
+2. Open the newly created Cemu directory in Visual Studio using the "Open a local folder" option
+3. In the menu select Project -> Configure CMake. Wait until it is done, this may take a long time
+4. You can now build, run and debug Cemu
 
-You can also skip steps 3-5 and open the root folder of the cloned repo directly in Visual Studio (as a folder) and use the built-in CMake support but be warned that cmake support in VS can be a bit finicky.
+Any other IDE should also work as long as it has CMake and MSVC support. CLion and Visual Studio Code have been confirmed to work.
 
 ## Linux
 
@@ -46,7 +45,8 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
 5. You should now have a Cemu executable file in the /bin folder, which you can run using `./bin/Cemu_release`.
 
 #### Using GCC
-While we use and test Cemu using clang, using GCC might work better with your distro (they should be fairly similar performance/issues wise and should only be considered if compilation is the issue).  
+While we build and test Cemu using clang, using GCC might work better with your distro (they should be fairly similar performance/issues wise and should only be considered if compilation is the issue).
+
 You can use GCC by doing the following:
 - make sure you have g++ installed in your system
   - installation for Ubuntu and derivatives: `sudo apt install g++`

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -15,7 +15,7 @@ Cemu comes with a `.clang-format` file which is supported by most IDEs for forma
 
 ## About types
 
-Cemu provides it's own set of basic fixed-width types. They are:
+Cemu provides its own set of basic fixed-width types. They are:
 `uint8`, `sint8`, `uint16`, `sint16`, `uint32`, `sint32`, `uint64`, `sint64`. Always use these types over something like `uint32_t`. Using `size_t` is also acceptable where suitable. Avoid C types like `int` or `long`. The only exception is when interacting with external libraries which expect these types as parameters.
 
 ## When and where to put brackets
@@ -48,7 +48,7 @@ In UI related code you can use `formatWxString`, but be aware that number format
 
 ## Strings and encoding
 
-We use UTF-8 encoded `std::string` where possible. Some conversations need special handling and we have helper functions for those:
+We use UTF-8 encoded `std::string` where possible. Some conversions need special handling and we have helper functions for those:
 ```cpp
 // std::filesystem::path <-> std::string (in precompiled.h)
 std::string _pathToUtf8(const fs::path& path);
@@ -69,7 +69,7 @@ If you want to write to log.txt use `cemuLog_log()`. The log type parameter shou
 
 A pretty large part of Cemu's code base are re-implementations of various Cafe OS modules (e.g. `coreinit.rpl`, `gx2.rpl`...). These generally run in the context of the emulated process, thus special care has to be taken to use types with the correct size and endianness when interacting with memory.
 
-Keep in mind that the emulated Espresso CPU is 32bit big-endian, while the host architectures targeted by Cemu are 64bit litte-endian! 
+Keep in mind that the emulated Espresso CPU is 32bit big-endian, while the host architectures targeted by Cemu are 64bit little-endian! 
 
 To keep code simple and remove the need for manual endian-swapping, Cemu has templates and aliases of the basic types with explicit endian-ness.
 For big-endian types add the suffix `be`. Example: `uint32be`

--- a/dist/windows/Cemu.manifest
+++ b/dist/windows/Cemu.manifest
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="amd64" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
+        </dependentAssembly>
+    </dependency>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3"><security><requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel></requestedPrivileges></security>
+    </trustInfo>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+        </windowsSettings>
+    </application>
+</assembly>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,8 @@ add_executable(CemuBin
 if(WIN32)
 	target_sources(CemuBin PRIVATE
 	resource/cemu.rc
-)
+	../dist/windows/cemu.manifest
+	)
 endif()
 
 set_property(TARGET CemuBin PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -77,7 +78,7 @@ if (MACOS_BUNDLE)
 	set(MACOSX_BUNDLE_BUNDLE_NAME "Cemu")
 	set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${CMAKE_PROJECT_VERSION})
 	set(MACOSX_BUNDLE_BUNDLE_VERSION ${CMAKE_PROJECT_VERSION})
-	set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2022 Cemu Project")
+	set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2023 Cemu Project")
 
 	set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
 

--- a/src/Cafe/Filesystem/FST/FST.cpp
+++ b/src/Cafe/Filesystem/FST/FST.cpp
@@ -12,6 +12,8 @@
 
 #include "boost/range/adaptor/reversed.hpp"
 
+#define SET_FST_ERROR(__code) 	if (errorCodeOut) *errorCodeOut = ErrorCode::__code
+
 class FSTDataSource
 {
 public:
@@ -215,23 +217,22 @@ bool FSTVolume::FindDiscKey(const fs::path& path, NCrypto::AesKey& discTitleKey)
 
 // open WUD image using key cache
 // if no matching key is found then keyFound will return false
-FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, bool* keyFound)
+FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, ErrorCode* errorCodeOut)
 {
+	SET_FST_ERROR(UNKNOWN_ERROR);
 	KeyCache_Prepare();
 	NCrypto::AesKey discTitleKey;
 	if (!FindDiscKey(path, discTitleKey))
 	{
-		if(keyFound)
-			*keyFound = false;
+		SET_FST_ERROR(DISC_KEY_MISSING);
 		return nullptr;
 	}
-	if(keyFound)
-		*keyFound = true;
-	return OpenFromDiscImage(path, discTitleKey);
+	return OpenFromDiscImage(path, discTitleKey, errorCodeOut);
 }
 
 // open WUD image
-FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& discTitleKey)
+FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& discTitleKey, ErrorCode* errorCodeOut)
+
 {
 	// WUD images support multiple partitions, each with their own key and FST
 	// the process for loading game data FSTVolume from a WUD image is as follows:
@@ -240,6 +241,7 @@ FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& d
 	// 3) find main GM partition
 	// 4) use SI information to get titleKey for GM partition
 	// 5) Load FST for GM
+	SET_FST_ERROR(UNKNOWN_ERROR);
 	std::unique_ptr<FSTDataSourceWUD> dataSource(FSTDataSourceWUD::Open(path));
 	if (!dataSource)
 		return nullptr;
@@ -365,11 +367,15 @@ FSTVolume* FSTVolume::OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& d
 
 	// load GM partition
 	dataSource->SetBaseOffset((uint64)partitionArray[gmPartitionIndex].partitionAddress * DISC_SECTOR_SIZE);
-	return OpenFST(std::move(dataSource), (uint64)partitionHeaderGM.fstSector * DISC_SECTOR_SIZE, partitionHeaderGM.fstSize, &gmTitleKey, static_cast<FSTVolume::ClusterHashMode>(partitionHeaderGM.fstHashType));
+	FSTVolume* r = OpenFST(std::move(dataSource), (uint64)partitionHeaderGM.fstSector * DISC_SECTOR_SIZE, partitionHeaderGM.fstSize, &gmTitleKey, static_cast<FSTVolume::ClusterHashMode>(partitionHeaderGM.fstHashType));
+	if (r)
+		SET_FST_ERROR(OK);
+	return r;
 }
 
-FSTVolume* FSTVolume::OpenFromContentFolder(fs::path folderPath)
+FSTVolume* FSTVolume::OpenFromContentFolder(fs::path folderPath, ErrorCode* errorCodeOut)
 {
+	SET_FST_ERROR(UNKNOWN_ERROR);
 	// load TMD
 	FileStream* tmdFile = FileStream::openFile2(folderPath / "title.tmd");
 	if (!tmdFile)
@@ -379,17 +385,26 @@ FSTVolume* FSTVolume::OpenFromContentFolder(fs::path folderPath)
 	delete tmdFile;
 	NCrypto::TMDParser tmdParser;
 	if (!tmdParser.parse(tmdData.data(), tmdData.size()))
+	{
+		SET_FST_ERROR(BAD_TITLE_TMD);
 		return nullptr;
+	}
 	// load ticket
 	FileStream* ticketFile = FileStream::openFile2(folderPath / "title.tik");
 	if (!ticketFile)
+	{
+		SET_FST_ERROR(TITLE_TIK_MISSING);
 		return nullptr;
+	}
 	std::vector<uint8> ticketData;
 	ticketFile->extract(ticketData);
 	delete ticketFile;
 	NCrypto::ETicketParser ticketParser;
 	if (!ticketParser.parse(ticketData.data(), ticketData.size()))
+	{
+		SET_FST_ERROR(BAD_TITLE_TIK);
 		return nullptr;
+	}
 	NCrypto::AesKey titleKey;
 	ticketParser.GetTitleKey(titleKey);
 	// open data source
@@ -412,6 +427,8 @@ FSTVolume* FSTVolume::OpenFromContentFolder(fs::path folderPath)
 	// load FST
 	// fstSize = size of first cluster?
 	FSTVolume* fstVolume = FSTVolume::OpenFST(std::move(dataSource), 0, fstSize, &titleKey, fstHashMode);
+	if (fstVolume)
+		SET_FST_ERROR(OK);
 	return fstVolume;
 }
 

--- a/src/Cafe/Filesystem/FST/FST.h
+++ b/src/Cafe/Filesystem/FST/FST.h
@@ -20,11 +20,21 @@ private:
 class FSTVolume
 {
 public:
+	enum class ErrorCode
+  	{
+		OK = 0,
+		UNKNOWN_ERROR = 1,
+	  	DISC_KEY_MISSING = 2,
+	  	TITLE_TIK_MISSING = 3,
+	    BAD_TITLE_TMD = 4,
+	    BAD_TITLE_TIK = 5,
+  	};
+
 	static bool FindDiscKey(const fs::path& path, NCrypto::AesKey& discTitleKey);
 
-	static FSTVolume* OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& discTitleKey);
-	static FSTVolume* OpenFromDiscImage(const fs::path& path, bool* keyFound = nullptr);
-	static FSTVolume* OpenFromContentFolder(fs::path folderPath);
+	static FSTVolume* OpenFromDiscImage(const fs::path& path, NCrypto::AesKey& discTitleKey, ErrorCode* errorCodeOut = nullptr);
+	static FSTVolume* OpenFromDiscImage(const fs::path& path, ErrorCode* errorCodeOut = nullptr);
+	static FSTVolume* OpenFromContentFolder(fs::path folderPath, ErrorCode* errorCodeOut = nullptr);
 
 	~FSTVolume();
 

--- a/src/Cafe/GraphicPack/GraphicPack2.h
+++ b/src/Cafe/GraphicPack/GraphicPack2.h
@@ -97,13 +97,12 @@ public:
 	};
 	using PresetPtr = std::shared_ptr<Preset>;
 
-	GraphicPack2(std::wstring filename);
-	GraphicPack2(std::wstring filename, IniParser& rules);
+	GraphicPack2(std::string filename, IniParser& rules);
 
 	bool IsEnabled() const { return m_enabled; }
 	bool IsActivated() const { return m_activated; }
 	sint32 GetVersion() const { return m_version; }
-	const std::wstring& GetFilename() const { return m_filename; }
+	const std::string& GetFilename() const { return m_filename; }
 	const fs::path GetFilename2() const { return fs::path(m_filename); }
 	bool RequiresRestart(bool changeEnableState, bool changePreset);
 	bool Reload();
@@ -165,7 +164,7 @@ public:
 	static const std::vector<std::shared_ptr<GraphicPack2>>& GetGraphicPacks() { return s_graphic_packs; }
 	static const std::vector<std::shared_ptr<GraphicPack2>>& GetActiveGraphicPacks() { return s_active_graphic_packs; }
 	static void LoadGraphicPack(fs::path graphicPackPath);
-	static bool LoadGraphicPack(const std::wstring& filename, class IniParser& rules);
+	static bool LoadGraphicPack(const std::string& filename, class IniParser& rules);
 	static bool ActivateGraphicPack(const std::shared_ptr<GraphicPack2>& graphic_pack);
 	static bool DeactivateGraphicPack(const std::shared_ptr<GraphicPack2>& graphic_pack);
 	static void ClearGraphicPacks();
@@ -209,7 +208,7 @@ private:
 			parser.TryAddConstant(var.first, (TType)var.second.second);
 	}
 
-	std::wstring m_filename;
+	std::string m_filename;
 
 	sint32 m_version;
 	std::string m_name;

--- a/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2Patches.cpp
@@ -83,7 +83,7 @@ bool GraphicPack2::LoadCemuPatches()
 	};
 
 	bool foundPatches = false;
-	fs::path path(m_filename);
+	fs::path path(_utf8ToPath(m_filename));
 	path.remove_filename();
 	for (auto& p : fs::directory_iterator(path))
 	{
@@ -91,10 +91,10 @@ bool GraphicPack2::LoadCemuPatches()
 		if (fs::is_regular_file(p.status()) && path.has_filename())
 		{
 			// check if filename matches
-			std::wstring filename = path.filename().generic_wstring();
-			if (boost::istarts_with(filename, L"patch_") && boost::iends_with(filename, L".asm"))
+			std::string filename = _pathToUtf8(path.filename());
+			if (boost::istarts_with(filename, "patch_") && boost::iends_with(filename, ".asm"))
 			{
-				FileStream* patchFile = FileStream::openFile(path.generic_wstring().c_str());
+				FileStream* patchFile = FileStream::openFile2(path);
 				if (patchFile)
 				{
 					// read file
@@ -126,27 +126,20 @@ void GraphicPack2::LoadPatchFiles()
 	// order of loading patches:
 	// 1) Load Cemu-style patches (patch_<name>.asm), stop here if at least one patch file exists
 	// 2) Load Cemuhook patches.txt
-
-	// update: As of 1.20.2b Cemu always takes over patching since Cemuhook patching broke due to other internal changes (memory allocation changed and some reordering on when graphic packs get loaded)
 	if (LoadCemuPatches())
 		return; // exit if at least one Cemu style patch file was found
 	// fall back to Cemuhook patches.txt to guarantee backward compatibility
-	fs::path path(m_filename);
+	fs::path path(_utf8ToPath(m_filename));
 	path.remove_filename();
 	path.append("patches.txt");
-
-	FileStream* patchFile = FileStream::openFile(path.generic_wstring().c_str());
-
+	FileStream* patchFile = FileStream::openFile2(path);
 	if (patchFile == nullptr)
 		return;
-
 	// read file
 	std::vector<uint8> fileData;
 	patchFile->extract(fileData);
 	delete patchFile;
-
 	cemu_assert_debug(list_patchGroups.empty());
-
 	// parse
 	MemStreamReader patchesStream(fileData.data(), (sint32)fileData.size());
 	ParseCemuhookPatchesTxtInternal(patchesStream);

--- a/src/Cafe/GraphicPack/GraphicPack2PatchesParser.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2PatchesParser.cpp
@@ -25,7 +25,7 @@ sint32 GraphicPack2::GetLengthWithoutComment(const char* str, size_t length)
 
 void GraphicPack2::LogPatchesSyntaxError(sint32 lineNumber, std::string_view errorMsg)
 {
-	cemuLog_log(LogType::Force, fmt::format(L"Syntax error while parsing patch for graphic pack '{}':", this->GetFilename()));
+	cemuLog_log(LogType::Force, "Syntax error while parsing patch for graphic pack '{}':", this->GetFilename());
 	if(lineNumber >= 0)
 		cemuLog_log(LogType::Force, fmt::format("Line {0}: {1}", lineNumber, errorMsg));
 	else

--- a/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
@@ -511,9 +511,9 @@ void debugger_enterTW(PPCInterpreter_t* hCPU)
 	{
 		if (bp->bpType == DEBUGGER_BP_T_LOGGING && bp->enabled)
 		{
-			std::wstring logName = !bp->comment.empty() ? L"Breakpoint '"+bp->comment+L"'" : fmt::format(L"Breakpoint at 0x{:08X} (no comment)", bp->address);
-			std::wstring logContext = fmt::format(L"Thread: {:08x} LR: 0x{:08x}", coreinitThread_getCurrentThreadMPTRDepr(hCPU), hCPU->spr.LR, cemuLog_advancedPPCLoggingEnabled() ? L" Stack Trace:" : L"");
-			cemuLog_log(LogType::Force, L"[Debugger] {} was executed! {}", logName, logContext);
+			std::string logName = !bp->comment.empty() ? "Breakpoint '"+boost::nowide::narrow(bp->comment)+"'" : fmt::format("Breakpoint at 0x{:08X} (no comment)", bp->address);
+			std::string logContext = fmt::format("Thread: {:08x} LR: 0x{:08x}", coreinitThread_getCurrentThreadMPTRDepr(hCPU), hCPU->spr.LR, cemuLog_advancedPPCLoggingEnabled() ? " Stack Trace:" : "");
+			cemuLog_log(LogType::Force, "[Debugger] {} was executed! {}", logName, logContext);
 			if (cemuLog_advancedPPCLoggingEnabled())
 				DebugLogStackTrace(coreinitThread_getCurrentThreadDepr(hCPU), hCPU->gpr[1]);
 			break;

--- a/src/Cafe/HW/Latte/Core/LatteBufferData.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteBufferData.cpp
@@ -132,22 +132,18 @@ void LatteBufferCache_syncGPUUniformBuffers(LatteDecompilerShader* shader, const
 {
 	if (shader->uniformMode == LATTE_DECOMPILER_UNIFORM_MODE_FULL_CBANK)
 	{
-		// use full uniform buffers
-		for (sint32 t = 0; t < shader->uniformBufferListCount; t++)
+		for(const auto& buf : shader->list_quickBufferList)
 		{
-			sint32 i = shader->uniformBufferList[t];
+			sint32 i = buf.index;
 			MPTR physicalAddr = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 0];
 			uint32 uniformSize = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 1] + 1;
-
-			if (physicalAddr == MPTR_NULL)
+			if (physicalAddr == MPTR_NULL) [[unlikely]]
 			{
-				// no data
 				g_renderer->buffer_bindUniformBuffer(shaderType, i, 0, 0);
 				continue;
 			}
-
+			uniformSize = std::min<uint32>(uniformSize, buf.size);
 			uint32 bindOffset = LatteBufferCache_retrieveDataInCache(physicalAddr, uniformSize);
-
 			g_renderer->buffer_bindUniformBuffer(shaderType, i, bindOffset, uniformSize);
 		}
 	}

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Cafe/HW/Latte/Core/LatteConst.h"
 #include "Cafe/HW/Latte/Renderer/RendererShader.h"
+#include <boost/container/static_vector.hpp>
 
 namespace LatteDecompiler
 {
@@ -158,11 +159,13 @@ struct LatteDecompilerShader
 	struct LatteFetchShader* compatibleFetchShader{};
 	// error tracking
 	bool hasError{false}; // if set, the shader cannot be used
-	// optimized access / iteration
-	// list of uniform buffers used
-	uint8 uniformBufferList[LATTE_NUM_MAX_UNIFORM_BUFFERS];
-	uint8 uniformBufferListCount{ 0 };
-	// list of used texture units (faster access than iterating textureUnitMask)
+	// compact resource lists for optimized access
+	struct QuickBufferEntry
+	{
+		uint8 index;
+		uint16 size;
+	};
+	boost::container::static_vector<QuickBufferEntry, LATTE_NUM_MAX_UNIFORM_BUFFERS> list_quickBufferList;
 	uint8 textureUnitList[LATTE_NUM_MAX_TEX_UNITS];
 	uint8 textureUnitListCount{ 0 };
 	// input

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -440,7 +440,7 @@ void RendererShaderVk::ShaderCacheLoading_begin(uint64 cacheTitleId)
 	}
 	uint32 spirvCacheMagic = GeneratePrecompiledCacheId();
 	const std::string cacheFilename = fmt::format("{:016x}_spirv.bin", cacheTitleId);
-	const std::wstring cachePath = ActiveSettings::GetCachePath("shaderCache/precompiled/{}", cacheFilename).generic_wstring();
+	const fs::path cachePath = ActiveSettings::GetCachePath("shaderCache/precompiled/{}", cacheFilename);
 	s_spirvCache = FileCache::Open(cachePath, true, spirvCacheMagic);
 	if (s_spirvCache == nullptr)
 		cemuLog_log(LogType::Force, "Unable to open SPIR-V cache {}", cacheFilename);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.cpp
@@ -1,12 +1,80 @@
 #include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
 #define VKFUNC_DEFINE
 #include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
+#include <numeric> // for std::iota
 
 #if BOOST_OS_LINUX || BOOST_OS_MACOS
 #include <dlfcn.h>
 #endif
 
+#define VULKAN_API_CPU_BENCHMARK 0	// if 1, Cemu will log the CPU time spent per Vulkan API function
+
 bool g_vulkan_available = false;
+
+#if VULKAN_API_CPU_BENCHMARK != 0
+uint64 s_vulkanBenchmarkLastResultsTime = 0;
+
+struct VulkanBenchmarkFuncInfo
+{
+	std::string funcName;
+	uint64 cycles;
+	uint32 numCalls;
+};
+
+std::vector<VulkanBenchmarkFuncInfo*> s_vulkanBenchmarkFuncs;
+
+template<typename TRet, typename... Args>
+auto VkWrapperFuncGenTest(TRet (*func)(Args...), const char* name)
+{
+	static VulkanBenchmarkFuncInfo _FuncInfo;
+	static auto _FuncPtrCopy = func;
+	TRet (*newFunc)(Args...);
+	if constexpr(std::is_void_v<TRet>)
+	{
+		newFunc = +[](Args... args) { uint64 t = __rdtsc(); _mm_mfence(); _FuncPtrCopy(args...); _mm_mfence(); _FuncInfo.cycles += (__rdtsc() - t); _FuncInfo.numCalls++; };
+	}
+	else
+		newFunc = +[](Args... args) -> TRet { uint64 t = __rdtsc(); _mm_mfence(); TRet r = _FuncPtrCopy(args...); _mm_mfence(); _FuncInfo.cycles += (__rdtsc() - t); _FuncInfo.numCalls++; return r; };
+	if(func && func != newFunc)
+		_FuncPtrCopy = func;
+	if(_FuncInfo.funcName.empty())
+	{
+		_FuncInfo = {.funcName = name, .cycles = 0, .numCalls = 0};
+		s_vulkanBenchmarkFuncs.emplace_back(&_FuncInfo);
+	}
+	return newFunc;
+};
+#endif
+
+// called when a TV SwapBuffers is called
+void VulkanBenchmarkPrintResults()
+{
+#if VULKAN_API_CPU_BENCHMARK != 0
+	// note: This could be done by hooking vk present functions
+	uint64 currentCycle = __rdtsc();
+	uint64 elapsedCycles = currentCycle - s_vulkanBenchmarkLastResultsTime;
+	s_vulkanBenchmarkLastResultsTime = currentCycle;
+	double elapsedCyclesDbl = (double)elapsedCycles;
+	cemuLog_log(LogType::Force, "--- Vulkan API CPU benchmark ---");
+	cemuLog_log(LogType::Force, "Elapsed cycles this frame: {:} | Current cycle {:} | NumFunc {:}", elapsedCycles, currentCycle, s_vulkanBenchmarkFuncs.size());
+
+	std::vector<sint32> sortedIndices(s_vulkanBenchmarkFuncs.size());
+	std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
+	std::sort(sortedIndices.begin(), sortedIndices.end(),
+			  [](int32_t a, int32_t b) {
+				  return s_vulkanBenchmarkFuncs[a]->cycles > s_vulkanBenchmarkFuncs[b]->cycles;
+			  });
+	for (sint32 idx : sortedIndices)
+	{
+		auto& func = s_vulkanBenchmarkFuncs[idx];
+		if(func->cycles == 0)
+			return;
+		cemuLog_log(LogType::Force, "{}: {} cycles ({:.4}%) {} calls", func->funcName.c_str(), func->cycles, ((double)func->cycles / elapsedCyclesDbl) * 100.0, func->numCalls);
+		func->cycles = 0;
+		func->numCalls = 0;
+	}
+#endif
+}
 
 #if BOOST_OS_WINDOWS
 
@@ -57,7 +125,12 @@ bool InitializeDeviceVulkan(VkDevice device)
 
 	#define VKFUNC_DEVICE_INIT
 	#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
-	
+
+#if VULKAN_API_CPU_BENCHMARK != 0
+	#define VKFUNC_DEFINE_CUSTOM(__func) __func = VkWrapperFuncGenTest(__func, #__func)
+	#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
+#endif
+
 	return true;
 }
 
@@ -121,7 +194,12 @@ bool InitializeDeviceVulkan(VkDevice device)
 
 	#define VKFUNC_DEVICE_INIT
 	#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
-	
+
+#if VULKAN_API_CPU_BENCHMARK != 0
+	#define VKFUNC_DEFINE_CUSTOM(__func) __func = VkWrapperFuncGenTest(__func, #__func)
+	#include "Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h"
+#endif
+
 	return true;
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanAPI.h
@@ -14,7 +14,11 @@ extern bool g_vulkan_available;
 
 #endif
 
-#ifdef VKFUNC_DEFINE
+#ifdef VKFUNC_DEFINE_CUSTOM
+	#define VKFUNC(__FUNC__) VKFUNC_DEFINE_CUSTOM(__FUNC__)
+	#define VKFUNC_INSTANCE(__FUNC__) VKFUNC_DEFINE_CUSTOM(__FUNC__)
+	#define VKFUNC_DEVICE(__FUNC__) VKFUNC_DEFINE_CUSTOM(__FUNC__)
+#elif defined(VKFUNC_DEFINE)
 	#define VKFUNC(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
 	#define VKFUNC_INSTANCE(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
 	#define VKFUNC_DEVICE(__FUNC__) NOEXPORT PFN_##__FUNC__ __FUNC__ = nullptr
@@ -239,3 +243,4 @@ VKFUNC_DEVICE(vkDestroyDescriptorSetLayout);
 #undef VKFUNC
 #undef VKFUNC_INSTANCE
 #undef VKFUNC_DEVICE
+#undef VKFUNC_DEFINE_CUSTOM

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -59,10 +59,10 @@ uint32 VulkanPipelineStableCache::BeginLoading(uint64 cacheTitleId)
 
 	// open cache file or create it
 	cemu_assert_debug(s_cache == nullptr);
-	s_cache = FileCache::Open(pathCacheFile.generic_wstring(), true, LatteShaderCache_getPipelineCacheExtraVersion(cacheTitleId));
+	s_cache = FileCache::Open(pathCacheFile, true, LatteShaderCache_getPipelineCacheExtraVersion(cacheTitleId));
 	if (!s_cache)
 	{
-		cemuLog_log(LogType::Force, "Failed to open or create Vulkan pipeline cache file: {}", pathCacheFile.generic_string());
+		cemuLog_log(LogType::Force, "Failed to open or create Vulkan pipeline cache file: {}", _pathToUtf8(pathCacheFile));
 		return 0;
 	}
 	else

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2768,6 +2768,8 @@ void VulkanRenderer::NotifyLatteCommandProcessorIdle()
 		SubmitCommandBuffer();
 }
 
+void VulkanBenchmarkPrintResults();
+
 void VulkanRenderer::SwapBuffers(bool swapTV, bool swapDRC)
 {
 	SubmitCommandBuffer();
@@ -2777,6 +2779,9 @@ void VulkanRenderer::SwapBuffers(bool swapTV, bool swapDRC)
 
 	if (swapDRC && IsSwapchainInfoValid(false))
 		SwapBuffer(false);
+
+	if(swapTV)
+		VulkanBenchmarkPrintResults();
 }
 
 void VulkanRenderer::ClearColorbuffer(bool padView)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -1591,10 +1591,9 @@ void VulkanRenderer::draw_updateUniformBuffersDirectAccess(LatteDecompilerShader
 {
 	if (shader->uniformMode == LATTE_DECOMPILER_UNIFORM_MODE_FULL_CBANK)
 	{
-		// use full uniform buffers
-		for (sint32 t = 0; t < shader->uniformBufferListCount; t++)
+		for(const auto& buf : shader->list_quickBufferList)
 		{
-			sint32 i = shader->uniformBufferList[t];
+			sint32 i = buf.index;
 			MPTR physicalAddr = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 0];
 			uint32 uniformSize = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 1] + 1;
 
@@ -1603,6 +1602,7 @@ void VulkanRenderer::draw_updateUniformBuffersDirectAccess(LatteDecompilerShader
 				cemu_assert_unimplemented();
 				continue;
 			}
+			uniformSize = std::min<uint32>(uniformSize, buf.size);
 
 			cemu_assert_debug(physicalAddr < 0x50000000);
 
@@ -1621,7 +1621,7 @@ void VulkanRenderer::draw_updateUniformBuffersDirectAccess(LatteDecompilerShader
 				dynamicOffsetInfo.shaderUB[VulkanRendererConst::SHADER_STAGE_INDEX_FRAGMENT].unformBufferOffset[bufferIndex] = physicalAddr - m_importedMemBaseAddress;
 				break;
 			default:
-				cemu_assert_debug(false);
+				UNREACHABLE;
 			}
 		}
 	}

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -370,8 +370,12 @@ void VulkanRenderer::indexData_uploadIndexMemory(uint32 offset, uint32 size)
 	// does nothing since the index buffer memory is coherent
 }
 
+float s_vkUniformData[512 * 4];
+
 void VulkanRenderer::uniformData_updateUniformVars(uint32 shaderStageIndex, LatteDecompilerShader* shader)
 {
+	auto GET_UNIFORM_DATA_PTR = [&](size_t index) { return s_vkUniformData + (index / 4); };
+
 	sint32 shaderAluConst;
 	sint32 shaderUniformRegisterOffset;
 
@@ -390,27 +394,23 @@ void VulkanRenderer::uniformData_updateUniformVars(uint32 shaderStageIndex, Latt
 		shaderUniformRegisterOffset = mmSQ_GS_UNIFORM_BLOCK_START;
 		break;
 	default:
-		cemu_assert_debug(false);
+		UNREACHABLE;
 	}
 
 	if (shader->resourceMapping.uniformVarsBufferBindingPoint >= 0)
 	{
-		float uniformData[512 * 4];
-
 		if (shader->uniform.list_ufTexRescale.empty() == false)
 		{
 			for (auto& entry : shader->uniform.list_ufTexRescale)
 			{
 				float* xyScale = LatteTexture_getEffectiveTextureScale(shader->shaderType, entry.texUnit);
-				float* v = uniformData + (entry.uniformLocation / 4);
 				memcpy(entry.currentValue, xyScale, sizeof(float) * 2);
-				memcpy(v, xyScale, sizeof(float) * 2);
+				memcpy(GET_UNIFORM_DATA_PTR(entry.uniformLocation), xyScale, sizeof(float) * 2);
 			}
 		}
 		if (shader->uniform.loc_alphaTestRef >= 0)
 		{
-			float* v = uniformData + (shader->uniform.loc_alphaTestRef / 4);
-			v[0] = LatteGPUState.contextNew.SX_ALPHA_REF.get_ALPHA_TEST_REF();
+			*GET_UNIFORM_DATA_PTR(shader->uniform.loc_alphaTestRef) = LatteGPUState.contextNew.SX_ALPHA_REF.get_ALPHA_TEST_REF();
 		}
 		if (shader->uniform.loc_pointSize >= 0)
 		{
@@ -418,41 +418,38 @@ void VulkanRenderer::uniformData_updateUniformVars(uint32 shaderStageIndex, Latt
 			float pointWidth = (float)pointSizeReg.get_WIDTH() / 8.0f;
 			if (pointWidth == 0.0f)
 				pointWidth = 1.0f / 8.0f; // minimum size
-			float* v = uniformData + (shader->uniform.loc_pointSize / 4);
-			v[0] = pointWidth;
+			*GET_UNIFORM_DATA_PTR(shader->uniform.loc_pointSize) = pointWidth;
 		}
 		if (shader->uniform.loc_remapped >= 0)
 		{
-			LatteBufferCache_LoadRemappedUniforms(shader, uniformData + (shader->uniform.loc_remapped / 4));
+			LatteBufferCache_LoadRemappedUniforms(shader, GET_UNIFORM_DATA_PTR(shader->uniform.loc_remapped));
 		}
 		if (shader->uniform.loc_uniformRegister >= 0)
 		{
 			uint32* uniformRegData = (uint32*)(LatteGPUState.contextRegister + mmSQ_ALU_CONSTANT0_0 + shaderAluConst);
-			float* v = uniformData + (shader->uniform.loc_uniformRegister / 4);
-			memcpy(v, uniformRegData, shader->uniform.count_uniformRegister * 16);
+			memcpy(GET_UNIFORM_DATA_PTR(shader->uniform.loc_uniformRegister), uniformRegData, shader->uniform.count_uniformRegister * 16);
 		}
 		if (shader->uniform.loc_windowSpaceToClipSpaceTransform >= 0)
 		{
 			sint32 viewportWidth;
 			sint32 viewportHeight;
 			LatteRenderTarget_GetCurrentVirtualViewportSize(&viewportWidth, &viewportHeight); // always call after _updateViewport()
-			float* v = uniformData + (shader->uniform.loc_windowSpaceToClipSpaceTransform / 4);
+			float* v = GET_UNIFORM_DATA_PTR(shader->uniform.loc_windowSpaceToClipSpaceTransform);
 			v[0] = 2.0f / (float)viewportWidth;
 			v[1] = 2.0f / (float)viewportHeight;
 		}
 		if (shader->uniform.loc_fragCoordScale >= 0)
 		{
-			float* coordScale = uniformData + (shader->uniform.loc_fragCoordScale / 4);
-			LatteMRT::GetCurrentFragCoordScale(coordScale);
+			LatteMRT::GetCurrentFragCoordScale(GET_UNIFORM_DATA_PTR(shader->uniform.loc_fragCoordScale));
 		}
 		if (shader->uniform.loc_verticesPerInstance >= 0)
 		{
-			*(int*)(uniformData + (shader->uniform.loc_verticesPerInstance / 4)) = m_streamoutState.verticesPerInstance;
+			*(int*)(s_vkUniformData + ((size_t)shader->uniform.loc_verticesPerInstance / 4)) = m_streamoutState.verticesPerInstance;
 			for (sint32 b = 0; b < LATTE_NUM_STREAMOUT_BUFFER; b++)
 			{
 				if (shader->uniform.loc_streamoutBufferBase[b] >= 0)
 				{
-					*(int*)(uniformData + (shader->uniform.loc_streamoutBufferBase[b] / 4)) = m_streamoutState.buffer[b].ringBufferOffset;
+					*(uint32*)GET_UNIFORM_DATA_PTR(shader->uniform.loc_streamoutBufferBase[b]) = m_streamoutState.buffer[b].ringBufferOffset;
 				}
 			}
 		}
@@ -463,7 +460,7 @@ void VulkanRenderer::uniformData_updateUniformVars(uint32 shaderStageIndex, Latt
 		}
 		uint32 bufferAlignmentM1 = std::max(m_featureControl.limits.minUniformBufferOffsetAlignment, m_featureControl.limits.nonCoherentAtomSize) - 1;
 		const uint32 uniformOffset = m_uniformVarBufferWriteIndex;
-		memcpy(m_uniformVarBufferPtr + uniformOffset, uniformData, shader->uniform.uniformRangeSize);
+		memcpy(m_uniformVarBufferPtr + uniformOffset, s_vkUniformData, shader->uniform.uniformRangeSize);
 		m_uniformVarBufferWriteIndex += shader->uniform.uniformRangeSize;
 		m_uniformVarBufferWriteIndex = (m_uniformVarBufferWriteIndex + bufferAlignmentM1) & ~bufferAlignmentM1;
 		// update dynamic offset

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -1574,7 +1574,7 @@ void VulkanRenderer::draw_updateVertexBuffersDirectAccess()
 		uint32 bufferSize = LatteGPUState.contextRegister[bufferBaseRegisterIndex + 1] + 1;
 		uint32 bufferStride = (LatteGPUState.contextRegister[bufferBaseRegisterIndex + 2] >> 11) & 0xFFFF;
 
-		if (bufferAddress == MPTR_NULL)
+		if (bufferAddress == MPTR_NULL) [[unlikely]]
 		{
 			bufferAddress = 0x10000000;
 		}
@@ -1597,7 +1597,7 @@ void VulkanRenderer::draw_updateUniformBuffersDirectAccess(LatteDecompilerShader
 			MPTR physicalAddr = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 0];
 			uint32 uniformSize = LatteGPUState.contextRegister[uniformBufferRegOffset + i * 7 + 1] + 1;
 
-			if (physicalAddr == MPTR_NULL)
+			if (physicalAddr == MPTR_NULL) [[unlikely]]
 			{
 				cemu_assert_unimplemented();
 				continue;

--- a/src/Cafe/IOSU/legacy/iosu_act.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_act.cpp
@@ -113,7 +113,7 @@ void iosuAct_loadAccounts()
 	//	}
 	//}
 
-	cemuLog_log(LogType::Force, L"IOSU_ACT: using account {} in first slot", first_acc.GetMiiName());
+	cemuLog_log(LogType::Force, "IOSU_ACT: using account {} in first slot", boost::nowide::narrow(first_acc.GetMiiName()));
 	
 	_actAccountDataInitialized = true;
 }

--- a/src/Cafe/IOSU/legacy/iosu_crypto.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.cpp
@@ -615,10 +615,10 @@ void iosuCrypto_init()
 	iosuCrypto_loadSSLCertificates();
 }
 
-bool iosuCrypto_checkRequirementMLCFile(std::string_view mlcSubpath, std::wstring& additionalErrorInfo_filePath)
+bool iosuCrypto_checkRequirementMLCFile(std::string_view mlcSubpath, std::string& additionalErrorInfo_filePath)
 {
 	const auto path = ActiveSettings::GetMlcPath(mlcSubpath);
-	additionalErrorInfo_filePath = path.generic_wstring();
+	additionalErrorInfo_filePath = _pathToUtf8(path);
 	sint32 fileDataSize = 0;
 	auto fileData = FileStream::LoadIntoMemory(path);
 	if (!fileData)
@@ -626,7 +626,7 @@ bool iosuCrypto_checkRequirementMLCFile(std::string_view mlcSubpath, std::wstrin
 	return true;
 }
 
-sint32 iosuCrypt_checkRequirementsForOnlineMode(std::wstring& additionalErrorInfo)
+sint32 iosuCrypt_checkRequirementsForOnlineMode(std::string& additionalErrorInfo)
 {
 	std::error_code ec;
 	// check if otp.bin is present

--- a/src/Cafe/IOSU/legacy/iosu_crypto.h
+++ b/src/Cafe/IOSU/legacy/iosu_crypto.h
@@ -74,7 +74,7 @@ enum
 	IOS_CRYPTO_ONLINE_REQ_MISSING_FILE
 };
 
-sint32 iosuCrypt_checkRequirementsForOnlineMode(std::wstring& additionalErrorInfo);
+sint32 iosuCrypt_checkRequirementsForOnlineMode(std::string& additionalErrorInfo);
 void iosuCrypto_readOtpData(void* output, sint32 wordIndex, sint32 size);
 
 std::vector<const wchar_t*> iosuCrypt_getCertificateKeys();

--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -78,13 +78,6 @@ struct RPLRegionMappingTable
 void RPLLoader_UnloadModule(RPLModule* rpl);
 void RPLLoader_RemoveDependency(const char* name);
 
-char _ansiToLower(char c)
-{
-	if (c >= 'A' && c <= 'Z')
-		c -= ('A' - 'a');
-	return c;
-}
-
 uint8* RPLLoader_AllocateTrampolineCodeSpace(RPLModule* rplLoaderContext, sint32 size)
 {	
 	if (rplLoaderContext)

--- a/src/Cafe/OS/libs/coreinit/coreinit_Time.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Time.cpp
@@ -28,16 +28,6 @@ namespace coreinit
 		osLib_returnFromFunction64(hCPU, osTime);
 	}
 
-	uint64 coreinit_getTimeBase_dummy()
-	{
-		return __rdtsc();
-	}
-
-	void export_OSGetSystemTimeDummy(PPCInterpreter_t* hCPU)
-	{
-		osLib_returnFromFunction64(hCPU, coreinit_getTimeBase_dummy());
-	}
-
 	void export_OSGetSystemTime(PPCInterpreter_t* hCPU)
 	{
 		osLib_returnFromFunction64(hCPU, coreinit_getTimerTick());
@@ -371,14 +361,13 @@ namespace coreinit
 	void InitializeTimeAndCalendar()
 	{
 		osLib_addFunction("coreinit", "OSGetTime", export_OSGetTime);
-		osLib_addFunction("coreinit", "OSGetSystemTime", export_OSGetSystemTimeDummy);
+		osLib_addFunction("coreinit", "OSGetSystemTime", export_OSGetSystemTime);
 		osLib_addFunction("coreinit", "OSGetTick", export_OSGetTick);
 		osLib_addFunction("coreinit", "OSGetSystemTick", export_OSGetSystemTick);
 
 		cafeExportRegister("coreinit", OSTicksToCalendarTime, LogType::Placeholder);
 		cafeExportRegister("coreinit", OSCalendarTimeToTicks, LogType::Placeholder);
 
-		osLib_addFunction("coreinit", "OSGetSystemTime", export_OSGetSystemTime);
 
 		//timeTest();
 	}

--- a/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
+++ b/src/Cafe/OS/libs/nn_nfp/nn_nfp.cpp
@@ -180,7 +180,7 @@ struct
 	bool hasOpenApplicationArea; // set to true if application area was opened or created
 	// currently active Amiibo
 	bool hasActiveAmiibo;
-	std::wstring amiiboPath;
+	fs::path amiiboPath;
 	bool hasInvalidHMAC;
 	uint32 amiiboTouchTime;
 	AmiiboRawNFCData amiiboNFCData; // raw data
@@ -188,7 +188,6 @@ struct
 	AmiiboProcessedData amiiboProcessedData;
 }nfp_data = { 0 };
 
-bool nnNfp_touchNfcTagFromFile(const wchar_t* filePath, uint32* nfcError);
 bool nnNfp_writeCurrentAmiibo();
 
 #include "AmiiboCrypto.h"
@@ -770,7 +769,7 @@ void nnNfp_unloadAmiibo()
 	nnNfpUnlock();
 }
 
-bool nnNfp_touchNfcTagFromFile(const wchar_t* filePath, uint32* nfcError)
+bool nnNfp_touchNfcTagFromFile(const fs::path& filePath, uint32* nfcError)
 {
 	AmiiboRawNFCData rawData = { 0 };
 	auto nfcData = FileStream::LoadIntoMemory(filePath);
@@ -847,11 +846,11 @@ bool nnNfp_touchNfcTagFromFile(const wchar_t* filePath, uint32* nfcError)
 	memcpy(&nfp_data.amiiboNFCData, &rawData, sizeof(AmiiboRawNFCData));
 	// decrypt amiibo
 	amiiboDecrypt();
-	nfp_data.amiiboPath = std::wstring(filePath);
+	nfp_data.amiiboPath = filePath;
 	nfp_data.hasActiveAmiibo = true;
 	if (nfp_data.activateEvent)
 	{
-		coreinit::OSEvent* osEvent = (coreinit::OSEvent*)memory_getPointerFromVirtualOffset(nfp_data.activateEvent);
+		MEMPTR<coreinit::OSEvent> osEvent(nfp_data.activateEvent);
 		coreinit::OSSignalEvent(osEvent);
 	}
 	nfp_data.amiiboTouchTime = GetTickCount();

--- a/src/Cafe/OS/libs/nn_nfp/nn_nfp.h
+++ b/src/Cafe/OS/libs/nn_nfp/nn_nfp.h
@@ -8,7 +8,7 @@ namespace nn::nfp
 void nnNfp_load();
 void nnNfp_update();
 
-bool nnNfp_touchNfcTagFromFile(const wchar_t* filePath, uint32* nfcError);
+bool nnNfp_touchNfcTagFromFile(const fs::path& filePath, uint32* nfcError);
 
 #define NFP_STATE_NONE			(0)
 #define NFP_STATE_INIT			(1)

--- a/src/Cafe/TitleList/TitleInfo.cpp
+++ b/src/Cafe/TitleList/TitleInfo.cpp
@@ -77,6 +77,7 @@ TitleInfo::TitleInfo(const fs::path& path, std::string_view subPath)
 	if (!path.has_filename())
 	{
 		m_isValid = false;
+		SetInvalidReason(InvalidReason::BAD_PATH_OR_INACCESSIBLE);
 		return;
 	}
 	m_isValid = true;
@@ -269,6 +270,7 @@ bool TitleInfo::DetectFormat(const fs::path& path, fs::path& pathOut, TitleDataF
 			return true;
 		}
 	}
+	SetInvalidReason(InvalidReason::UNKNOWN_FORMAT);
 	return false;
 }
 
@@ -319,6 +321,12 @@ uint64 TitleInfo::GetUID()
 {
 	cemu_assert_debug(m_isValid);
 	return m_uid;
+}
+
+void TitleInfo::SetInvalidReason(InvalidReason reason)
+{
+	if(m_invalidReason == InvalidReason::NONE)
+		m_invalidReason = reason; // only update reason when it hasn't been set before
 }
 
 std::mutex sZArchivePoolMtx;
@@ -382,21 +390,29 @@ bool TitleInfo::Mount(std::string_view virtualPath, std::string_view subfolder, 
 		if (!r)
 		{
 			cemuLog_log(LogType::Force, "Failed to mount {} to {}", virtualPath, subfolder);
+			SetInvalidReason(InvalidReason::BAD_PATH_OR_INACCESSIBLE);
 			return false;
 		}
 	}
 	else if (m_titleFormat == TitleDataFormat::WUD || m_titleFormat == TitleDataFormat::NUS)
 	{
+		FSTVolume::ErrorCode fstError;
 		if (m_mountpoints.empty())
 		{
 			cemu_assert_debug(!m_wudVolume);
 			if(m_titleFormat == TitleDataFormat::WUD)
-				m_wudVolume = FSTVolume::OpenFromDiscImage(m_fullPath); // open wud/wux
+				m_wudVolume = FSTVolume::OpenFromDiscImage(m_fullPath, &fstError); // open wud/wux
 			else
-				m_wudVolume = FSTVolume::OpenFromContentFolder(m_fullPath.parent_path());	// open from .app files directory, the path points to /title.tmd
+				m_wudVolume = FSTVolume::OpenFromContentFolder(m_fullPath.parent_path(), &fstError); // open from .app files directory, the path points to /title.tmd
 		}
 		if (!m_wudVolume)
+		{
+			if (fstError == FSTVolume::ErrorCode::DISC_KEY_MISSING)
+				SetInvalidReason(InvalidReason::NO_DISC_KEY);
+			else if (fstError == FSTVolume::ErrorCode::TITLE_TIK_MISSING)
+				SetInvalidReason(InvalidReason::NO_TITLE_TIK);
 			return false;
+		}
 		bool r = FSCDeviceWUD_Mount(virtualPath, subfolder, m_wudVolume, mountPriority);
 		cemu_assert_debug(r);
 		if (!r)
@@ -518,6 +534,7 @@ bool TitleInfo::ParseXmlInfo()
 		m_parsedAppXml = nullptr;
 		m_parsedCosXml = nullptr;
 		m_isValid = false;
+		SetInvalidReason(InvalidReason::MISSING_XML_FILES);
 		return false;
 	}
 	m_isValid = true;

--- a/src/Cafe/TitleList/TitleInfo.h
+++ b/src/Cafe/TitleList/TitleInfo.h
@@ -65,6 +65,16 @@ public:
 		INVALID_STRUCTURE = 0,
 	};
 
+	enum class InvalidReason : uint8
+	{
+		NONE = 0,
+		BAD_PATH_OR_INACCESSIBLE = 1,
+		UNKNOWN_FORMAT = 2,
+		NO_DISC_KEY = 3,
+		NO_TITLE_TIK = 4,
+		MISSING_XML_FILES = 4,
+	};
+
 	struct CachedInfo
 	{
 		TitleDataFormat titleDataFormat;
@@ -101,6 +111,7 @@ public:
 	CachedInfo MakeCacheEntry();
 
 	bool IsValid() const;
+	InvalidReason GetInvalidReason() const { return m_invalidReason; }
 	uint64 GetUID(); // returns a unique identifier derived from the absolute canonical title location which can be used to identify this title by its location. May not persist across sessions, especially when Cemu is used portable
 
 	fs::path GetPath() const;
@@ -182,7 +193,7 @@ private:
 
 	bool DetectFormat(const fs::path& path, fs::path& pathOut, TitleDataFormat& formatOut);
 	void CalcUID();
-
+	void SetInvalidReason(InvalidReason reason);
 	bool ParseAppXml(std::vector<uint8>& appXmlData);
 
 	bool m_isValid{ false };
@@ -190,6 +201,7 @@ private:
 	fs::path m_fullPath;
 	std::string m_subPath; // used for formats where fullPath isn't unique on its own (like WUA)
 	uint64 m_uid{};
+	InvalidReason m_invalidReason{ InvalidReason::NONE }; // if m_isValid == false, this contains a more detailed error code
 	// mounting info
 	std::vector<std::pair<sint32, std::string>> m_mountpoints;
 	class FSTVolume* m_wudVolume{};

--- a/src/Cafe/TitleList/TitleInfo.h
+++ b/src/Cafe/TitleList/TitleInfo.h
@@ -60,6 +60,7 @@ public:
 		HOST_FS = 1, // host filesystem directory (fullPath points to root with content/code/meta subfolders)
 		WUD = 2, // WUD or WUX
 		WIIU_ARCHIVE = 3, // Wii U compressed single-file archive (.wua)
+	  	NUS = 4, // NUS format. Directory with .app files, title.tik and title.tmd
 		// error
 		INVALID_STRUCTURE = 0,
 	};

--- a/src/Cemu/Logging/CemuLogging.cpp
+++ b/src/Cemu/Logging/CemuLogging.cpp
@@ -157,14 +157,6 @@ bool cemuLog_log(LogType type, std::u8string_view text)
 	return cemuLog_log(type, s);
 }
 
-bool cemuLog_log(LogType type, std::wstring_view text)
-{
-	if (!cemuLog_isLoggingEnabled(type))
-		return false;
-
-	return cemuLog_log(type, boost::nowide::narrow(text.data(), text.size()));
-}
-
 void cemuLog_waitForFlush()
 {
 	cemuLog_createLogFile(false);

--- a/src/Cemu/Logging/CemuLogging.h
+++ b/src/Cemu/Logging/CemuLogging.h
@@ -68,7 +68,6 @@ inline bool cemuLog_isLoggingEnabled(LogType type)
 
 bool cemuLog_log(LogType type, std::string_view text);
 bool cemuLog_log(LogType type, std::u8string_view text);
-bool cemuLog_log(LogType type, std::wstring_view text);
 void cemuLog_waitForFlush(); // wait until all log lines are written
 
 template <typename T>

--- a/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
+++ b/src/Cemu/Tools/DownloadManager/DownloadManager.cpp
@@ -1541,7 +1541,7 @@ void DownloadManager::runManager()
 	auto cacheFilePath = ActiveSettings::GetMlcPath("usr/save/system/nim/nup/");
 	fs::create_directories(cacheFilePath);
 	cacheFilePath /= "cemu_cache.dat";
-	s_nupFileCache = FileCache::Open(cacheFilePath.generic_wstring(), true);
+	s_nupFileCache = FileCache::Open(cacheFilePath, true);
 	// launch worker thread
 	std::thread t(&DownloadManager::threadFunc, this);
 	t.detach();

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -468,6 +468,14 @@ inline fs::path _utf8ToPath(std::string_view input)
     return fs::path(v);
 }
 
+// locale-independent variant of tolower() which also matches Wii U behavior
+inline char _ansiToLower(char c)
+{
+	if (c >= 'A' && c <= 'Z')
+		c -= ('A' - 'a');
+	return c;
+}
+
 class RunAtCemuBoot // -> replaces this with direct function calls. Linkers other than MSVC may optimize way object files entirely if they are not referenced from outside. So a source file self-registering using this would be causing issues
 {
 public:

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -235,10 +235,13 @@ inline uint64 _udiv128(uint64 highDividend, uint64 lowDividend, uint64 divisor, 
 
 #if defined(_MSC_VER)
     #define UNREACHABLE __assume(false)
+	#define ASSUME(__cond) __assume(__cond)
 #elif defined(__GNUC__)
     #define UNREACHABLE __builtin_unreachable()
+	#define ASSUME(__cond) __attribute__((assume(__cond)))
 #else
     #define UNREACHABLE
+	#define ASSUME(__cond)
 #endif
 
 #if defined(_MSC_VER)

--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -33,7 +33,6 @@ FileStream* FileStream::openFile(const wchar_t* path, bool allowWrite)
 
 FileStream* FileStream::openFile2(const fs::path& path, bool allowWrite)
 {
-	//return openFile(path.generic_wstring().c_str(), allowWrite);
 	FileStream* fs = new FileStream(path, true, allowWrite);
 	if (fs->m_isValid)
 		return fs;

--- a/src/config/ActiveSettings.cpp
+++ b/src/config/ActiveSettings.cpp
@@ -40,7 +40,7 @@ ActiveSettings::LoadOnce(
 	g_config.SetFilename(GetConfigPath("settings.xml").generic_wstring());
 	g_config.Load();
 	LaunchSettings::ChangeNetworkServiceURL(GetConfig().account.active_service);
-	std::wstring additionalErrorInfo;
+	std::string additionalErrorInfo;
 	s_has_required_online_files = iosuCrypt_checkRequirementsForOnlineMode(additionalErrorInfo) == IOS_CRYPTO_ONLINE_REQ_OK;
 	return failed_write_access;
 }

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -110,7 +110,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 
 		try
 		{
-			recent_launch_files.emplace_back(boost::nowide::widen(path));
+			recent_launch_files.emplace_back(path);
 		}
 		catch (const std::exception&)
 		{
@@ -125,10 +125,9 @@ void CemuConfig::Load(XMLConfigParser& parser)
 		const std::string path = element.value("");
 		if (path.empty())
 			continue;
-
 		try
 		{
-			recent_nfc_files.emplace_back(boost::nowide::widen(path));
+			recent_nfc_files.emplace_back(path);
 		}
 		catch (const std::exception&)
 		{
@@ -143,10 +142,9 @@ void CemuConfig::Load(XMLConfigParser& parser)
 		const std::string path = element.value("");
 		if (path.empty())
 			continue;
-
 		try
 		{
-			game_paths.emplace_back(boost::nowide::widen(path));
+			game_paths.emplace_back(path);
 		}
 		catch (const std::exception&)
 		{
@@ -402,20 +400,20 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	auto launch_files_parser = config.set("RecentLaunchFiles");
 	for (const auto& entry : recent_launch_files)
 	{
-		launch_files_parser.set("Entry", boost::nowide::narrow(entry).c_str());
+		launch_files_parser.set("Entry", entry.c_str());
 	}
 	
 	auto nfc_files_parser = config.set("RecentNFCFiles");
 	for (const auto& entry : recent_nfc_files)
 	{
-		nfc_files_parser.set("Entry", boost::nowide::narrow(entry).c_str());
+		nfc_files_parser.set("Entry", entry.c_str());
 	}
 		
 	// game paths
 	auto game_path_parser = config.set("GamePaths");
 	for (const auto& entry : game_paths)
 	{
-		game_path_parser.set("Entry", boost::nowide::narrow(entry).c_str());
+		game_path_parser.set("Entry", entry.c_str());
 	}
 
 	// game list cache
@@ -593,22 +591,18 @@ void CemuConfig::SetGameListCustomName(uint64 titleId, std::string customName)
 	gameEntry->custom_name = std::move(customName);
 }
 
-void CemuConfig::AddRecentlyLaunchedFile(std::wstring_view file)
+void CemuConfig::AddRecentlyLaunchedFile(std::string_view file)
 {
-	// insert into front
-	recent_launch_files.insert(recent_launch_files.begin(), std::wstring{ file });
+	recent_launch_files.insert(recent_launch_files.begin(), std::string(file));
 	RemoveDuplicatesKeepOrder(recent_launch_files);
-	// keep maximum of entries
 	while(recent_launch_files.size() > kMaxRecentEntries)
 		recent_launch_files.pop_back();
 }
 
-void CemuConfig::AddRecentNfcFile(std::wstring_view file)
+void CemuConfig::AddRecentNfcFile(std::string_view file)
 {
-	// insert into front
-	recent_nfc_files.insert(recent_nfc_files.begin(), std::wstring{ file });
+	recent_nfc_files.insert(recent_nfc_files.begin(), std::string(file));
 	RemoveDuplicatesKeepOrder(recent_nfc_files);
-	// keep maximum of entries
 	while (recent_nfc_files.size() > kMaxRecentEntries)
 		recent_nfc_files.pop_back();
 }

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -379,7 +379,7 @@ struct CemuConfig
 	ConfigValue<bool> disable_screensaver{DISABLE_SCREENSAVER_DEFAULT};
 #undef DISABLE_SCREENSAVER_DEFAULT
 
-	std::vector<std::wstring> game_paths;
+	std::vector<std::string> game_paths;
 	std::mutex game_cache_entries_mutex;
 	std::vector<GameEntry> game_cache_entries;
 
@@ -399,8 +399,8 @@ struct CemuConfig
 
 	// max 15 entries
 	static constexpr size_t kMaxRecentEntries = 15;
-	std::vector<std::wstring> recent_launch_files;
-	std::vector<std::wstring> recent_nfc_files;
+	std::vector<std::string> recent_launch_files;
+	std::vector<std::string> recent_nfc_files;
 
 	Vector2i window_position{-1,-1};
 	Vector2i window_size{ -1,-1 };
@@ -499,8 +499,8 @@ struct CemuConfig
 	void Load(XMLConfigParser& parser);
 	void Save(XMLConfigParser& parser);
 
-	void AddRecentlyLaunchedFile(std::wstring_view file);
-	void AddRecentNfcFile(std::wstring_view file);
+	void AddRecentlyLaunchedFile(std::string_view file);
+	void AddRecentNfcFile(std::string_view file);
 
 	bool IsGameListFavorite(uint64 titleId);
 	void SetGameListFavorite(uint64 titleId, bool isFavorite);

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -198,9 +198,9 @@ void CemuApp::OnAssertFailure(const wxChar* file, int line, const wxChar* func, 
 {
 	cemuLog_createLogFile(false);
 	cemuLog_log(LogType::Force, "Encountered wxWidgets assert!");
-	cemuLog_log(LogType::Force, fmt::format(L"File: {0} Line: {1}", std::wstring_view(file), line));
-	cemuLog_log(LogType::Force, fmt::format(L"Func: {0} Cond: {1}", func, std::wstring_view(cond)));
-	cemuLog_log(LogType::Force, fmt::format(L"Message: {}", std::wstring_view(msg)));
+	cemuLog_log(LogType::Force, "File: {0} Line: {1}", wxString(file).utf8_string(), line);
+	cemuLog_log(LogType::Force, "Func: {0} Cond: {1}", wxString(func).utf8_string(), wxString(cond).utf8_string());
+	cemuLog_log(LogType::Force, "Message: {}", wxString(msg).utf8_string());
 
 #if BOOST_OS_WINDOWS
 	DumpThreadStackTrace();

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -923,7 +923,7 @@ void GeneralSettings2::StoreConfig()
 
 	config.game_paths.clear();
 	for (auto& path : m_game_paths->GetStrings())
-		config.game_paths.emplace_back(path);
+		config.game_paths.emplace_back(path.utf8_string());
 
 	auto selection = m_language->GetSelection();
 	if (selection == 0)
@@ -1530,7 +1530,7 @@ void GeneralSettings2::ApplyConfig()
 
 	for (auto& path : config.game_paths)
 	{
-		m_game_paths->Append(path);
+		m_game_paths->Append(to_wxString(path));
 	}
 
 	const auto app = (CemuApp*)wxTheApp;

--- a/src/gui/GettingStartedDialog.cpp
+++ b/src/gui/GettingStartedDialog.cpp
@@ -229,7 +229,7 @@ void GettingStartedDialog::OnClose(wxCloseEvent& event)
 		const auto it = std::find(config.game_paths.cbegin(), config.game_paths.cend(), gamePath);
 		if (it == config.game_paths.cend())
 		{
-			config.game_paths.emplace_back(gamePath.generic_wstring());
+			config.game_paths.emplace_back(_pathToUtf8(gamePath));
 			m_game_path_changed = true;
 		}
 	}
@@ -248,7 +248,7 @@ void GettingStartedDialog::OnClose(wxCloseEvent& event)
 
 	CafeTitleList::ClearScanPaths();
 	for (auto& it : GetConfig().game_paths)
-		CafeTitleList::AddScanPath(it);
+		CafeTitleList::AddScanPath(_utf8ToPath(it));
 	CafeTitleList::Refresh();
 }
 

--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -329,7 +329,7 @@ void GraphicPacksWindow2::SaveStateToConfig()
 
 	for (const auto& gp : GraphicPack2::GetGraphicPacks())
 	{
-		auto filename = MakeRelativePath(ActiveSettings::GetUserDataPath(), gp->GetFilename()).lexically_normal();
+		auto filename = MakeRelativePath(ActiveSettings::GetUserDataPath(), _utf8ToPath(gp->GetFilename())).lexically_normal();
 		if (gp->IsEnabled())
 		{
 			data.graphic_pack_entries.try_emplace(filename);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -639,13 +639,15 @@ void MainWindow::OnFileMenu(wxCommandEvent& event)
 	if (menuId == MAINFRAME_MENU_ID_FILE_LOAD)
 	{
 		const auto wildcard = formatWxString(
-			"{}|*.wud;*.wux;*.wua;*.iso;*.rpx;*.elf"
+			"{}|*.wud;*.wux;*.wua;*.iso;*.rpx;*.elf;title.tmd"
 			"|{}|*.wud;*.wux;*.iso"
+			"|{}|title.tmd"
 			"|{}|*.wua"
 			"|{}|*.rpx;*.elf"
 			"|{}|*",
 			_("All Wii U files (*.wud, *.wux, *.wua, *.iso, *.rpx, *.elf)"),
 			_("Wii U image (*.wud, *.wux, *.iso, *.wad)"),
+			_("Wii U NUS content"),
 			_("Wii U archive (*.wua)"),
 			_("Wii U executable (*.rpx, *.elf)"),
 			_("All files (*.*)")

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -559,6 +559,16 @@ bool MainWindow::FileLoad(std::wstring fileName, wxLaunchGameEvent::INITIATED_BY
 		{
 			wxString t = _("Unable to launch game\nPath:\n");
 			t.append(fileName);
+			if(launchTitle.GetInvalidReason() == TitleInfo::InvalidReason::NO_DISC_KEY)
+			{
+				t.append(_("\n\n"));
+				t.append(_("Could not decrypt title. Make sure that keys.txt contains the correct disc key for this title."));
+			}
+			if(launchTitle.GetInvalidReason() == TitleInfo::InvalidReason::NO_TITLE_TIK)
+			{
+				t.append(_(""));
+				t.append(_("\n\nCould not decrypt title because title.tik is missing."));
+			}
 			wxMessageBox(t, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 			return false;
 		}

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -65,7 +65,7 @@ public:
 	void UpdateSettingsAfterGameLaunch();
 	void RestoreSettingsAfterGameExited();
 
-	bool FileLoad(std::wstring fileName, wxLaunchGameEvent::INITIATED_BY initiatedBy);
+	bool FileLoad(const fs::path launchPath, wxLaunchGameEvent::INITIATED_BY initiatedBy);
 
 	[[nodiscard]] bool IsGameLaunched() const { return m_game_launched; }
 

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -274,6 +274,9 @@ void wxTitleManagerList::OnConvertToCompressedFormat(uint64 titleId, uint64 righ
 					break; // prefer the users selection
 			}
 		}
+	}
+	for (const auto& data : m_data)
+	{
 		if (hasUpdateTitleId && data->entry.title_id == updateTitleId)
 		{
 			if (!titleInfo_update.IsValid())

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -352,7 +352,7 @@ void wxTitleManagerList::OnConvertToCompressedFormat(uint64 titleId, uint64 righ
 		boost::replace_all(shortName, ":", "");
 	}
 	// for the default output directory we use the first game path configured by the user
-	std::wstring defaultDir = L"";
+	std::string defaultDir = "";
 	if (!GetConfig().game_paths.empty())
 		defaultDir = GetConfig().game_paths.front();
 	// get the short name, which we will use as a suggested default file name

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -941,6 +941,8 @@ wxString wxTitleManagerList::GetTitleEntryText(const TitleEntry& entry, ItemColu
 			return _("Folder");
 		case wxTitleManagerList::EntryFormat::WUD:
 			return _("WUD");
+		case wxTitleManagerList::EntryFormat::NUS:
+			return _("NUS");
 		case wxTitleManagerList::EntryFormat::WUA:
 			return _("WUA");
 		}
@@ -1010,15 +1012,18 @@ void wxTitleManagerList::HandleTitleListCallback(CafeTitleListCallbackEvent* evt
 	wxTitleManagerList::EntryFormat entryFormat;
 	switch (titleInfo.GetFormat())
 	{
-	case TitleInfo::TitleDataFormat::HOST_FS:
-	default:
-		entryFormat = EntryFormat::Folder;
-		break;
 	case TitleInfo::TitleDataFormat::WUD:
 		entryFormat = EntryFormat::WUD;
 		break;
+	case TitleInfo::TitleDataFormat::NUS:
+		entryFormat = EntryFormat::NUS;
+		break;
 	case TitleInfo::TitleDataFormat::WIIU_ARCHIVE:
 		entryFormat = EntryFormat::WUA;
+		break;
+	case TitleInfo::TitleDataFormat::HOST_FS:
+	default:
+		entryFormat = EntryFormat::Folder;
 		break;
 	}
 

--- a/src/gui/components/wxTitleManagerList.h
+++ b/src/gui/components/wxTitleManagerList.h
@@ -42,6 +42,7 @@ public:
 	{
 		Folder,
 		WUD,
+		NUS,
 		WUA,
 	};
 


### PR DESCRIPTION
In this PR:

- Support for game dumps in NUS/WUP format (collection of .app files + title.tmd + title.tik) Closes #929
- Shader decompiler will now limit the size of uniform buffers if it can be determined at translation time. Smaller uniforms means the uniform synchronization overhead is reduced a bit.
- Added a Vulkan API CPU profiler. This can only be enabled in source code and is mainly intended to aid with optimization work.
- Fixed an issue where WUA conversion would ignore updates
- Better error messages when encrypted titles fail to launch, like informing the user about missing key in keys.txt
- Use utf8 in more places
- Updated Windows build instructions in BUILD.md
- Make the Windows build DPI-aware again (Closes #828 #155 #896)