### PR TITLE
make altf4/cmd-q propogate to the parent after MainWindow::CreateCanvas has set focus

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1480,6 +1480,18 @@ void MainWindow::OnKeyUp(wxKeyEvent& event)
 		g_window_info.has_screenshot_request = true; // async screenshot request
 }
 
+void MainWindow::OnKeyDown(wxKeyEvent& event)
+{
+	if (event.AltDown() && event.GetKeyCode() == WXK_F4)
+	{
+		Close(true);
+	}
+	else
+	{
+		event.Skip();
+	}
+}
+
 void MainWindow::OnChar(wxKeyEvent& event)
 {
 	if (swkbd_hasKeyboardInputHook())
@@ -1585,6 +1597,7 @@ void MainWindow::CreateCanvas()
 
 	// key events
 	m_render_canvas->Bind(wxEVT_KEY_UP, &MainWindow::OnKeyUp, this);
+	m_render_canvas->Bind(wxEVT_KEY_DOWN, &MainWindow::OnKeyDown, this);
 	m_render_canvas->Bind(wxEVT_CHAR, &MainWindow::OnChar, this);
 
 	m_render_canvas->SetDropTarget(new wxAmiiboDropTarget(this));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1482,7 +1482,8 @@ void MainWindow::OnKeyUp(wxKeyEvent& event)
 
 void MainWindow::OnKeyDown(wxKeyEvent& event)
 {
-	if (event.AltDown() && event.GetKeyCode() == WXK_F4)
+	if ((event.AltDown() && event.GetKeyCode() == WXK_F4) || 
+		(event.CmdDown() && event.GetKeyCode() == 'Q'))
 	{
 		Close(true);
 	}

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -124,6 +124,7 @@ public:
 	void OnSetWindowTitle(wxCommandEvent& event);
 
 	void OnKeyUp(wxKeyEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
 	void OnChar(wxKeyEvent& event);
 
 	void OnToolsInput(wxCommandEvent& event);


### PR DESCRIPTION
Makes the force exit key combo for various OS work when Cemu is running a game as a window or fullscreen