### PR TITLE
Reduce default Deadzone value

### DIFF
--- a/src/input/api/Controller.h
+++ b/src/input/api/Controller.h
@@ -130,7 +130,7 @@ public:
 
 	struct AxisSetting
 	{
-		AxisSetting(float deadzone = 0.25f) : deadzone(deadzone) {}
+		AxisSetting(float deadzone = 0.15f) : deadzone(deadzone) {}
 		float deadzone;
 		float range = 1.0f;
 	};


### PR DESCRIPTION
25% is far too much for most controllers, a saner default can be 15%.

I have several controllers to test on (even no-names) and I don't recall having ones above 10%, the worsts may be Xbox 360 controllers.