### PR TITLE
Fix crash instroduced by #1115

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -779,10 +779,10 @@ namespace CafeSystem
 			return r;
 		// setup memory space and PPC recompiler
         SetupMemorySpace();
+        PPCRecompiler_init();
 		r = SetupExecutable(); // load RPX
 		if (r != STATUS_CODE::SUCCESS)
 			return r;
-		PPCRecompiler_init();
 		InitVirtualMlcStorage();
 		return STATUS_CODE::SUCCESS;
 	}
@@ -821,11 +821,11 @@ namespace CafeSystem
 		uint32 h = generateHashFromRawRPXData(execData->data(), execData->size());
 		sForegroundTitleId = 0xFFFFFFFF00000000ULL | (uint64)h;
 		cemuLog_log(LogType::Force, "Generated placeholder TitleId: {:016x}", sForegroundTitleId);
-		// setup memory space
+		// setup memory space and ppc recompiler
         SetupMemorySpace();
+        PPCRecompiler_init();
         // load executable
         SetupExecutable();
-		PPCRecompiler_init();
 		InitVirtualMlcStorage();
 		return STATUS_CODE::SUCCESS;
 	}

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -748,7 +748,6 @@ namespace CafeSystem
 			}
 		}
 		LoadMainExecutable();
-		gameProfile_load();
 		return STATUS_CODE::SUCCESS;
 	}
 
@@ -777,6 +776,7 @@ namespace CafeSystem
 		STATUS_CODE r = LoadAndMountForegroundTitle(titleId);
 		if (r != STATUS_CODE::SUCCESS)
 			return r;
+		gameProfile_load();
 		// setup memory space and PPC recompiler
         SetupMemorySpace();
         PPCRecompiler_init();


### PR DESCRIPTION
#1115 introduced a crash when the game profile was set to anything other than single-core interpreter.
Instead of shuffling the init order, move call to load the game profile.