### PR TITLE
GDBStub: Fix checkSum string to int conversion

### DIFF
--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
@@ -356,7 +356,7 @@ void GDBServer::ThreadFunc()
 				}
 				char checkSumStr[2];
 				receiveMessage(checkSumStr, 2);
-				uint32_t checkSum = std::stoi(checkSumStr, nullptr, 16);
+				uint32_t checkSum = std::stoi(std::string(checkSumStr, sizeof(checkSumStr)), nullptr, 16);
 				assert((checkedSum & 0xFF) == checkSum);
 
 				HandleCommand(message);


### PR DESCRIPTION
Since `checkSumStr` isn't null terminated, this caused `std::stoi` to throw an exception due to invalid characters following on the stack.