### PR TITLE
Mac: Add wua filetype to info.plist

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,7 @@ if (MACOS_BUNDLE)
 
 	set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
  	set(MACOSX_MINIMUM_SYSTEM_VERSION "12.0")
-  	set(MACOSX_BUNDLE_TYPE_EXTENSIONS "wua")
+  	set(MACOSX_BUNDLE_TYPE_EXTENSION "wua")
 
 	set_target_properties(CemuBin PROPERTIES
 		MACOSX_BUNDLE true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ if (MACOS_BUNDLE)
 
 	set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
  	set(MACOSX_MINIMUM_SYSTEM_VERSION "12.0")
+  	set(MACOSX_BUNDLE_TYPE_EXTENSIONS "wua")
 
 	set_target_properties(CemuBin PROPERTIES
 		MACOSX_BUNDLE true

--- a/src/resource/MacOSXBundleInfo.plist.in
+++ b/src/resource/MacOSXBundleInfo.plist.in
@@ -30,5 +30,20 @@
     	<string>${MACOSX_BUNDLE_CATEGORY}</string>
      	<key>LSMinimumSystemVersion</key>
     	<string>${MACOSX_MINIMUM_SYSTEM_VERSION}</string>
+     	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+			<string>${MACOSX_BUNDLE_TYPE_EXTENSION}</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>cemu.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>Wii U File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src/resource/MacOSXBundleInfo.plist.in
+++ b/src/resource/MacOSXBundleInfo.plist.in
@@ -37,8 +37,6 @@
 			<array>
 			<string>${MACOSX_BUNDLE_TYPE_EXTENSION}</string>
 			</array>
-			<key>CFBundleTypeIconFile</key>
-			<string>cemu.icns</string>
 			<key>CFBundleTypeName</key>
 			<string>Wii U File</string>
 			<key>CFBundleTypeRole</key>


### PR DESCRIPTION
Declaring support for `wua` filetypes in the info.plist will associate wua files with Cemu. 

Needs testing with the CI: 

- [x] Viewing a `wua` file in Finder should display a document icon with a Cemu icon superimposed on it. 

Example from OpenEmu: 
<img width="206" alt="Screenshot 2023-12-09 at 12 16 42" src="https://github.com/cemu-project/Cemu/assets/50119606/8ce586d6-4a3e-4786-a364-7ee0f56a5a93">

- [x] Double-clicking on a `wua` file should now cause Cemu to open. 

The action we would expect is to run the `wua` on launch. 
Edit: Or else to first add to the games list and then launch...
Edit 2: Cemu opens, but nothing else happens. Functionality can be added in a separate PR. 