### PR TITLE
CafeSystem: call PPCRecompiler_init after SetupExecutable

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -821,11 +821,11 @@ namespace CafeSystem
 		uint32 h = generateHashFromRawRPXData(execData->data(), execData->size());
 		sForegroundTitleId = 0xFFFFFFFF00000000ULL | (uint64)h;
 		cemuLog_log(LogType::Force, "Generated placeholder TitleId: {:016x}", sForegroundTitleId);
-		// setup memory space and ppc recompiler
+		// setup memory space
         SetupMemorySpace();
-        PPCRecompiler_init();
         // load executable
         SetupExecutable();
+		PPCRecompiler_init();
 		InitVirtualMlcStorage();
 		return STATUS_CODE::SUCCESS;
 	}

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -779,10 +779,10 @@ namespace CafeSystem
 			return r;
 		// setup memory space and PPC recompiler
         SetupMemorySpace();
-        PPCRecompiler_init();
 		r = SetupExecutable(); // load RPX
 		if (r != STATUS_CODE::SUCCESS)
 			return r;
+		PPCRecompiler_init();
 		InitVirtualMlcStorage();
 		return STATUS_CODE::SUCCESS;
 	}


### PR DESCRIPTION
Fixes: #911
This makes sure that the gameprofile is loaded when the recompiler initialises and uses the selected mode.