### PR TITLE
InputSettings: Fix controller type counter to restore WPAD limit

### DIFF
--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -745,11 +745,13 @@ void InputSettings2::on_emulated_controller_dropdown(wxCommandEvent& event)
 	wxWindowUpdateLocker lock(emulated_controllers);
 
 	bool is_gamepad_selected = false;
+	bool is_wpad_selected = false;
 	const auto selected = emulated_controllers->GetSelection();
 	const auto selected_value = emulated_controllers->GetStringSelection();
 	if(selected != wxNOT_FOUND)
 	{
 		is_gamepad_selected = selected_value == to_wxString(EmulatedController::type_to_string(EmulatedController::Type::VPAD));
+		is_wpad_selected = !is_gamepad_selected && selected != 0;
 	}
 
 	const auto [vpad_count, wpad_count] = InputManager::instance().get_controller_count();
@@ -760,7 +762,7 @@ void InputSettings2::on_emulated_controller_dropdown(wxCommandEvent& event)
 	if (vpad_count < InputManager::kMaxVPADControllers || is_gamepad_selected)
 		emulated_controllers->Append(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::VPAD)));
 
-	if (wpad_count < InputManager::kMaxWPADControllers || !is_gamepad_selected)
+	if (wpad_count < InputManager::kMaxWPADControllers || is_wpad_selected)
 	{
 		emulated_controllers->AppendString(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::Pro)));
 		emulated_controllers->AppendString(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::Classic)));

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -309,7 +309,7 @@ std::pair<size_t, size_t> InputSettings2::get_emulated_controller_types() const
 			continue;
 
 		const auto api_type = page_data->ref().m_controller->type();
-		if (api_type) 
+		if (api_type >= EmulatedController::MAX)
 			continue;
 
 		if (api_type == EmulatedController::VPAD)

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -297,28 +297,7 @@ wxWindow* InputSettings2::initialize_page(size_t index)
 
 std::pair<size_t, size_t> InputSettings2::get_emulated_controller_types() const
 {
-	size_t vpad = 0, wpad = 0;
-	for(size_t i = 0; i < m_notebook->GetPageCount(); ++i)
-	{
-		auto* page = m_notebook->GetPage(i);
-		auto* page_data = (wxControllerPageData*)page->GetClientObject();
-		if (!page_data)
-			continue;
-		
-		if (!page_data->ref().m_controller) // = disabled
-			continue;
-
-		const auto api_type = page_data->ref().m_controller->type();
-		if (api_type >= EmulatedController::MAX)
-			continue;
-
-		if (api_type == EmulatedController::VPAD)
-			++vpad;
-		else
-			++wpad;
-	}
-
-	return std::make_pair(vpad, wpad);
+	return InputManager::instance().get_controller_count();
 }
 
 std::shared_ptr<ControllerBase> InputSettings2::get_active_controller() const

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -295,11 +295,6 @@ wxWindow* InputSettings2::initialize_page(size_t index)
 	return page;
 }
 
-std::pair<size_t, size_t> InputSettings2::get_emulated_controller_types() const
-{
-	return InputManager::instance().get_controller_count();
-}
-
 std::shared_ptr<ControllerBase> InputSettings2::get_active_controller() const
 {
 	auto& page_data = get_current_page_data();
@@ -757,7 +752,7 @@ void InputSettings2::on_emulated_controller_dropdown(wxCommandEvent& event)
 		is_gamepad_selected = selected_value == to_wxString(EmulatedController::type_to_string(EmulatedController::Type::VPAD));
 	}
 
-	const auto [vpad_count, wpad_count] = get_emulated_controller_types();
+	const auto [vpad_count, wpad_count] = InputManager::instance().get_controller_count();
 
 	emulated_controllers->Clear();
 	emulated_controllers->AppendString(_("Disabled"));

--- a/src/gui/input/InputSettings2.cpp
+++ b/src/gui/input/InputSettings2.cpp
@@ -80,13 +80,14 @@ InputSettings2::InputSettings2(wxWindow* parent)
 		auto* page = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
 		page->SetClientObject(nullptr); // force internal type to client object
 		m_notebook->AddPage(page, formatWxString(_("Controller {}"), i + 1));
+		initialize_page(i);
 	}
 
 	m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &InputSettings2::on_controller_page_changed, this);
 	sizer->Add(m_notebook, 1, wxEXPAND);
 
 	m_notebook->SetSelection(0);
-	auto* first_page = initialize_page(0);
+	auto* first_page = m_notebook->GetPage(0);
 
 	// init first/default page for fitting size
 	auto* page_data = (wxControllerPageData*)first_page->GetClientObject();
@@ -126,11 +127,11 @@ InputSettings2::~InputSettings2()
 }
 
 
-wxWindow* InputSettings2::initialize_page(size_t index)
+void InputSettings2::initialize_page(size_t index)
 {
 	auto* page = m_notebook->GetPage(index);
 	if (page->GetClientObject()) // already initialized
-		return page;
+		return;
 
 	page->Bind(wxEVT_LEFT_UP, &InputSettings2::on_left_click, this);
 
@@ -291,8 +292,6 @@ wxWindow* InputSettings2::initialize_page(size_t index)
 	page->Layout();
 
 	page->SetClientObject(new wxCustomData(page_data));
-
-	return page;
 }
 
 std::pair<size_t, size_t> InputSettings2::get_emulated_controller_types() const
@@ -521,7 +520,6 @@ void InputSettings2::on_controller_changed()
 
 void InputSettings2::on_notebook_page_changed(wxBookCtrlEvent& event)
 {
-	initialize_page(event.GetSelection());
 	update_state();
 	event.Skip();
 }
@@ -705,7 +703,6 @@ void InputSettings2::on_profile_delete(wxCommandEvent& event)
 
 void InputSettings2::on_controller_page_changed(wxBookCtrlEvent& event)
 {
-	initialize_page(event.GetSelection());
 	update_state();
 	event.Skip();
 }
@@ -771,11 +768,13 @@ void InputSettings2::on_emulated_controller_dropdown(wxCommandEvent& event)
 	wxWindowUpdateLocker lock(emulated_controllers);
 
 	bool is_gamepad_selected = false;
+	bool is_wpad_selected = false;
 	const auto selected = emulated_controllers->GetSelection();
 	const auto selected_value = emulated_controllers->GetStringSelection();
 	if(selected != wxNOT_FOUND)
 	{
 		is_gamepad_selected = selected_value == to_wxString(EmulatedController::type_to_string(EmulatedController::Type::VPAD));
+		is_wpad_selected = !is_gamepad_selected && selected != 0;
 	}
 
 	const auto [vpad_count, wpad_count] = get_emulated_controller_types();
@@ -786,7 +785,7 @@ void InputSettings2::on_emulated_controller_dropdown(wxCommandEvent& event)
 	if (vpad_count < InputManager::kMaxVPADControllers || is_gamepad_selected)
 		emulated_controllers->Append(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::VPAD)));
 
-	if (wpad_count < InputManager::kMaxWPADControllers || !is_gamepad_selected)
+	if (wpad_count < InputManager::kMaxWPADControllers || is_wpad_selected)
 	{
 		emulated_controllers->AppendString(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::Pro)));
 		emulated_controllers->AppendString(to_wxString(EmulatedController::type_to_string(EmulatedController::Type::Classic)));

--- a/src/gui/input/InputSettings2.h
+++ b/src/gui/input/InputSettings2.h
@@ -27,9 +27,6 @@ private:
 
 	wxWindow* initialize_page(size_t index);
 
-	// count active <vpad, wpad> controllers
-	std::pair<size_t, size_t> get_emulated_controller_types() const; 
-	
 	// currently selected controller from active tab
 	std::shared_ptr<ControllerBase> get_active_controller() const;
 

--- a/src/gui/input/InputSettings2.h
+++ b/src/gui/input/InputSettings2.h
@@ -25,7 +25,7 @@ private:
 
 	wxBitmap m_connected, m_disconnected, m_low_battery;
 
-	void initialize_page(size_t index);
+	wxWindow* initialize_page(size_t index);
 
 	// count active <vpad, wpad> controllers
 	std::pair<size_t, size_t> get_emulated_controller_types() const; 

--- a/src/gui/input/InputSettings2.h
+++ b/src/gui/input/InputSettings2.h
@@ -25,7 +25,7 @@ private:
 
 	wxBitmap m_connected, m_disconnected, m_low_battery;
 
-	wxWindow* initialize_page(size_t index);
+	void initialize_page(size_t index);
 
 	// count active <vpad, wpad> controllers
 	std::pair<size_t, size_t> get_emulated_controller_types() const; 


### PR DESCRIPTION
get_emulated_controller_types always returned zero for the number of wpads. It _was_ able to count VPAD's because EmulatedController::VPAD is the only enum value that evaluates to false.
Additionally, create all pages of the input settings menu when it is first opened, so that the counter can see controllers on different pages before the user viewed those pages.
This restores the WPAD limit of 7.