### PR TITLE
add llvm package for Fedora

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -57,7 +57,7 @@ At Step 3 in [Build Cemu using cmake and clang](#build-cemu-using-cmake-and-clan
    `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja`
 
 #### For Fedora and derivatives:
-`sudo dnf install clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel libtool libusb1-devel nasm ninja-build perl-core systemd-devel zlib-devel`
+`sudo dnf install clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel libtool libusb1-devel llvm nasm ninja-build perl-core systemd-devel zlib-devel`
 
 ### Build Cemu
 
@@ -128,7 +128,7 @@ If you are getting a different error than any of the errors listed above, you ma
 
 ##### Building Errors
 
-This section refers to running `cmake --build build`. 
+This section refers to running `cmake --build build`.
 
 * `main.cpp.o: in function 'std::__cxx11::basic_string...`
    * You likely are experiencing a clang-14 issue. This can only be fixed by either lowering the clang version or using GCC, see [GCC](#gcc).


### PR DESCRIPTION
Fedora requires the llvm compiler in order to compile Cemu with `clang`. 
Installing `clang` will install `llvm-libs` but not `llvm`.
Interestingly enough it also installs `gcc` and `gcc-c++` as dependencies -- so we don't need to install those separately (if compiling with `gcc`) 
```
========================================================================================================================================
 Package                                   Architecture          Version                                   Repository              Size
========================================================================================================================================
Installing:
 clang                                     x86_64                17.0.6-2.fc39                             updates                 76 k
Installing dependencies:
 ....
 gcc                                       x86_64                13.2.1-3.fc39                             fedora                  34 M
 gcc-c++                                   x86_64                13.2.1-3.fc39                             fedora                  13 M
 ....
 llvm-libs                                 x86_64                17.0.6-3.fc39                             updates                 27 M

```
