### PR TITLE
Fix several language selection issues

### DIFF
--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -238,7 +238,7 @@ void CemuApp::LocalizeUI()
 
 std::vector<const wxLanguageInfo*> CemuApp::GetAvailableTranslationLanguages(wxTranslations* translationsMgr)
 {
-	wxFileTranslationsLoader::AddCatalogLookupPathPrefix(ActiveSettings::GetDataPath("resources").generic_string());
+	wxFileTranslationsLoader::AddCatalogLookupPathPrefix(wxHelper::FromPath(ActiveSettings::GetDataPath("resources")));
 	std::vector<const wxLanguageInfo*> languages;
 	for (const auto& langName : translationsMgr->GetAvailableTranslations("cemu"))
 	{

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -228,7 +228,7 @@ void CemuApp::LocalizeUI()
 		translationsMgr->SetLanguage(static_cast<wxLanguage>(configuredLanguage));
 		translationsMgr->AddCatalog("cemu");
 
-		if (wxLocale::IsAvailable(configuredLanguage))
+		if (translationsMgr->IsLoaded("cemu") && wxLocale::IsAvailable(configuredLanguage))
 			m_locale.Init(configuredLanguage);
 
 		// This must be run after wxLocale::Init, as the latter sets up its own wxTranslations instance which we want to override

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -209,13 +209,20 @@ int CemuApp::FilterEvent(wxEvent& event)
 	return wxApp::FilterEvent(event);
 }
 
+std::vector<const wxLanguageInfo *> CemuApp::GetLanguages() const {
+	std::vector availableLanguages(m_availableTranslations);
+	availableLanguages.insert(availableLanguages.begin(), wxLocale::GetLanguageInfo(wxLANGUAGE_ENGLISH));
+	return availableLanguages;
+}
+
 void CemuApp::LocalizeUI()
 {
 	std::unique_ptr<wxTranslations> translationsMgr(new wxTranslations());
 	m_availableTranslations = GetAvailableTranslationLanguages(translationsMgr.get());
 
 	const sint32 configuredLanguage = GetConfig().language;
-	bool isTranslationAvailable = std::any_of(m_availableTranslations.begin(), m_availableTranslations.end(), [configuredLanguage](const wxLanguageInfo* info) { return info->Language == configuredLanguage; });
+	bool isTranslationAvailable = std::any_of(m_availableTranslations.begin(), m_availableTranslations.end(),
+											  [configuredLanguage](const wxLanguageInfo* info) { return info->Language == configuredLanguage; });
 	if (configuredLanguage == wxLANGUAGE_DEFAULT || isTranslationAvailable)
 	{
 		translationsMgr->SetLanguage(static_cast<wxLanguage>(configuredLanguage));

--- a/src/gui/CemuApp.h
+++ b/src/gui/CemuApp.h
@@ -13,7 +13,7 @@ public:
 	void OnAssertFailure(const wxChar* file, int line, const wxChar* func, const wxChar* cond, const wxChar* msg) override;
 	int FilterEvent(wxEvent& event) override;
 
-	const std::vector<const wxLanguageInfo*>& GetLanguages() const { return m_availableTranslations; }
+	std::vector<const wxLanguageInfo*> GetLanguages() const;
 
 	static void CreateDefaultFiles(bool first_start = false);
 	static bool TrySelectMLCPath(fs::path path);

--- a/src/gui/CemuApp.h
+++ b/src/gui/CemuApp.h
@@ -13,8 +13,7 @@ public:
 	void OnAssertFailure(const wxChar* file, int line, const wxChar* func, const wxChar* cond, const wxChar* msg) override;
 	int FilterEvent(wxEvent& event) override;
 
-	const std::vector<const wxLanguageInfo*>& GetLanguages() const { return m_languages; }
-	static std::vector<const wxLanguageInfo*> GetAvailableLanguages();
+	const std::vector<const wxLanguageInfo*>& GetLanguages() const { return m_availableTranslations; }
 
 	static void CreateDefaultFiles(bool first_start = false);
 	static bool TrySelectMLCPath(fs::path path);
@@ -22,11 +21,13 @@ public:
 
 private:
 	void ActivateApp(wxActivateEvent& event);
+	void LocalizeUI();
+	static std::vector<const wxLanguageInfo*> GetAvailableTranslationLanguages(wxTranslations* translationsMgr);
 
 	MainWindow* m_mainFrame = nullptr;
 
 	wxLocale m_locale;
-	std::vector<const wxLanguageInfo*> m_languages;
+	std::vector<const wxLanguageInfo*> m_availableTranslations;
 };
 
 wxDECLARE_APP(CemuApp);

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -123,7 +123,7 @@ wxPanel* GeneralSettings2::AddGeneralPage(wxNotebook* notebook)
 
 			first_row->Add(new wxStaticText(box, wxID_ANY, _("Language"), wxDefaultPosition, wxDefaultSize, 0), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-			wxString language_choices[] = { _("Default"), "English" };
+			wxString language_choices[] = { _("Default") };
 			m_language = new wxChoice(box, wxID_ANY, wxDefaultPosition, wxDefaultSize, std::size(language_choices), language_choices);
 			m_language->SetSelection(0);
 			m_language->SetToolTip(_("Changes the interface language of Cemu\nAvailable languages are stored in the translation directory\nA restart will be required after changing the language"));
@@ -928,8 +928,6 @@ void GeneralSettings2::StoreConfig()
 	auto selection = m_language->GetSelection();
 	if (selection == 0)
 		GetConfig().language = wxLANGUAGE_DEFAULT;
-	else if (selection == 1)
-		GetConfig().language = wxLANGUAGE_ENGLISH;
 	else
 	{
 		const auto language = m_language->GetStringSelection();

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1027,7 +1027,7 @@ void wxGameList::OnGameEntryUpdatedByTitleId(wxTitleIdEvent& event)
 				if (playTimeStat.last_played.year != 0)
 				{
 					const wxDateTime tmp((wxDateTime::wxDateTime_t)playTimeStat.last_played.day, (wxDateTime::Month)playTimeStat.last_played.month, (wxDateTime::wxDateTime_t)playTimeStat.last_played.year, 0, 0, 0, 0);
-					SetItem(index, ColumnGameStarted, tmp.FormatISODate());
+					SetItem(index, ColumnGameStarted, tmp.FormatDate());
 				}
 				else
 					SetItem(index, ColumnGameStarted, _("never"));


### PR DESCRIPTION
This PR simplifies the logic for loading UI translations, which should fix several issues people have encountered.
First, we now translate UI strings using the [wxTranslations](https://docs.wxwidgets.org/3.2/classwx_translations.html) class directly: this makes language selection work with languages that aren't installed/supported on the operating system (this mostly applies to Linux: before this PR, choosing a language not installed on the machine didn't do anything).
Furthermore, the logic used to apply the UI localization has been fixed so that when the "Default" language is selected, the UI uses the system default language (and not English as it did before). The "English" language option now also works as intended: it stays selected upon closing and reopening the settings window and when it's selected, no localization is applied.

While I was at it, I also took the opportunity to format the "last played" date in the game list using the currently selected locale.

Some testing on macOS would be appreciated.

Fixes #717 
Fixes #616
Should fix #580