### PR TITLE
Minor localization adjustments

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -55,6 +55,7 @@ std::string _pathToUtf8(const fs::path& path);
 fs::path _utf8ToPath(std::string_view input);
 
 // wxString <-> std::string
+wxString wxString::FromUTF8(const std::string& s)
 wxString to_wxString(std::string_view str); // in gui/helpers.h
 std::string wxString::utf8_string();
 

--- a/src/audio/audioDebuggerWindow.cpp
+++ b/src/audio/audioDebuggerWindow.cpp
@@ -33,93 +33,93 @@ AudioDebuggerWindow::AudioDebuggerWindow(wxFrame& parent)
 	// add columns
 	wxListItem col0;
 	col0.SetId(0);
-	col0.SetText(wxT("idx"));
+	col0.SetText("idx");
 	col0.SetWidth(40);
 	voiceListbox->InsertColumn(0, col0);
 	wxListItem col1;
 	col1.SetId(1);
-	col1.SetText(wxT("state"));
+	col1.SetText("state");
 	col1.SetWidth(48);
 	voiceListbox->InsertColumn(1, col1);
 	//wxListItem col2;
 	// format
 	col1.SetId(2);
-	col1.SetText(wxT("fmt"));
+	col1.SetText("fmt");
 	col1.SetWidth(52);
 	voiceListbox->InsertColumn(2, col1);
 	// sample base addr
 	col1.SetId(3);
-	col1.SetText(wxT("base"));
+	col1.SetText("base");
 	col1.SetWidth(70);
 	voiceListbox->InsertColumn(3, col1);
 	// current offset
 	col1.SetId(4);
-	col1.SetText(wxT("current"));
+	col1.SetText("current");
 	col1.SetWidth(70);
 	voiceListbox->InsertColumn(4, col1);
 	// loop offset
 	col1.SetId(5);
-	col1.SetText(wxT("loop"));
+	col1.SetText("loop");
 	col1.SetWidth(70);
 	voiceListbox->InsertColumn(5, col1);
 	// end offset
 	col1.SetId(6);
-	col1.SetText(wxT("end"));
+	col1.SetText("end");
 	col1.SetWidth(70);
 	voiceListbox->InsertColumn(6, col1);
 	// volume
 	col1.SetId(7);
-	col1.SetText(wxT("vol"));
+	col1.SetText("vol");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(7, col1);
 	// volume delta
 	col1.SetId(8);
-	col1.SetText(wxT("volD"));
+	col1.SetText("volD");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(8, col1);
 	// src
 	col1.SetId(9);
-	col1.SetText(wxT("src"));
+	col1.SetText("src");
 	col1.SetWidth(70);
 	voiceListbox->InsertColumn(9, col1);
 	// low-pass filter coef a0
 	col1.SetId(10);
-	col1.SetText(wxT("lpa0"));
+	col1.SetText("lpa0");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(10, col1);
 	// low-pass filter coef b0
 	col1.SetId(11);
-	col1.SetText(wxT("lpb0"));
+	col1.SetText("lpb0");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(11, col1);
 	// biquad filter coef b0
 	col1.SetId(12);
-	col1.SetText(wxT("bqb0"));
+	col1.SetText("bqb0");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(12, col1);
 	// biquad filter coef b0
 	col1.SetId(13);
-	col1.SetText(wxT("bqb1"));
+	col1.SetText("bqb1");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(13, col1);
 	// biquad filter coef b0
 	col1.SetId(14);
-	col1.SetText(wxT("bqb2"));
+	col1.SetText("bqb2");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(14, col1);
 	// biquad filter coef a0
 	col1.SetId(15);
-	col1.SetText(wxT("bqa1"));
+	col1.SetText("bqa1");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(15, col1);
 	// biquad filter coef a1
 	col1.SetId(16);
-	col1.SetText(wxT("bqa2"));
+	col1.SetText("bqa2");
 	col1.SetWidth(46);
 	voiceListbox->InsertColumn(16, col1);
 	// device mix
 	col1.SetId(17);
-	col1.SetText(wxT("deviceMix"));
+	col1.SetText("deviceMix");
 	col1.SetWidth(186);
 	voiceListbox->InsertColumn(17, col1);
 

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -215,7 +215,7 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 		std::string errorMsg;
 		errorMsg.append("Error while trying to parse command line parameter:\n");
 		errorMsg.append(ex.what());
-		wxMessageBox(errorMsg, wxT("Parameter error"), wxICON_ERROR);
+		wxMessageBox(errorMsg, "Parameter error", wxICON_ERROR);
 		return false;
 	}
 	

--- a/src/gui/CemuUpdateWindow.cpp
+++ b/src/gui/CemuUpdateWindow.cpp
@@ -24,7 +24,7 @@ wxDECLARE_EVENT(wxEVT_PROGRESS, wxCommandEvent);
 wxDEFINE_EVENT(wxEVT_PROGRESS, wxCommandEvent);
 
 CemuUpdateWindow::CemuUpdateWindow(wxWindow* parent)
-	: wxDialog(parent, wxID_ANY, "Cemu update", wxDefaultPosition, wxDefaultSize,
+	: wxDialog(parent, wxID_ANY, _("Cemu update"), wxDefaultPosition, wxDefaultSize,
 		wxCAPTION | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxCLOSE_BOX)
 {
 	auto* sizer = new wxBoxSizer(wxVERTICAL);
@@ -35,7 +35,7 @@ CemuUpdateWindow::CemuUpdateWindow(wxWindow* parent)
 	auto* rows = new wxFlexGridSizer(0, 2, 0, 0);
 	rows->AddGrowableCol(1);
 
-	m_text = new wxStaticText(this, wxID_ANY, "Checking for latest version...");
+	m_text = new wxStaticText(this, wxID_ANY, _("Checking for latest version..."));
 	rows->Add(m_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
 	{

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -757,7 +757,7 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		wxPGChoices gender;
 		gender.Add(_("Female"), 0);
 		gender.Add(_("Male"), 1);
-		m_account_grid->Append(new wxEnumProperty("Gender", kPropertyGender, gender));
+		m_account_grid->Append(new wxEnumProperty(_("Gender"), kPropertyGender, gender));
 
 		m_account_grid->Append(new wxStringProperty(_("Email"), kPropertyEmail));
 

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -51,17 +51,17 @@
 
 #include "util/ScreenSaver/ScreenSaver.h"
 
-const wxString kDirectSound(wxT("DirectSound"));
-const wxString kXAudio27(wxT("XAudio2.7"));
-const wxString kXAudio2(wxT("XAudio2"));
-const wxString kCubeb(wxT("Cubeb"));
+const wxString kDirectSound("DirectSound");
+const wxString kXAudio27("XAudio2.7");
+const wxString kXAudio2("XAudio2");
+const wxString kCubeb("Cubeb");
 
-const wxString kPropertyPersistentId(wxT("PersistentId"));
-const wxString kPropertyMiiName(wxT("MiiName"));
-const wxString kPropertyBirthday(wxT("Birthday"));
-const wxString kPropertyGender(wxT("Gender"));
-const wxString kPropertyEmail(wxT("Email"));
-const wxString kPropertyCountry(wxT("Country"));
+const wxString kPropertyPersistentId("PersistentId");
+const wxString kPropertyMiiName("MiiName");
+const wxString kPropertyBirthday("Birthday");
+const wxString kPropertyGender("Gender");
+const wxString kPropertyEmail("Email");
+const wxString kPropertyCountry("Country");
 
 wxDEFINE_EVENT(wxEVT_ACCOUNTLIST_REFRESH, wxCommandEvent);
 
@@ -211,7 +211,7 @@ wxPanel* GeneralSettings2::AddGeneralPage(wxNotebook* notebook)
 
 		box_sizer->Add(m_mlc_path, 1, wxALL | wxEXPAND, 5);
 
-		auto* change_path = new wxButton(box, wxID_ANY, wxT("..."));
+		auto* change_path = new wxButton(box, wxID_ANY, "...");
 		change_path->Bind(wxEVT_BUTTON, &GeneralSettings2::OnMLCPathSelect, this);
 		change_path->SetToolTip(_("Select a custom mlc path\nThe mlc path is used to store Wii U related files like save games, game updates and dlc data"));
 		box_sizer->Add(change_path, 0, wxALL, 5);
@@ -369,7 +369,7 @@ wxPanel* GeneralSettings2::AddAudioPage(wxNotebook* notebook)
 		m_audio_latency = new wxSlider(box, wxID_ANY, 2, 0, IAudioAPI::kBlockCount - 1, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL);
 		m_audio_latency->SetToolTip(_("Controls the amount of buffered audio data\nHigher values will create a delay in audio playback, but may avoid audio problems when emulation is too slow"));
 		audio_general_row->Add(m_audio_latency, 0, wxEXPAND | wxALL, 5);
-		auto latency_text = new wxStaticText(box, wxID_ANY, wxT("24ms"));
+		auto latency_text = new wxStaticText(box, wxID_ANY, "24ms");
 		audio_general_row->Add(latency_text, 0, wxALIGN_CENTER_VERTICAL | wxALL | wxALIGN_RIGHT, 5);
 		m_audio_latency->Bind(wxEVT_SLIDER, &GeneralSettings2::OnLatencySliderChanged, this, wxID_ANY, wxID_ANY, new wxControlObject(latency_text));
 		m_audio_latency->Bind(wxEVT_SLIDER, &GeneralSettings2::OnAudioLatencyChanged, this);
@@ -408,7 +408,7 @@ wxPanel* GeneralSettings2::AddAudioPage(wxNotebook* notebook)
 		audio_tv_row->Add(new wxStaticText(box, wxID_ANY, _("Volume")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 		m_tv_volume = new wxSlider(box, wxID_ANY, 100, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL);
 		audio_tv_row->Add(m_tv_volume, 0, wxEXPAND | wxALL, 5);
-		auto audio_tv_volume_text = new wxStaticText(box, wxID_ANY, wxT("100%"));
+		auto audio_tv_volume_text = new wxStaticText(box, wxID_ANY, "100%");
 		audio_tv_row->Add(audio_tv_volume_text, 0, wxALIGN_CENTER_VERTICAL | wxALL | wxALIGN_RIGHT, 5);
 
 		m_tv_volume->Bind(wxEVT_SLIDER, &GeneralSettings2::OnSliderChangedPercent, this, wxID_ANY, wxID_ANY, new wxControlObject(audio_tv_volume_text));
@@ -449,7 +449,7 @@ wxPanel* GeneralSettings2::AddAudioPage(wxNotebook* notebook)
 		audio_pad_row->Add(new wxStaticText(box, wxID_ANY, _("Volume")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 		m_pad_volume = new wxSlider(box, wxID_ANY, 100, 0, 100);
 		audio_pad_row->Add(m_pad_volume, 0, wxEXPAND | wxALL, 5);
-		auto audio_pad_volume_text = new wxStaticText(box, wxID_ANY, wxT("100%"));
+		auto audio_pad_volume_text = new wxStaticText(box, wxID_ANY, "100%");
 		audio_pad_row->Add(audio_pad_volume_text, 0, wxALIGN_CENTER_VERTICAL | wxALL | wxALIGN_RIGHT, 5);
 
 		m_pad_volume->Bind(wxEVT_SLIDER, &GeneralSettings2::OnSliderChangedPercent, this, wxID_ANY, wxID_ANY, new wxControlObject(audio_pad_volume_text));
@@ -490,7 +490,7 @@ wxPanel* GeneralSettings2::AddAudioPage(wxNotebook* notebook)
 		audio_input_row->Add(new wxStaticText(box, wxID_ANY, _("Volume")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 		m_input_volume = new wxSlider(box, wxID_ANY, 100, 0, 100);
 		audio_input_row->Add(m_input_volume, 0, wxEXPAND | wxALL, 5);
-		auto audio_input_volume_text = new wxStaticText(box, wxID_ANY, wxT("100%"));
+		auto audio_input_volume_text = new wxStaticText(box, wxID_ANY, "100%");
 		audio_input_row->Add(audio_input_volume_text, 0, wxALIGN_CENTER_VERTICAL | wxALL | wxALIGN_RIGHT, 5);
 
 		m_input_volume->Bind(wxEVT_SLIDER, &GeneralSettings2::OnSliderChangedPercent, this, wxID_ANY, wxID_ANY, new wxControlObject(audio_input_volume_text));
@@ -747,7 +747,7 @@ wxPanel* GeneralSettings2::AddAccountPage(wxNotebook* notebook)
 		m_account_grid->SetMinSize({ 300, -1 });
 		//m_account_grid->Append(new wxPropertyCategory("Main"));
 
-		auto* persistent_id_gprop = m_account_grid->Append(new wxStringProperty(wxT("PersistentId"), kPropertyPersistentId));
+		auto* persistent_id_gprop = m_account_grid->Append(new wxStringProperty("PersistentId", kPropertyPersistentId));
 		persistent_id_gprop->SetHelpString(_("The persistent id is the internal folder name used for your saves"));
 		m_account_grid->SetPropertyReadOnly(persistent_id_gprop);
 
@@ -821,7 +821,7 @@ wxPanel* GeneralSettings2::AddDebugPage(wxNotebook* notebook)
 
 		debug_row->Add(new wxStaticText(panel, wxID_ANY, _("GDB Stub port"), wxDefaultPosition, wxDefaultSize, 0), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-		m_gdb_port = new wxSpinCtrl(panel, wxID_ANY, wxT("1337"), wxDefaultPosition, wxDefaultSize, 0, 1000, 65535);
+		m_gdb_port = new wxSpinCtrl(panel, wxID_ANY, "1337", wxDefaultPosition, wxDefaultSize, 0, 1000, 65535);
 		m_gdb_port->SetToolTip(_("Changes the port that the GDB stub will use, which you can use by either starting Cemu with the --enable-gdbstub option or by enabling it the Debug tab."));
 
 		debug_row->Add(m_gdb_port, 0, wxALL | wxEXPAND, 5);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -150,8 +150,7 @@ enum
 	MAINFRAME_MENU_ID_DEBUG_DUMP_FST,
 	MAINFRAME_MENU_ID_DEBUG_DUMP_CURL_REQUESTS,
 	// help
-	MAINFRAME_MENU_ID_HELP_WEB = 21700,
-	MAINFRAME_MENU_ID_HELP_ABOUT,
+	MAINFRAME_MENU_ID_HELP_ABOUT = 21700,
 	MAINFRAME_MENU_ID_HELP_UPDATE,
 	MAINFRAME_MENU_ID_HELP_GETTING_STARTED,
 
@@ -225,7 +224,6 @@ EVT_MENU(MAINFRAME_MENU_ID_DEBUG_VIEW_PPC_DEBUGGER, MainWindow::OnDebugViewPPCDe
 EVT_MENU(MAINFRAME_MENU_ID_DEBUG_VIEW_AUDIO_DEBUGGER, MainWindow::OnDebugViewAudioDebugger)
 EVT_MENU(MAINFRAME_MENU_ID_DEBUG_VIEW_TEXTURE_RELATIONS, MainWindow::OnDebugViewTextureRelations)
 // help menu
-EVT_MENU(MAINFRAME_MENU_ID_HELP_WEB, MainWindow::OnHelpVistWebpage)
 EVT_MENU(MAINFRAME_MENU_ID_HELP_ABOUT, MainWindow::OnHelpAbout)
 EVT_MENU(MAINFRAME_MENU_ID_HELP_UPDATE, MainWindow::OnHelpUpdate)
 EVT_MENU(MAINFRAME_MENU_ID_HELP_GETTING_STARTED, MainWindow::OnHelpGettingStarted)
@@ -1815,8 +1813,6 @@ void MainWindow::OnTimer(wxTimerEvent& event)
 		
 }
 
-void MainWindow::OnHelpVistWebpage(wxCommandEvent& event) {}
-
 #define BUILD_DATE __DATE__ " " __TIME__
 
 class CemuAboutDialog : public wxDialog
@@ -2270,8 +2266,6 @@ void MainWindow::RecreateMenu()
 	m_menuBar->Append(debugMenu, _("&Debug"));
 	// help menu
 	wxMenu* helpMenu = new wxMenu();
-	//helpMenu->Append(MAINFRAME_MENU_ID_HELP_WEB, wxT("&Visit website"));
-	//helpMenu->AppendSeparator();
 	m_check_update_menu = helpMenu->Append(MAINFRAME_MENU_ID_HELP_UPDATE, _("&Check for updates"));
 #if BOOST_OS_LINUX || BOOST_OS_MACOS
 	m_check_update_menu->Enable(false);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -560,13 +560,13 @@ bool MainWindow::FileLoad(const fs::path launchPath, wxLaunchGameEvent::INITIATE
 			t.append(_pathToUtf8(launchPath));
 			if(launchTitle.GetInvalidReason() == TitleInfo::InvalidReason::NO_DISC_KEY)
 			{
-				t.append(_("\n\n"));
+				t.append("\n\n");
 				t.append(_("Could not decrypt title. Make sure that keys.txt contains the correct disc key for this title."));
 			}
 			if(launchTitle.GetInvalidReason() == TitleInfo::InvalidReason::NO_TITLE_TIK)
 			{
-				t.append(_(""));
-				t.append(_("\n\nCould not decrypt title because title.tik is missing."));
+				t.append("\n\n");
+				t.append(_("Could not decrypt title because title.tik is missing."));
 			}
 			wxMessageBox(t, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 			return false;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -100,7 +100,6 @@ public:
 	void OnOptionsInput(wxCommandEvent& event);
 	void OnAccountSelect(wxCommandEvent& event);
 	void OnConsoleLanguage(wxCommandEvent& event);
-	void OnHelpVistWebpage(wxCommandEvent& event);
 	void OnHelpAbout(wxCommandEvent& event);
 	void OnHelpGettingStarted(wxCommandEvent& event);
 	void OnHelpUpdate(wxCommandEvent& event);

--- a/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
+++ b/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
@@ -24,7 +24,7 @@ wxCreateAccountDialog::wxCreateAccountDialog(wxWindow* parent)
 	m_persistent_id->SetToolTip(_("The persistent id is the internal folder name used for your saves. Only change this if you are importing saves from a Wii U with a specific id"));
 	main_sizer->Add(m_persistent_id, 1, wxALL | wxEXPAND, 5);
 
-	main_sizer->Add(new wxStaticText(this, wxID_ANY, wxT("Mii name")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+	main_sizer->Add(new wxStaticText(this, wxID_ANY, _("Mii name")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 	m_mii_name = new wxTextCtrl(this, wxID_ANY);
 	m_mii_name->SetFocus();

--- a/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
+++ b/src/gui/dialogs/CreateAccount/wxCreateAccountDialog.cpp
@@ -18,7 +18,7 @@ wxCreateAccountDialog::wxCreateAccountDialog(wxWindow* parent)
 	main_sizer->SetFlexibleDirection(wxBOTH);
 	main_sizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
-	main_sizer->Add(new wxStaticText(this, wxID_ANY, wxT("PersistentId")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+	main_sizer->Add(new wxStaticText(this, wxID_ANY, "PersistentId"), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 	
 	m_persistent_id = new wxTextCtrl(this, wxID_ANY, fmt::format("{:x}", Account::GetNextPersistentId()));
 	m_persistent_id->SetToolTip(_("The persistent id is the internal folder name used for your saves. Only change this if you are importing saves from a Wii U with a specific id"));

--- a/src/gui/input/InputAPIAddWindow.cpp
+++ b/src/gui/input/InputAPIAddWindow.cpp
@@ -90,11 +90,11 @@ InputAPIAddWindow::InputAPIAddWindow(wxWindow* parent, const wxPoint& position,
 			auto* row = new wxBoxSizer(wxHORIZONTAL);
 			// we only have dsu settings atm, so add elements now
 			row->Add(new wxStaticText(m_settings_panel, wxID_ANY, _("IP")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-			m_ip = new wxTextCtrl(m_settings_panel, wxID_ANY, wxT("127.0.0.1"));
+			m_ip = new wxTextCtrl(m_settings_panel, wxID_ANY, "127.0.0.1");
 			row->Add(m_ip, 0, wxALL, 5);
 
 			row->Add(new wxStaticText(m_settings_panel, wxID_ANY, _("Port")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-			m_port = new wxTextCtrl(m_settings_panel, wxID_ANY, wxT("26760"));
+			m_port = new wxTextCtrl(m_settings_panel, wxID_ANY, "26760");
 			row->Add(m_port, 0, wxALL, 5);
 
 			panel_sizer->Add(row, 0, wxEXPAND);

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -238,11 +238,11 @@ wxWindow* InputSettings2::initialize_page(size_t index)
 			// add/remove buttons
 			auto* bttn_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-			auto* add_api = new wxButton(page, wxID_ANY, wxT(" + "), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+			auto* add_api = new wxButton(page, wxID_ANY, " + ", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 			add_api->Bind(wxEVT_BUTTON, &InputSettings2::on_controller_add, this);
 			bttn_sizer->Add(add_api, 0, wxALL, 5);
 
-			auto* remove_api = new wxButton(page, wxID_ANY, wxT("  -  "), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+			auto* remove_api = new wxButton(page, wxID_ANY, "  -  ", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 			remove_api->Bind(wxEVT_BUTTON, &InputSettings2::on_controller_remove, this);
 			bttn_sizer->Add(remove_api, 0, wxALL, 5);
 


### PR DESCRIPTION
This PR fixes some more untranslated UI strings I've stumbled upon.
While I was at it, I took the opportunity to make some minor improvements to the GUI code:
- removed all usages of the [wxT](https://docs.wxwidgets.org/3.2/group__group__funcmacro__string.html#ga437ea6ba615b75dac8603e96ec864160) macro, which is [useless since wxWidgets 3.0](https://docs.wxwidgets.org/3.2/overview_changes_since28.html#overview_changes_unicode)
- addressed a small issue in commit f6c3c96d, which mistakenly added two translatable strings containing nothing or just newlines

One last thing: I added the `wxString::FromUTF8` to the `wxString <-> std::string` conversions mentioned in the code style guidelines.
I think that it should be the preferred way to convert a `std::string` into a `wxString`. Also, wxWidgets 3.3 will add a [FromUTF8 overload that takes a std::string_view](https://docs.wxwidgets.org/latest/classwx_string.html#adf4cc48dd71ddff7f8d49684e38172a1), so we'll be able to use that one in place of our custom helper.