### PR TITLE
Add support for portable directory without build flag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         
     - name: "cmake"
       run: |
-        cmake -S . -B build ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} -DPORTABLE=OFF -DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja
+        cmake -S . -B build ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} -DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja
         
     - name: "Build Cemu"
       run: |
@@ -258,7 +258,6 @@ jobs:
         cd build
         cmake .. ${{ env.BUILD_FLAGS }} \
         -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
-        -DPORTABLE=OFF \
         -DMACOS_BUNDLE=ON \
         -DCMAKE_C_COMPILER=/usr/local/opt/llvm@15/bin/clang \
         -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@15/bin/clang++ \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.21.1)
 
 option(ENABLE_VCPKG "Enable the vcpkg package manager" ON)
-option(PORTABLE "All data created and maintained by Cemu will be in the directory where the executable file is located" ON)
 option(MACOS_BUNDLE "The executable when built on macOS will be created as an application bundle" OFF)
 set(EXPERIMENTAL_VERSION "" CACHE STRING "") # used by CI script to set experimental version
 
@@ -44,10 +43,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_compile_definitions($<$<CONFIG:Debug>:CEMU_DEBUG_ASSERT>) # if build type is debug, set CEMU_DEBUG_ASSERT
-
-if(PORTABLE)
-	add_compile_definitions(PORTABLE)
-endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -59,33 +59,44 @@ bool CemuApp::OnInit()
 	fs::path user_data_path, config_path, cache_path, data_path;
 	auto standardPaths = wxStandardPaths::Get();
 	fs::path exePath(wxHelper::MakeFSPath(standardPaths.GetExecutablePath()));
-#ifdef PORTABLE
-#if MACOS_BUNDLE
-    exePath = exePath.parent_path().parent_path().parent_path();
+
+	// Try a portable path first, if it exists.
+	user_data_path = config_path = cache_path = data_path = exePath.parent_path() / "portable";
+#if BOOST_OS_MACOS
+	// If run from an app bundle, use its parent directory.
+	fs::path appPath = exePath.parent_path().parent_path().parent_path();
+	if (appPath.extension() == ".app")
+		user_data_path = config_path = cache_path = data_path = appPath.parent_path() / "portable";
 #endif
-	user_data_path = config_path = cache_path = data_path = exePath.parent_path();
-#else
-	SetAppName("Cemu");
-	wxString appName=GetAppName();
-	#if BOOST_OS_LINUX
-	standardPaths.SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
-	auto getEnvDir = [&](const wxString& varName, const wxString& defaultValue)
+
+	if (!fs::exists(user_data_path))
 	{
-		wxString dir;
-		if (!wxGetEnv(varName, &dir) || dir.empty())
-			return defaultValue;
-		return dir;
-	};
-	wxString homeDir=wxFileName::GetHomeDir();
-	user_data_path = (getEnvDir(wxS("XDG_DATA_HOME"), homeDir + wxS("/.local/share")) + "/" + appName).ToStdString();
-	config_path = (getEnvDir(wxS("XDG_CONFIG_HOME"), homeDir + wxS("/.config")) + "/" + appName).ToStdString();
-	#else
-	user_data_path = config_path = standardPaths.GetUserDataDir().ToStdString();
-	#endif
-	data_path = standardPaths.GetDataDir().ToStdString();
-	cache_path = standardPaths.GetUserDir(wxStandardPaths::Dir::Dir_Cache).ToStdString();
-	cache_path /= appName.ToStdString();
+#if BOOST_OS_WINDOWS
+		user_data_path = config_path = cache_path = data_path = exePath.parent_path();
+#else
+		SetAppName("Cemu");
+		wxString appName=GetAppName();
+#if BOOST_OS_LINUX
+		standardPaths.SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
+		auto getEnvDir = [&](const wxString& varName, const wxString& defaultValue)
+		{
+			wxString dir;
+			if (!wxGetEnv(varName, &dir) || dir.empty())
+				return defaultValue;
+			return dir;
+		};
+		wxString homeDir=wxFileName::GetHomeDir();
+		user_data_path = (getEnvDir(wxS("XDG_DATA_HOME"), homeDir + wxS("/.local/share")) + "/" + appName).ToStdString();
+		config_path = (getEnvDir(wxS("XDG_CONFIG_HOME"), homeDir + wxS("/.config")) + "/" + appName).ToStdString();
+#else
+		user_data_path = config_path = standardPaths.GetUserDataDir().ToStdString();
 #endif
+		data_path = standardPaths.GetDataDir().ToStdString();
+		cache_path = standardPaths.GetUserDir(wxStandardPaths::Dir::Dir_Cache).ToStdString();
+		cache_path /= appName.ToStdString();
+#endif
+	}
+
 	auto failed_write_access = ActiveSettings::LoadOnce(exePath, user_data_path, config_path, cache_path, data_path);
 	for (auto&& path : failed_write_access)
 		wxMessageBox(formatWxString(_("Cemu can't write to {}!"), wxString::FromUTF8(_pathToUtf8(path))),


### PR DESCRIPTION
Removes the need for a compile-time portable flag, instead supporting using either a portable or system directory at runtime.

The behavior is as follows:
* First, on all platforms, check for the directory "portable" in the same directory as the executable (or app bundle on macOS, if running from an app bundle). If that directory exists, use it for all paths.
  * This is how most other emulators approach this, e.g. the Citra/Yuzu "user" directory, the Ryujinx "portable" directory, etc.
* Otherwise, match the old behavior:
  * Windows: Use the directory the executable is in.
  * Linux: Use XDG directories where possible, plus the other directories from wxWidgets.
  * macOS: Use the standard directories from wxWidgets.