### PR TITLE
Set macOS min version to 12.0 Monterey

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ if (MACOS_BUNDLE)
 	set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2023 Cemu Project")
 
 	set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
+ 	set(MACOSX_MINIMUM_SYSTEM_VERSION "12.0")
 
 	set_target_properties(CemuBin PROPERTIES
 		MACOSX_BUNDLE true

--- a/src/resource/MacOSXBundleInfo.plist.in
+++ b/src/resource/MacOSXBundleInfo.plist.in
@@ -26,7 +26,9 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
-    <key>LSApplicationCategoryType</key>
-    <string>${MACOSX_BUNDLE_CATEGORY}</string>
+    	<key>LSApplicationCategoryType</key>
+    	<string>${MACOSX_BUNDLE_CATEGORY}</string>
+     	<key>LSMinimumSystemVersion</key>
+    	<string>${MACOSX_MINIMUM_SYSTEM_VERSION}</string>
 </dict>
 </plist>


### PR DESCRIPTION
I've noticed in Discord that the minimum macOS version is 12 Monterey, but the actual minimum version set on the app bundle is 10.10 Yosemite. 

This PR adds the minimum version key to Info.plist, with a MACOSX_MINIMUM_SYSTEM_VERSION var. 
This var is then set to 12.0 in CmakeLists.txt

The purpose of setting the minimum version is so that users on Big Sur or lower will not be able to open the app, and they will be informed that it can't be run on their OS and they will be prompted to update. 

This should hopefully reduce the number of issues reported on GitHub and Discord. 

Testing: 
Ensure the CI builds and check that the app bundle advertises the required OS to be 12 or later. 
<img width="181" alt="Screenshot 2023-11-19 at 23 34 40" src="https://github.com/cemu-project/Cemu/assets/50119606/a2efb9a0-67f5-470f-bc7d-dea4d2271d01">

