### PR TITLE
Changes to game shortcuts and UTF8 gamelist name fixes

### DIFF
--- a/src/Cafe/TitleList/ParsedMetaXml.h
+++ b/src/Cafe/TitleList/ParsedMetaXml.h
@@ -90,8 +90,11 @@ struct ParsedMetaXml
 			else if (boost::starts_with(name, "longname_"))
 			{
 				const sint32 index = GetLanguageIndex(name.substr(std::size("longname_") - 1));
-				if (index != -1)
-					parsedMetaXml->m_long_name[index] = child.text().as_string();
+				if (index != -1){
+					std::string longname = child.text().as_string();
+					std::replace_if(longname.begin(), longname.end(), [](char c) { return c == '\r' || c == '\n';}, ' ');
+					parsedMetaXml->m_long_name[index] = longname;
+				}
 			}
 			else if (boost::starts_with(name, L"shortname_"))
 			{

--- a/src/Cafe/TitleList/TitleInfo.cpp
+++ b/src/Cafe/TitleList/TitleInfo.cpp
@@ -637,9 +637,9 @@ std::string TitleInfo::GetMetaTitleName() const
 	if (m_parsedMetaXml)
 	{
 		std::string titleNameCfgLanguage;
-		titleNameCfgLanguage = m_parsedMetaXml->GetShortName(GetConfig().console_language);
+		titleNameCfgLanguage = m_parsedMetaXml->GetLongName(GetConfig().console_language);
 		if (titleNameCfgLanguage.empty()) //Get English Title
-			titleNameCfgLanguage = m_parsedMetaXml->GetShortName(CafeConsoleLanguage::EN);
+			titleNameCfgLanguage = m_parsedMetaXml->GetLongName(CafeConsoleLanguage::EN);
 		if (titleNameCfgLanguage.empty()) //Unknown Title
 			titleNameCfgLanguage = "Unknown Title";
 		return titleNameCfgLanguage;

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -59,7 +59,12 @@ bool CemuApp::OnInit()
 	fs::path user_data_path, config_path, cache_path, data_path;
 	auto standardPaths = wxStandardPaths::Get();
 	fs::path exePath(wxHelper::MakeFSPath(standardPaths.GetExecutablePath()));
-
+#if BOOST_OS_LINUX
+	// GetExecutablePath returns the AppImage's temporary mount location
+	wxString appImagePath;
+	if (wxGetEnv(("APPIMAGE"), &appImagePath))
+		exePath = wxHelper::MakeFSPath(appImagePath);
+#endif
 	// Try a portable path first, if it exists.
 	user_data_path = config_path = cache_path = data_path = exePath.parent_path() / "portable";
 #if BOOST_OS_MACOS

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1282,11 +1282,6 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 	auto exePath = ActiveSettings::GetExecutablePath();
 	const char* flatpakId = getenv("FLATPAK_ID");
 
-	// GetExecutablePath returns the AppImage's temporary mount location, instead of its actual path
-	wxString appimagePath;
-	if (wxGetEnv(("APPIMAGE"), &appimagePath))
-		exePath = appimagePath.utf8_string();
-
 	const wxString desktopEntryName = wxString::Format("%s.desktop", titleName);
 	wxFileDialog entryDialog(this, _("Choose desktop entry location"), "~/.local/share/applications", desktopEntryName,
 							 "Desktop file (*.desktop)|*.desktop", wxFD_SAVE | wxFD_CHANGE_DIR | wxFD_OVERWRITE_PROMPT);

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1278,7 +1278,7 @@ void wxGameList::DeleteCachedStrings()
 void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 {
 	const auto titleId = gameInfo.GetBaseTitleId();
-	const auto titleName = gameInfo.GetTitleName();
+	const auto titleName = wxString::FromUTF8(gameInfo.GetTitleName());
 	auto exePath = ActiveSettings::GetExecutablePath();
 	const char* flatpakId = getenv("FLATPAK_ID");
 
@@ -1335,14 +1335,14 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 		"Terminal=false\n"
 		"Type=Application\n"
 		"Categories=Game;\n",
-		titleName,
+		titleName.utf8_string(),
 		desktopExecEntry,
 		_pathToUtf8(iconPath.value_or("")));
 
 	if (flatpakId)
 		desktopEntryString += fmt::format("X-Flatpak={}\n", flatpakId);
 
-	std::ofstream outputStream(output_path);
+	std::ofstream outputStream(output_path.utf8_string());
 	if (!outputStream.good())
 	{
 		auto errorMsg = formatWxString(_("Failed to save desktop entry to {}"), output_path.utf8_string());
@@ -1355,7 +1355,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 {
 	const auto titleId = gameInfo.GetBaseTitleId();
-	const auto titleName = gameInfo.GetTitleName();
+	const auto titleName = wxString::FromUTF8(gameInfo.GetTitleName());
 	auto exePath = ActiveSettings::GetExecutablePath();
 
 	// Get '%APPDATA%\Microsoft\Windows\Start Menu\Programs' path

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1376,7 +1376,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 	int iconIdx;
 	int smallIconIdx;
 	std::optional<fs::path> icon_path = std::nullopt;
-	if (GetConfig().permanent_storage && QueryIconForTitle(titleId, iconIdx, smallIconIdx))
+	if (QueryIconForTitle(titleId, iconIdx, smallIconIdx))
 	{
 		const auto icon = m_image_list->GetIcon(iconIdx);
 		PWSTR localAppData;
@@ -1413,7 +1413,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 
 		IPersistFile* shellLinkFile;
 		// save the shortcut
-		hres = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&shell_link_file));
+		hres = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&shellLinkFile));
 		if (SUCCEEDED(hres))
 		{
 			hres = shellLinkFile->Save(outputPath.wc_str(), TRUE);

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1392,6 +1392,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 		if (!bitmap.CopyFromIcon(icon))
 		{
 			cemuLog_log(LogType::Force, "Failed to copy icon");
+			return;
 		}
 
 		icon_path = folder / fmt::format("{:016x}.ico", titleId);

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1371,7 +1371,8 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 	const auto outputPath = shortcutDialog.GetPath();
 
 	std::optional<fs::path> icon_path = std::nullopt;
-	[&]() {
+	[&]()
+	{
 		int iconIdx;
 		int smallIconIdx;
 		if (!QueryIconForTitle(titleId, iconIdx, smallIconIdx))
@@ -1404,7 +1405,7 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 			icon_path = std::nullopt;
 			cemuLog_log(LogType::Force, "Icon failed to save");
 		}
-	}s();
+	}();
 
 	IShellLinkW* shellLink;
 	HRESULT hres = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink));

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1430,9 +1430,13 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 		if (SUCCEEDED(hres))
 		{
 			hres = shellLinkFile->Save(outputPath.wc_str(), TRUE);
-			shellLinkFile->Release();
+			shellLinkFile->Release();	
 		}
 		shellLink->Release();
+	}
+	if (!SUCCEEDED(hres)) {
+		auto errorMsg = formatWxString(_("Failed to save shortcut to {}"), outputPath);
+		wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 	}
 }
 #endif

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -730,7 +730,7 @@ void wxGameList::OnContextMenuSelected(wxCommandEvent& event)
             {
                 if (wxTheClipboard->Open())
                 {
-                    wxTheClipboard->SetData(new wxTextDataObject(gameInfo.GetTitleName()));
+                    wxTheClipboard->SetData(new wxTextDataObject(wxString::FromUTF8(gameInfo.GetTitleName())));
                     wxTheClipboard->Close();
                 }
                 break;

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -1299,13 +1299,9 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
     std::optional<fs::path> icon_path;
     // Obtain and convert icon
     {
-        m_icon_cache_mtx.lock();
-        const auto icon_iter = m_icon_cache.find(title_id);
-        const auto result_index = (icon_iter != m_icon_cache.cend()) ? std::optional<int>(icon_iter->second.first) : std::nullopt;
-        m_icon_cache_mtx.unlock();
+		int iconIndex, smallIconIndex;
 
-        // In most cases it should find it
-        if (!result_index){
+        if (!QueryIconForTitle(title_id, iconIndex, smallIconIndex)){
             wxMessageBox(_("Icon is yet to load, so will not be used by the shortcut"), _("Warning"), wxOK | wxCENTRE | wxICON_WARNING);
         }
         else {
@@ -1316,10 +1312,9 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
             }
             else {
                 icon_path = out_icon_dir / fmt::format("{:016x}.png", gameInfo.GetBaseTitleId());
-
-                auto image = m_image_list->GetIcon(result_index.value()).ConvertToImage();
-
                 wxFileOutputStream png_file(_pathToUtf8(icon_path.value()));
+
+				auto image = m_image_list->GetIcon(iconIndex).ConvertToImage();
                 wxPNGHandler pngHandler;
                 if (!pngHandler.SaveFile(&image, png_file, false)) {
                     icon_path = std::nullopt;


### PR DESCRIPTION
- Windows icons are stored as `.ico` files to `%LOCALAPPDATA%/Cemu/icons/`
- Long title names chosen as some games (NSMBU + NSLU) add trailing dots for their shortnames
- Long title names have their newlines replaced with spaces at parsing
- Linux shortcut paths are saved with UTF-8 encoding
- Game titles are copied and saved with UTF-8 encoding