### PR TITLE
nsyshid: remove stray print statements

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/BackendWindowsHID.cpp
+++ b/src/Cafe/OS/libs/nsyshid/BackendWindowsHID.cpp
@@ -446,7 +446,6 @@ namespace nsyshid::backend::windows
 		{
 			sprintf(debugOutput + i * 3, "%02x ", data[i]);
 		}
-		fmt::print("{} Data: {}\n", prefix, debugOutput);
 		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
 	}
 } // namespace nsyshid::backend::windows

--- a/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
+++ b/src/Cafe/OS/libs/nsyshid/nsyshid.cpp
@@ -332,7 +332,6 @@ namespace nsyshid
 		{
 			sprintf(debugOutput + i * 3, "%02x ", data[i]);
 		}
-		fmt::print("{} Data: {}\n", prefix, debugOutput);
 		cemuLog_logDebug(LogType::Force, "[{}] Data: {}", prefix, debugOutput);
 	}
 


### PR DESCRIPTION
This should fix a nasty regression, that I introduced as part of #950, which could lead to crashes.
Sorry about that :sweat_smile:

See https://github.com/cemu-project/Cemu/pull/971#issuecomment-1813261040 and https://github.com/cemu-project/Cemu/pull/977