### PR TITLE
docs: add missing libboost dependencies to build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,7 +24,7 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
 ### Installing dependencies
 
 #### For Ubuntu and derivatives:
-`sudo apt install -y cmake curl clang-15 freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build libboost-program-options1.74-dev libboost-nowide1.74-dev`
+`sudo apt install -y cmake curl clang-15 freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build libboost-program-options-dev libboost-nowide-dev libboost-filesystem-dev`
 
 You may also need to install `libusb-1.0-0-dev` as a workaround for an issue with the vcpkg hidapi package.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -24,7 +24,7 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
 ### Installing dependencies
 
 #### For Ubuntu and derivatives:
-`sudo apt install -y cmake curl clang-15 freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build`
+`sudo apt install -y cmake curl clang-15 freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build libboost-program-options1.74-dev libboost-nowide1.74-dev`
 
 You may also need to install `libusb-1.0-0-dev` as a workaround for an issue with the vcpkg hidapi package.
 


### PR DESCRIPTION
These dependencies seem to be required to build Cemu on Ubuntu 23.10 and Ubuntu 22.04 but are missing from `BUILD.md`. See https://github.com/cemu-project/Cemu/issues/223#issuecomment-1774122908 for more context.

Validated that these packages exist as far back as 22.04.1 LTS and that installing them fixes the error in #223.