### PR TITLE
nsyshid: Fix SetProtocol and SetReport for Libusb Backend

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -332,7 +332,6 @@ namespace nsyshid
 		{
 			sprintf(debugOutput + i * 3, "%02x ", data[i]);
 		}
-		fmt::print("{} Data: {}\n", prefix, debugOutput);
 		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
 	}
 


### PR DESCRIPTION
The initial implementation of the libusb backend didn't implement SetProtocol and SetReport, and these methods are important for the Skylanders Games as the portal device uses these methods to receive commands from the game, and then respond via the HIDRead methods.

I have tested this as working on my Mac, with Giants and Swap Force. Will also require testing via linux. At the moment I have hard coded the values in the libusb_control_transfer method, but I will attempt to find the correct enum values for this.