### PR TITLE
Vulkan: Check for 0 size before wayland resize

### DIFF
--- a/src/gui/canvas/VulkanCanvas.cpp
+++ b/src/gui/canvas/VulkanCanvas.cpp
@@ -66,6 +66,10 @@ void VulkanCanvas::OnPaint(wxPaintEvent& event)
 
 void VulkanCanvas::OnResize(wxSizeEvent& event)
 {
+	const wxSize size = GetSize();
+	if (size.GetWidth() == 0 || size.GetHeight() == 0)
+		return;
+
 #if BOOST_OS_LINUX && HAS_WAYLAND
 	if(m_subsurface)
 	{
@@ -73,9 +77,6 @@ void VulkanCanvas::OnResize(wxSizeEvent& event)
 		m_subsurface->setSize(sRect.GetX(), sRect.GetY(), sRect.GetWidth(), sRect.GetHeight());
 	}
 #endif
-	const wxSize size = GetSize();
-	if (size.GetWidth() == 0 || size.GetHeight() == 0)
-		return;
 
 	const wxRect refreshRect(size);
 	RefreshRect(refreshRect, false);


### PR DESCRIPTION
Currently if launching with a title-id Cemu stalls at the point that it tries to resize the wayland subsurface.

Fixes "Launching games directly with the --title-id argument doesn't work in Wayland" (#999)