### PR TITLE
Update thread names

### DIFF
--- a/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp
@@ -297,7 +297,7 @@ bool GDBServer::Initialize()
 
 void GDBServer::ThreadFunc()
 {
-	SetThreadName("GDBServer::ThreadFunc");
+	SetThreadName("GDBServer");
 
 	while (!m_stopRequested)
 	{

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
@@ -294,7 +294,7 @@ std::atomic_bool s_recompilerThreadStopSignal{false};
 
 void PPCRecompiler_thread()
 {
-	SetThreadName("PPCRecompiler_thread");
+	SetThreadName("PPCRecompiler");
 	while (true)
 	{
         if(s_recompilerThreadStopSignal)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -8,6 +8,7 @@
 
 #include <glslang/Public/ShaderLang.h>
 #include <glslang/SPIRV/GlslangToSpv.h>
+#include <util/helpers/helpers.h>
 
 bool s_isLoadingShadersVk{ false };
 class FileCache* s_spirvCache{nullptr};
@@ -155,6 +156,7 @@ public:
 
 	void CompilerThreadFunc()
 	{
+		SetThreadName("vkShaderComp");
 		while (m_threadsActive.load(std::memory_order::relaxed))
 		{
 			s_compilationQueueCount.decrementWithWait();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanPipelineStableCache.cpp
@@ -408,6 +408,7 @@ bool VulkanPipelineStableCache::DeserializePipeline(MemStreamReader& memReader, 
 
 int VulkanPipelineStableCache::CompilerThread()
 {
+	SetThreadName("plCacheCompiler");
 	while (m_numCompilationThreads != 0)
 	{
 		std::vector<uint8> pipelineData = m_compilationQueue.pop();
@@ -421,6 +422,7 @@ int VulkanPipelineStableCache::CompilerThread()
 
 void VulkanPipelineStableCache::WorkerThread()
 {
+	SetThreadName("plCacheWriter");
 	while (true)
 	{
 		CachedPipeline* job;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1986,6 +1986,7 @@ void VulkanRenderer::WaitCommandBufferFinished(uint64 commandBufferId)
 
 void VulkanRenderer::PipelineCacheSaveThread(size_t cache_size)
 {
+	SetThreadName("vkDriverPlCache");
 	const auto dir = ActiveSettings::GetCachePath("shaderCache/driver/vk");
 	if (!fs::exists(dir))
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -190,6 +190,7 @@ std::queue<PipelineCompiler*> g_compilePipelineRequests;
 
 void compilePipeline_thread(sint32 threadIndex)
 {
+	SetThreadName("compilePl");
 #ifdef _WIN32
 	// one thread runs at normal priority while the others run at lower priority
 	if(threadIndex != 0)

--- a/src/Cafe/IOSU/ODM/iosu_odm.cpp
+++ b/src/Cafe/IOSU/ODM/iosu_odm.cpp
@@ -1,3 +1,4 @@
+#include <util/helpers/helpers.h>
 #include "iosu_odm.h"
 #include "config/ActiveSettings.h"
 #include "Common/FileStream.h"
@@ -79,6 +80,7 @@ namespace iosu
 
 		void ODMServiceThread()
 		{
+			SetThreadName("ODMService");
 			s_msgQueueId = IOS_CreateMessageQueue(_s_msgBuffer.GetPtr(), _s_msgBuffer.GetCount());
 			cemu_assert(!IOS_ResultIsError((IOS_ERROR)s_msgQueueId));
 			IOS_ERROR r = IOS_RegisterResourceManager(s_devicePath.c_str(), s_msgQueueId);

--- a/src/Cafe/IOSU/PDM/iosu_pdm.cpp
+++ b/src/Cafe/IOSU/PDM/iosu_pdm.cpp
@@ -1,3 +1,4 @@
+#include <util/helpers/helpers.h>
 #include "iosu_pdm.h"
 #include "Cafe/CafeSystem.h"
 #include "config/ActiveSettings.h"
@@ -387,6 +388,7 @@ namespace iosu
 
 		void TimeTrackingThread(uint64 titleId)
 		{
+			SetThreadName("PlayDiaryThread");
 			PlayStatsEntry* playStatsEntry = PlayStats_BeginNewTracking(titleId);
 
 			auto startTime = std::chrono::steady_clock::now();

--- a/src/Cafe/IOSU/nn/iosu_nn_service.cpp
+++ b/src/Cafe/IOSU/nn/iosu_nn_service.cpp
@@ -155,6 +155,7 @@ namespace iosu
 
 		void IPCService::ServiceThread()
 		{
+			SetThreadName("IPCService");
 			m_msgQueueId = IOS_CreateMessageQueue(_m_msgBuffer.GetPtr(), _m_msgBuffer.GetCount());
 			cemu_assert(!IOS_ResultIsError((IOS_ERROR)m_msgQueueId));
 			IOS_ERROR r = IOS_RegisterResourceManager(m_devicePath.c_str(), m_msgQueueId);

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -1168,7 +1168,7 @@ namespace coreinit
 
 	void OSSchedulerCoreEmulationThread(void* _assignedCoreIndex)
 	{
-		SetThreadName(fmt::format("OSSchedulerThread[core={}]", (uintptr_t)_assignedCoreIndex).c_str());
+		SetThreadName(fmt::format("OSSched[core={}]", (uintptr_t)_assignedCoreIndex).c_str());
 		t_assignedCoreIndex = (sint32)(uintptr_t)_assignedCoreIndex;
         #if defined(ARCH_X86_64)
 		_mm_setcsr(_mm_getcsr() | 0x8000); // flush denormals to zero

--- a/src/Cafe/TitleList/SaveList.cpp
+++ b/src/Cafe/TitleList/SaveList.cpp
@@ -1,5 +1,6 @@
 #include "SaveList.h"
 #include <charconv>
+#include <util/helpers/helpers.h>
 
 std::mutex sSLMutex;
 fs::path sSLMLCPath;
@@ -44,6 +45,7 @@ void CafeSaveList::Refresh()
 
 void CafeSaveList::RefreshThreadWorker()
 {
+	SetThreadName("SaveListWorker");
 	// clear save list
 	for (auto& itSaveInfo : sSLList)
 	{

--- a/src/Cafe/TitleList/TitleList.cpp
+++ b/src/Cafe/TitleList/TitleList.cpp
@@ -258,6 +258,7 @@ void CafeTitleList::AddTitleFromPath(fs::path path)
 
 bool CafeTitleList::RefreshWorkerThread()
 {
+	SetThreadName("TitleListWorker");
 	while (sTLRefreshRequests.load())
 	{
 		sTLRefreshRequests.store(0);

--- a/src/Cemu/FileCache/FileCache.cpp
+++ b/src/Cemu/FileCache/FileCache.cpp
@@ -50,7 +50,7 @@ struct _FileCacheAsyncWriter
 private:
 	void FileCacheThread()
 	{
-		SetThreadName("fileCache_thread");
+		SetThreadName("fileCache");
 		while (true)
 		{
 			std::unique_lock lock(m_fileCacheMutex);

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1194,6 +1194,7 @@ void wxGameList::RemoveCache(const std::list<fs::path>& cachePaths, const std::s
 
 void wxGameList::AsyncWorkerThread()
 {
+	SetThreadName("GameListWorker");
 	while (m_async_worker_active)
 	{
 		m_async_task_count.decrementWithWait();

--- a/src/gui/guiWrapper.cpp
+++ b/src/gui/guiWrapper.cpp
@@ -37,7 +37,7 @@ void _wxLaunch()
 
 void gui_create()
 {
-	SetThreadName("MainThread");
+	SetThreadName("cemu");
 #if BOOST_OS_WINDOWS
 	// on Windows wxWidgets there is a bug where wxDirDialog->ShowModal will deadlock in Windows internals somehow
 	// moving the UI thread off the main thread fixes this

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -934,7 +934,7 @@ std::optional<glm::ivec2> InputManager::get_right_down_mouse_info(bool* is_pad)
 
 void InputManager::update_thread()
 {
-	SetThreadName("InputManager::update_thread");
+	SetThreadName("Input_update");
 	while (!m_update_thread_shutdown.load(std::memory_order::relaxed))
 	{
 		std::shared_lock lock(m_mutex);

--- a/src/input/api/DSU/DSUControllerProvider.cpp
+++ b/src/input/api/DSU/DSUControllerProvider.cpp
@@ -250,7 +250,7 @@ MotionSample DSUControllerProvider::get_motion_sample(uint8_t index) const
 
 void DSUControllerProvider::reader_thread()
 {
-	SetThreadName("DSUControllerProvider::reader_thread");
+	SetThreadName("DSU-reader");
 	bool first_read = true;
 	while (m_running.load(std::memory_order_relaxed))
 	{
@@ -383,7 +383,7 @@ void DSUControllerProvider::reader_thread()
 
 void DSUControllerProvider::writer_thread()
 {
-	SetThreadName("DSUControllerProvider::writer_thread");
+	SetThreadName("DSU-writer");
 	while (m_running.load(std::memory_order_relaxed))
 	{
 		std::unique_lock lock(m_writer_mutex);

--- a/src/input/api/SDL/SDLControllerProvider.cpp
+++ b/src/input/api/SDL/SDLControllerProvider.cpp
@@ -124,7 +124,7 @@ MotionSample SDLControllerProvider::motion_sample(int diid)
 
 void SDLControllerProvider::event_thread()
 {
-	SetThreadName("SDLControllerProvider::event_thread");
+	SetThreadName("SDL_events");
 	while (m_running.load(std::memory_order_relaxed))
 	{
 		SDL_Event event{};

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -143,7 +143,7 @@ WiimoteControllerProvider::WiimoteState WiimoteControllerProvider::get_state(siz
 
 void WiimoteControllerProvider::reader_thread()
 {
-	SetThreadName("WiimoteControllerProvider::reader_thread");
+	SetThreadName("Wiimote-reader");
 	std::chrono::steady_clock::time_point lastCheck = {};
 	while (m_running.load(std::memory_order_relaxed))
 	{
@@ -878,7 +878,7 @@ void WiimoteControllerProvider::set_motion_plus(size_t index, bool state)
 
 void WiimoteControllerProvider::writer_thread()
 {
-	SetThreadName("WiimoteControllerProvider::writer_thread");
+	SetThreadName("Wiimote-writer");
 	while (m_running.load(std::memory_order_relaxed))
 	{
 		std::unique_lock writer_lock(m_writer_mutex);

--- a/src/util/helpers/helpers.cpp
+++ b/src/util/helpers/helpers.cpp
@@ -155,7 +155,9 @@ void SetThreadName(const char* name)
 #elif BOOST_OS_MACOS
 	pthread_setname_np(name);
 #else
-    pthread_setname_np(pthread_self(), name);
+	if(std::strlen(name) > 15)
+		cemuLog_log(LogType::Force, "Truncating thread name {} because it was longer than 15 characters", name);
+	pthread_setname_np(pthread_self(), std::string{name}.substr(0,15).c_str());
 #endif
 }
 


### PR DESCRIPTION
Fixes #1013
I set out to change the main thread name to `cemu` like I suggested in #1116 and in the process I discovered that many threads did not get their proper names on Linux. The man page for `pthread_setname_np` states: `The thread name  is  a  meaningful  C  language string, whose length is restricted to 16 characters, including the terminating  null  byte  ('\0').` This means that there are only 15 usable characters. Instead of cutting them off at 15 characters I decided to find shorter names. I opted to change the names for all platforms because having preprocessor macros would make things needlessly cluttered. I also discovered some nameless threads and named them.
The `killall cemu` command now works as expected.

Before patch             |  After patch
:-------------------------:|:-------------------------:
![](https://github.com/cemu-project/Cemu/assets/7033575/dc222917-d5c4-4075-8bcd-7601812e533d)  |  ![image](https://github.com/cemu-project/Cemu/assets/7033575/85f5932e-f4bd-486c-8724-5684c520ba0c)


