### PR TITLE
Vulkan: Don't use glslang internal headers

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VKRPipelineInfo.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VKRPipelineInfo.cpp
@@ -3,7 +3,6 @@
 #include "Cafe/HW/Latte/Renderer/Vulkan/LatteTextureVk.h"
 #include "Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.h"
 
-#include <glslang/Include/Types.h>
 #include "Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h"
 #include "Cafe/HW/Latte/Core/LattePerformanceMonitor.h"
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -26,7 +26,7 @@
 
 #include "Cafe/HW/Latte/Core/LatteTiming.h" // vsync control
 
-#include <glslang/Include/Types.h>
+#include <glslang/Public/ShaderLang.h>
 
 #include <wx/msgdlg.h>
 


### PR DESCRIPTION
With these changes I'm able to build against glslang 1.3.275

I think this fixes https://github.com/cemu-project/Cemu/issues/1075