### PR TITLE
Improve current Exception Handler

### DIFF
--- a/src/Cafe/CafeSystem.h
+++ b/src/Cafe/CafeSystem.h
@@ -6,9 +6,8 @@
 
 namespace CafeSystem
 {
-	class SystemImplementation
-	{
-	public:
+	class SystemImplementation {
+	  public:
 		virtual void CafeRecreateCanvas() = 0;
 	};
 
@@ -17,12 +16,12 @@ namespace CafeSystem
 		SUCCESS,
 		INVALID_RPX,
 		UNABLE_TO_MOUNT, // failed to mount through TitleInfo (most likely caused by an invalid or outdated path)
-		//BAD_META_DATA, - the title list only stores titles with valid meta, so this error code is impossible
+						 // BAD_META_DATA, - the title list only stores titles with valid meta, so this error code is impossible
 	};
 
 	void Initialize();
 	void SetImplementation(SystemImplementation* impl);
-    void Shutdown();
+	void Shutdown();
 
 	STATUS_CODE PrepareForegroundTitle(TitleId titleId);
 	STATUS_CODE PrepareForegroundTitleFromStandaloneRPX(const fs::path& path);
@@ -53,7 +52,10 @@ namespace CafeSystem
 	uint32 GetRPXHashUpdated();
 
 	void RequestRecreateCanvas();
-};
+
+	void StartCrashErrorThread(PPCInterpreter_t* interpreter);
+
+}; // namespace CafeSystem
 
 extern RPLModule* applicationRPX;
 

--- a/src/Common/ExceptionHandler/ExceptionHandler.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler.cpp
@@ -7,9 +7,11 @@
 #include "ExceptionHandler.h"
 #include "gui/MainWindow.h"
 
-#include <wx/utils.h>
 #include <wx/msgdlg.h>
-#include <boost/algorithm/string.hpp>
+
+#ifdef BOOST_OS_WINDOWS
+#include <shlobj_core.h>
+#endif
 
 void DebugLogStackTrace(OSThread_t* thread, MPTR sp);
 
@@ -17,12 +19,12 @@ bool crashLogCreated = false;
 
 bool CrashLog_Create()
 {
-    if (crashLogCreated)
-        return false; // only create one crashlog
-    crashLogCreated = true;
-    cemuLog_createLogFile(true);
-    CrashLog_SetOutputChannels(true, true);
-    return true;
+	if (crashLogCreated)
+		return false; // only create one crashlog
+	crashLogCreated = true;
+	cemuLog_createLogFile(true);
+	CrashLog_SetOutputChannels(true, true);
+	return true;
 }
 
 static bool s_writeToStdErr{true};
@@ -30,176 +32,248 @@ static bool s_writeToLogTxt{true};
 
 void CrashLog_SetOutputChannels(bool writeToStdErr, bool writeToLogTxt)
 {
-    s_writeToStdErr = writeToStdErr;
-    s_writeToLogTxt = writeToLogTxt;
+	s_writeToStdErr = writeToStdErr;
+	s_writeToLogTxt = writeToLogTxt;
 }
 
 // outputs to both stderr and log.txt
 void CrashLog_WriteLine(std::string_view text, bool newLine)
 {
-    if(s_writeToLogTxt)
-        cemuLog_writeLineToLog(text, false, newLine);
-    if(s_writeToStdErr)
-    {
-        fwrite(text.data(), sizeof(char), text.size(), stderr);
-        if(newLine)
-            fwrite("\n", sizeof(char), 1, stderr);
-    }
+	if (s_writeToLogTxt)
+		cemuLog_writeLineToLog(text, false, newLine);
+	if (s_writeToStdErr)
+	{
+		fwrite(text.data(), sizeof(char), text.size(), stderr);
+		if (newLine)
+			fwrite("\n", sizeof(char), 1, stderr);
+	}
 }
 
 void CrashLog_WriteHeader(const char* header)
 {
-    CrashLog_WriteLine("-----------------------------------------");
-    CrashLog_WriteLine("   ", false);
-    CrashLog_WriteLine(header);
-    CrashLog_WriteLine("-----------------------------------------");
+	CrashLog_WriteLine("-----------------------------------------");
+	CrashLog_WriteLine("   ", false);
+	CrashLog_WriteLine(header);
+	CrashLog_WriteLine("-----------------------------------------");
 }
 
 void ExceptionHandler_LogGeneralInfo()
 {
-    char dumpLine[1024];
-    // info about game
-    CrashLog_WriteLine("");
-    CrashLog_WriteHeader("Game info");
-    if (CafeSystem::IsTitleRunning())
-    {
-        CrashLog_WriteLine("Game: ", false);
-        CrashLog_WriteLine(CafeSystem::GetForegroundTitleName());
-        // title id
-        CrashLog_WriteLine(fmt::format("TitleId: {:016x}", CafeSystem::GetForegroundTitleId()));
-        // rpx hash
-        sprintf(dumpLine, "RPXHash: %08x (Update: %08x)", CafeSystem::GetRPXHashBase(), CafeSystem::GetRPXHashUpdated());
-        CrashLog_WriteLine(dumpLine);
-    }
-    else
-    {
-        CrashLog_WriteLine("Not running");
-    }
-    // info about active PPC instance:
-    CrashLog_WriteLine("");
-    CrashLog_WriteHeader("Active PPC instance");
+	char dumpLine[1024];
+	// info about game
+	CrashLog_WriteLine("");
+	CrashLog_WriteHeader("Game info");
+	if (CafeSystem::IsTitleRunning())
+	{
+		CrashLog_WriteLine("Game: ", false);
+		CrashLog_WriteLine(CafeSystem::GetForegroundTitleName());
+		// title id
+		CrashLog_WriteLine(fmt::format("TitleId: {:016x}", CafeSystem::GetForegroundTitleId()));
+		// rpx hash
+		sprintf(dumpLine, "RPXHash: %08x (Update: %08x)", CafeSystem::GetRPXHashBase(), CafeSystem::GetRPXHashUpdated());
+		CrashLog_WriteLine(dumpLine);
+	}
+	else
+	{
+		CrashLog_WriteLine("Not running");
+	}
+	// info about active PPC instance:
+	CrashLog_WriteLine("");
+	CrashLog_WriteHeader("Active PPC instance");
 	PPCInterpreter_t* hCPU = PPCInterpreter_getCurrentInstance();
-    if (hCPU)
-    {
-        OSThread_t* currentThread = coreinit::OSGetCurrentThread();
-        uint32 threadPtr = memory_getVirtualOffsetFromPointer(coreinit::OSGetCurrentThread());
-        sprintf(dumpLine, "IP 0x%08x LR 0x%08x Thread 0x%08x", hCPU->instructionPointer, hCPU->spr.LR, threadPtr);
-        CrashLog_WriteLine(dumpLine);
+	if (hCPU)
+	{
+		OSThread_t* currentThread = coreinit::OSGetCurrentThread();
+		uint32 threadPtr = memory_getVirtualOffsetFromPointer(coreinit::OSGetCurrentThread());
+		sprintf(dumpLine, "IP 0x%08x LR 0x%08x Thread 0x%08x", hCPU->instructionPointer, hCPU->spr.LR, threadPtr);
+		CrashLog_WriteLine(dumpLine);
 
-        // GPR info
-        CrashLog_WriteLine("");
-        auto gprs = hCPU->gpr;
-        sprintf(dumpLine, "r0 =%08x r1 =%08x r2 =%08x r3 =%08x r4 =%08x r5 =%08x r6 =%08x r7 =%08x", gprs[0], gprs[1], gprs[2], gprs[3], gprs[4], gprs[5], gprs[6], gprs[7]);
-        CrashLog_WriteLine(dumpLine);
-        sprintf(dumpLine, "r8 =%08x r9 =%08x r10=%08x r11=%08x r12=%08x r13=%08x r14=%08x r15=%08x", gprs[8], gprs[9], gprs[10], gprs[11], gprs[12], gprs[13], gprs[14], gprs[15]);
-        CrashLog_WriteLine(dumpLine);
-        sprintf(dumpLine, "r16=%08x r17=%08x r18=%08x r19=%08x r20=%08x r21=%08x r22=%08x r23=%08x", gprs[16], gprs[17], gprs[18], gprs[19], gprs[20], gprs[21], gprs[22], gprs[23]);
-        CrashLog_WriteLine(dumpLine);
-        sprintf(dumpLine, "r24=%08x r25=%08x r26=%08x r27=%08x r28=%08x r29=%08x r30=%08x r31=%08x", gprs[24], gprs[25], gprs[26], gprs[27], gprs[28], gprs[29], gprs[30], gprs[31]);
-        CrashLog_WriteLine(dumpLine);
+		// GPR info
+		CrashLog_WriteLine("");
+		auto gprs = hCPU->gpr;
+		sprintf(dumpLine, "r0 =%08x r1 =%08x r2 =%08x r3 =%08x r4 =%08x r5 =%08x r6 =%08x r7 =%08x", gprs[0], gprs[1], gprs[2], gprs[3], gprs[4], gprs[5], gprs[6], gprs[7]);
+		CrashLog_WriteLine(dumpLine);
+		sprintf(dumpLine, "r8 =%08x r9 =%08x r10=%08x r11=%08x r12=%08x r13=%08x r14=%08x r15=%08x", gprs[8], gprs[9], gprs[10], gprs[11], gprs[12], gprs[13], gprs[14], gprs[15]);
+		CrashLog_WriteLine(dumpLine);
+		sprintf(dumpLine, "r16=%08x r17=%08x r18=%08x r19=%08x r20=%08x r21=%08x r22=%08x r23=%08x", gprs[16], gprs[17], gprs[18], gprs[19], gprs[20], gprs[21], gprs[22], gprs[23]);
+		CrashLog_WriteLine(dumpLine);
+		sprintf(dumpLine, "r24=%08x r25=%08x r26=%08x r27=%08x r28=%08x r29=%08x r30=%08x r31=%08x", gprs[24], gprs[25], gprs[26], gprs[27], gprs[28], gprs[29], gprs[30], gprs[31]);
+		CrashLog_WriteLine(dumpLine);
 
-        // stack trace
-        MPTR currentStackVAddr = hCPU->gpr[1];
-        CrashLog_WriteLine("");
-        CrashLog_WriteHeader("PPC stack trace");
-        DebugLogStackTrace(currentThread, currentStackVAddr);
+		// stack trace
+		MPTR currentStackVAddr = hCPU->gpr[1];
+		CrashLog_WriteLine("");
+		CrashLog_WriteHeader("PPC stack trace");
+		DebugLogStackTrace(currentThread, currentStackVAddr);
 
-        // stack dump
-        CrashLog_WriteLine("");
-        CrashLog_WriteHeader("PPC stack dump");
-        for (uint32 i = 0; i < 16; i++)
-        {
-            MPTR lineAddr = currentStackVAddr + i * 8 * 4;
-            if (memory_isAddressRangeAccessible(lineAddr, 8 * 4))
-            {
-                sprintf(dumpLine, "[0x%08x] %08x %08x %08x %08x - %08x %08x %08x %08x", lineAddr, memory_readU32(lineAddr + 0), memory_readU32(lineAddr + 4), memory_readU32(lineAddr + 8), memory_readU32(lineAddr + 12), memory_readU32(lineAddr + 16), memory_readU32(lineAddr + 20), memory_readU32(lineAddr + 24), memory_readU32(lineAddr + 28));
-                CrashLog_WriteLine(dumpLine);
-            }
-            else
-            {
-                sprintf(dumpLine, "[0x%08x] ?", lineAddr);
-                CrashLog_WriteLine(dumpLine);
-            }
-        }
-    }
-    else
-    {
-        CrashLog_WriteLine("Not active");
-    }
+		// stack dump
+		CrashLog_WriteLine("");
+		CrashLog_WriteHeader("PPC stack dump");
+		for (uint32 i = 0; i < 16; i++)
+		{
+			MPTR lineAddr = currentStackVAddr + i * 8 * 4;
+			if (memory_isAddressRangeAccessible(lineAddr, 8 * 4))
+			{
+				sprintf(dumpLine, "[0x%08x] %08x %08x %08x %08x - %08x %08x %08x %08x", lineAddr, memory_readU32(lineAddr + 0), memory_readU32(lineAddr + 4), memory_readU32(lineAddr + 8), memory_readU32(lineAddr + 12), memory_readU32(lineAddr + 16), memory_readU32(lineAddr + 20), memory_readU32(lineAddr + 24), memory_readU32(lineAddr + 28));
+				CrashLog_WriteLine(dumpLine);
+			}
+			else
+			{
+				sprintf(dumpLine, "[0x%08x] ?", lineAddr);
+				CrashLog_WriteLine(dumpLine);
+			}
+		}
+	}
+	else
+	{
+		CrashLog_WriteLine("Not active");
+	}
 
-    // PPC thread log
-    CrashLog_WriteLine("");
-    CrashLog_WriteHeader("PPC threads");
-    if (activeThreadCount == 0)
-    {
-        CrashLog_WriteLine("None active");
-    }
-    for (sint32 i = 0; i < activeThreadCount; i++)
-    {
-        MPTR threadItrMPTR = activeThread[i];
-        OSThread_t* threadItrBE = (OSThread_t*)memory_getPointerFromVirtualOffset(threadItrMPTR);
+	// PPC thread log
+	CrashLog_WriteLine("");
+	CrashLog_WriteHeader("PPC threads");
+	if (activeThreadCount == 0)
+	{
+		CrashLog_WriteLine("None active");
+	}
+	for (sint32 i = 0; i < activeThreadCount; i++)
+	{
+		MPTR threadItrMPTR = activeThread[i];
+		OSThread_t* threadItrBE = (OSThread_t*)memory_getPointerFromVirtualOffset(threadItrMPTR);
 
-        // get thread state
-        OSThread_t::THREAD_STATE threadState = threadItrBE->state;
-        const char* threadStateStr = "UNDEFINED";
-        if (threadItrBE->suspendCounter != 0)
-            threadStateStr = "SUSPENDED";
-        else if (threadState == OSThread_t::THREAD_STATE::STATE_NONE)
-            threadStateStr = "NONE";
-        else if (threadState == OSThread_t::THREAD_STATE::STATE_READY)
-            threadStateStr = "READY";
-        else if (threadState == OSThread_t::THREAD_STATE::STATE_RUNNING)
-            threadStateStr = "RUNNING";
-        else if (threadState == OSThread_t::THREAD_STATE::STATE_WAITING)
-            threadStateStr = "WAITING";
-        else if (threadState == OSThread_t::THREAD_STATE::STATE_MORIBUND)
-            threadStateStr = "MORIBUND";
-        // generate log line
-        uint8 affinity = threadItrBE->attr;
-        sint32 effectivePriority = threadItrBE->effectivePriority;
-        const char* threadName = "NULL";
-        if (!threadItrBE->threadName.IsNull())
-            threadName = threadItrBE->threadName.GetPtr();
-        sprintf(dumpLine, "%08x Ent %08x IP %08x LR %08x %-9s Aff %d%d%d Pri %2d Name %s", threadItrMPTR, _swapEndianU32(threadItrBE->entrypoint), threadItrBE->context.srr0, _swapEndianU32(threadItrBE->context.lr), threadStateStr, (affinity >> 0) & 1, (affinity >> 1) & 1, (affinity >> 2) & 1, effectivePriority, threadName);
-        // write line to log
-        CrashLog_WriteLine(dumpLine);
-    }
+		// get thread state
+		OSThread_t::THREAD_STATE threadState = threadItrBE->state;
+		const char* threadStateStr = "UNDEFINED";
+		if (threadItrBE->suspendCounter != 0)
+			threadStateStr = "SUSPENDED";
+		else if (threadState == OSThread_t::THREAD_STATE::STATE_NONE)
+			threadStateStr = "NONE";
+		else if (threadState == OSThread_t::THREAD_STATE::STATE_READY)
+			threadStateStr = "READY";
+		else if (threadState == OSThread_t::THREAD_STATE::STATE_RUNNING)
+			threadStateStr = "RUNNING";
+		else if (threadState == OSThread_t::THREAD_STATE::STATE_WAITING)
+			threadStateStr = "WAITING";
+		else if (threadState == OSThread_t::THREAD_STATE::STATE_MORIBUND)
+			threadStateStr = "MORIBUND";
+		// generate log line
+		uint8 affinity = threadItrBE->attr;
+		sint32 effectivePriority = threadItrBE->effectivePriority;
+		const char* threadName = "NULL";
+		if (!threadItrBE->threadName.IsNull())
+			threadName = threadItrBE->threadName.GetPtr();
+		sprintf(dumpLine, "%08x Ent %08x IP %08x LR %08x %-9s Aff %d%d%d Pri %2d Name %s", threadItrMPTR, _swapEndianU32(threadItrBE->entrypoint), threadItrBE->context.srr0, _swapEndianU32(threadItrBE->context.lr), threadStateStr, (affinity >> 0) & 1, (affinity >> 1) & 1, (affinity >> 2) & 1, effectivePriority, threadName);
+		// write line to log
+		CrashLog_WriteLine(dumpLine);
+	}
 }
 
 void ExceptionHandler_DisplayErrorInfo(PPCInterpreter_t* hCpu)
 {
-    if (g_mainFrame->IsFullScreen())
+	if (g_mainFrame->IsFullScreen())
 		g_mainFrame->SetFullScreen(false);
-        
-       wxString errorTitle;
-       wxString errorMessage;
 
-       // Game crash
-       if (hCpu)
-       {
-           errorTitle = _("The game crashed");
-           errorMessage = _("Oops! It looks like the game has encountered an unexpected error and crashed.\n"
-							"\n"
-							"Please note that this crash may be specific to the game and not necessarily due to CEMU.\n"
-                            "\n"
-							"If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
+	// If we're not a CPU thread, then we can shutdown the game execution
+	if (!hCpu)
+		CafeSystem::Shutdown();
 
-       } 
-       // CEMU crash
-       else
-       {
-            errorTitle = _("CEMU has crashed");
-            errorMessage = _("Oops! It looks like CEMU has encountered an unexpected error and crashed.\n"
-							 "\n"
-                            "If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
-       }
+	wxString errorTitle;
+	wxString errorMessage;
 
-       // Display error message
-	   wxMessageDialog dialog(nullptr, errorMessage, errorTitle, wxYES_NO | wxCENTRE | wxICON_ERROR);
-	   dialog.SetYesNoLabels(_("Quit"), _("Open GitHub and Quit"));
+	// Game crash
+	if (hCpu)
+	{
+		errorTitle = _("The game crashed");
+		errorMessage = _("Oops! It looks like the game has encountered an unexpected error and crashed.\n"
+						 "\n"
+						 "Please note that this crash may be specific to the game and not necessarily due to CEMU.\n"
+						 "\n"
+						 "If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
+	}
+	// CEMU crash
+	else
+	{
+		errorTitle = _("CEMU has crashed");
+		errorMessage = _("Oops! It looks like CEMU has encountered an unexpected error and crashed.\n"
+						 "\n"
+						 "If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
+	}
 
-	   if (dialog.ShowModal() == wxID_NO)
-		   wxLaunchDefaultBrowser("https://github.com/cemu-project/Cemu/issues/new?template=emulation_bug_report.yaml&title=Enter+a+title+for+the+bug+report+here");
+	// Display error message
+	wxMessageDialog dialog(nullptr, errorMessage, errorTitle, wxYES_NO | wxCENTRE | wxICON_ERROR);
+	dialog.SetYesNoLabels(_("Quit"), _("Open GitHub and Quit"));
 
-       _Exit(0);
+	if (dialog.ShowModal() == wxID_NO)
+		wxLaunchDefaultBrowser("https://github.com/cemu-project/Cemu/issues/new?template=emulation_bug_report.yaml&title=Enter+a+title+for+the+bug+report+here");
+
+	bool clipboardSet = false;
+
+	// Copy log file to clipboard
+#ifdef BOOST_OS_WINDOWS
+	if (OpenClipboard(nullptr))
+	{
+		const auto logPath = fs::absolute(cemuLog_GetLogFilePath());
+		const auto logPathStr = logPath.wstring();
+		const auto totalSize = ((logPathStr.length() + 1) * sizeof(wchar_t)) + sizeof(DROPFILES);
+
+		EmptyClipboard();
+		HGLOBAL hMem = GlobalAlloc(GHND | GMEM_SHARE, totalSize);
+		if (hMem)
+		{
+			DROPFILES* pDropFiles = (DROPFILES*)GlobalLock(hMem);
+			if (pDropFiles)
+			{
+				memset(pDropFiles, 0, totalSize);
+
+				pDropFiles->pFiles = sizeof(DROPFILES);
+				pDropFiles->fWide = TRUE;
+
+				wchar_t* dataDest = (wchar_t*)((char*)pDropFiles + sizeof(DROPFILES));
+				wcscpy_s(dataDest, logPathStr.length(), logPathStr.c_str());
+
+				GlobalUnlock(hMem);
+				SetClipboardData(CF_HDROP, hMem);
+
+				clipboardSet = true;
+			}
+		}
+		CloseClipboard();
+	}
+#endif
+
+	if (clipboardSet)
+		wxMessageBox(_("The log file has been copied to the clipboard. You can paste it on GitHub or Discord.\n"), _("Log file copied"), wxOK | wxICON_INFORMATION);
+
+	_Exit(0);
 }
+
+/*
+*
+* This errors for some reason, but the message box still pops up
+*
+* Failed to put data on the clipboard: -2147221008 (CoInitialize has not been called...)
+*
+* No matter my attempts to fix it
+*
+* calling CoInitialize here, still fails
+* calling CoInitialize in the main thread, still fails
+* calling CoInitialize in the UI thread, still fails
+*
+
+if (wxTheClipboard->Open())
+{
+wxTheClipboard->Clear();
+
+wxFileDataObject* fileData = new wxFileDataObject();
+fileData->AddFile(fs::absolute(cemuLog_GetLogFilePath()).string());
+
+debug_printf("%s\n", fs::absolute(cemuLog_GetLogFilePath()).c_str());
+
+wxTheClipboard->SetData(fileData);
+wxTheClipboard->Flush();
+wxTheClipboard->Close();
+
+wxMessageBox(_("The log file has been copied to the clipboard. You can paste it on GitHub or Discord.\n"), _("Log file copied"), wxOK | wxICON_INFORMATION);
+
+}
+*/

--- a/src/Common/ExceptionHandler/ExceptionHandler.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler.cpp
@@ -5,6 +5,11 @@
 #include "Cafe/HW/Espresso/PPCState.h"
 #include "Cafe/HW/Espresso/Debugger/GDBStub.h"
 #include "ExceptionHandler.h"
+#include "gui/MainWindow.h"
+
+#include <wx/utils.h>
+#include <wx/msgdlg.h>
+#include <boost/algorithm/string.hpp>
 
 void DebugLogStackTrace(OSThread_t* thread, MPTR sp);
 
@@ -159,4 +164,42 @@ void ExceptionHandler_LogGeneralInfo()
         // write line to log
         CrashLog_WriteLine(dumpLine);
     }
+}
+
+void ExceptionHandler_DisplayErrorInfo(PPCInterpreter_t* hCpu)
+{
+    if (g_mainFrame->IsFullScreen())
+		g_mainFrame->SetFullScreen(false);
+        
+       wxString errorTitle;
+       wxString errorMessage;
+
+       // Game crash
+       if (hCpu)
+       {
+           errorTitle = _("The game crashed");
+           errorMessage = _("Oops! It looks like the game has encountered an unexpected error and crashed.\n"
+							"\n"
+							"Please note that this crash may be specific to the game and not necessarily due to CEMU.\n"
+                            "\n"
+							"If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
+
+       } 
+       // CEMU crash
+       else
+       {
+            errorTitle = _("CEMU has crashed");
+            errorMessage = _("Oops! It looks like CEMU has encountered an unexpected error and crashed.\n"
+							 "\n"
+                            "If this is a recurring issue, please consider reporting the bug on the Discord or GitGub.\n");
+       }
+
+       // Display error message
+	   wxMessageDialog dialog(nullptr, errorMessage, errorTitle, wxYES_NO | wxCENTRE | wxICON_ERROR);
+	   dialog.SetYesNoLabels(_("Quit"), _("Open GitHub and Quit"));
+
+	   if (dialog.ShowModal() == wxID_NO)
+		   wxLaunchDefaultBrowser("https://github.com/cemu-project/Cemu/issues/new?template=emulation_bug_report.yaml&title=Enter+a+title+for+the+bug+report+here");
+
+       _Exit(0);
 }

--- a/src/Common/ExceptionHandler/ExceptionHandler.h
+++ b/src/Common/ExceptionHandler/ExceptionHandler.h
@@ -8,3 +8,5 @@ void CrashLog_WriteLine(std::string_view text, bool newLine = true);
 void CrashLog_WriteHeader(const char* header);
 
 void ExceptionHandler_LogGeneralInfo();
+
+void ExceptionHandler_DisplayErrorInfo(PPCInterpreter_t* hCpu);

--- a/src/Common/ExceptionHandler/ExceptionHandler_win32.cpp
+++ b/src/Common/ExceptionHandler/ExceptionHandler_win32.cpp
@@ -238,7 +238,7 @@ void createCrashlog(EXCEPTION_POINTERS* e, PCONTEXT context)
 		fs::copy_file(ActiveSettings::GetUserDataPath("log.txt"), p, ec);
 	}
 
-	exit(0);
+	CafeSystem::StartCrashErrorThread(PPCInterpreter_getCurrentInstance());
 
 	return;
 }
@@ -276,7 +276,7 @@ LONG WINAPI VectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 LONG WINAPI cemu_unhandledExceptionFilter(EXCEPTION_POINTERS* pExceptionInfo)
 {
 	createCrashlog(pExceptionInfo, pExceptionInfo->ContextRecord);
-	return EXCEPTION_NONCONTINUABLE_EXCEPTION;
+	return EXCEPTION_CONTINUE_EXECUTION;
 }
 
 void ExceptionHandler_Init()


### PR DESCRIPTION
# Purpose 

This PR aims to improve the CEMU exception handler

# Features

- [x] Add a game crash message dialog before exiting
- [x] Add a CEMU crash message dialog before exiting
- [ ] Copy ``log.txt`` to clipboard
  - [x] Win32
  - [ ] Linux
  - [ ] MacOS
- [ ] Make sure it works and doesn't break anything else
  - [x] Win32 debug/release
  - [ ] POSIX  debug/release
  
# Description

The changes spawn a thread on CafeSystem initialization that will continously read a boolean and yield if the boolean is ``false``.

This boolean is set to ``true`` if a unhandled exception occurs, shutting down CafeSystem (to avoid the game still running in the background and other synchronization issues occuring) then displaying the message boxes.

# Pictures

| ![image](https://github.com/cemu-project/Cemu/assets/39063367/bad6bdb9-fcc9-4a7b-8656-c0d9ad8299f8) | 
|:--:| 
| **Example CEMU crash** (forced crash in H264 decoder) |