### PR TITLE
Linux: Exit on SIGTERM

### DIFF
--- a/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler_posix.cpp
@@ -155,6 +155,7 @@ void ExceptionHandler_Init()
 
 	action.sa_handler = handler_SIGINT;
 	sigaction(SIGINT, &action, nullptr);
+	sigaction(SIGTERM, &action, nullptr);
 
     action.sa_flags = SA_SIGINFO;
     action.sa_handler = nullptr;


### PR DESCRIPTION
Addresses one concern of #1013
The issue also points out that linux (or at least utilities like killall) look(s) at the thread name and not the executable name.
We could change the name of the main thread to something ``cemu`` on linux. Which seems sensible because threads that don't set their name inherit the name of the thread that created them. So many Cemu threads are now called MainThread, which also isn't very helpful. But that's for another PR I think.