### PR TITLE
Improve setting of dpd_enable_fg

### DIFF
--- a/src/input/api/Controller.h
+++ b/src/input/api/Controller.h
@@ -2,6 +2,7 @@
 
 #include "input/InputManager.h"
 #include "input/motion/MotionSample.h"
+#include "input/api/ControllerState.h"
 
 namespace pugi
 {
@@ -118,6 +119,7 @@ public:
 	virtual bool has_position() { return false; }
 	virtual glm::vec2 get_position() { return {}; }
 	virtual glm::vec2 get_prev_position() { return {}; }
+	virtual PositionVisibility GetPositionVisibility() {return PositionVisibility::NONE;};
 
 	virtual bool has_rumble() { return false; }
 	virtual void start_rumble() {}

--- a/src/input/api/ControllerState.h
+++ b/src/input/api/ControllerState.h
@@ -3,6 +3,12 @@
 #include <glm/vec2.hpp>
 #include "util/helpers/fspinlock.h"
 
+enum class PositionVisibility {
+	NONE = 0,
+	FULL = 1,
+	PARTIAL = 2
+};
+
 // helper class for storing and managing button press states in a thread-safe manner
 struct ControllerButtonState
 {

--- a/src/input/api/DSU/DSUController.cpp
+++ b/src/input/api/DSU/DSUController.cpp
@@ -93,6 +93,13 @@ glm::vec2 DSUController::get_prev_position()
 	return {};
 }
 
+PositionVisibility DSUController::GetPositionVisibility()
+{
+	const auto state = m_provider->get_prev_state(m_index);
+
+	return (state.data.tpad1.active || state.data.tpad2.active) ? PositionVisibility::FULL : PositionVisibility::NONE;
+}
+
 std::string DSUController::get_button_name(uint64 button) const
 {
 	switch (button)

--- a/src/input/api/DSU/DSUController.h
+++ b/src/input/api/DSU/DSUController.h
@@ -32,6 +32,7 @@ public:
 	bool has_position() override;
 	glm::vec2 get_position() override;
 	glm::vec2 get_prev_position() override;
+	PositionVisibility GetPositionVisibility() override;
 
 	std::string get_button_name(uint64 button) const override;
 

--- a/src/input/api/Wiimote/NativeWiimoteController.cpp
+++ b/src/input/api/Wiimote/NativeWiimoteController.cpp
@@ -98,6 +98,11 @@ glm::vec2 NativeWiimoteController::get_prev_position()
 	const auto state = m_provider->get_state(m_index);
 	return state.ir_camera.m_prev_position;
 }
+PositionVisibility NativeWiimoteController::GetPositionVisibility()
+{
+	const auto state = m_provider->get_state(m_index);
+	return state.ir_camera.m_positionVisibility;
+}
 
 bool NativeWiimoteController::has_low_battery()
 {

--- a/src/input/api/Wiimote/NativeWiimoteController.h
+++ b/src/input/api/Wiimote/NativeWiimoteController.h
@@ -40,6 +40,7 @@ public:
 	bool has_position() override;
 	glm::vec2 get_position() override;
 	glm::vec2 get_prev_position() override;
+	PositionVisibility GetPositionVisibility() override;
 	
 	bool has_motion() override { return true; }
 	bool has_rumble() override { return true; }

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -766,14 +766,20 @@ void WiimoteControllerProvider::calculate_ir_position(WiimoteState& wiimote_stat
 		ir.middle = ir.position;
 		ir.distance = glm::length(ir.dots[indices.first].pos - ir.dots[indices.second].pos);
 		ir.indices = indices;
+		ir.m_positionVisibility = PositionVisibility::FULL;
 	}
 	else if (ir.dots[indices.first].visible)
 	{
 		ir.position = ir.middle + (ir.dots[indices.first].pos - ir.prev_dots[indices.first].pos);
+		ir.m_positionVisibility = PositionVisibility::PARTIAL;
 	}
 	else if (ir.dots[indices.second].visible)
 	{
 		ir.position = ir.middle + (ir.dots[indices.second].pos - ir.prev_dots[indices.second].pos);
+		ir.m_positionVisibility = PositionVisibility::PARTIAL;
+	}
+	else {
+		ir.m_positionVisibility = PositionVisibility::NONE;
 	}
 }
 

--- a/src/input/api/Wiimote/WiimoteControllerProvider.h
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.h
@@ -5,6 +5,7 @@
 #include "input/api/Wiimote/WiimoteMessages.h"
 
 #include "input/api/ControllerProvider.h"
+#include "input/api/ControllerState.h"
 
 #include <list>
 #include <variant>
@@ -61,6 +62,7 @@ public:
 			std::array<IRDot, 4> dots{}, prev_dots{};
 
 			glm::vec2 position{}, m_prev_position{};
+			PositionVisibility m_positionVisibility;
 			glm::vec2 middle {};
 			float distance = 0;
 			std::pair<sint32, sint32> indices{ 0,1 };

--- a/src/input/emulated/EmulatedController.cpp
+++ b/src/input/emulated/EmulatedController.cpp
@@ -207,6 +207,17 @@ glm::vec2 EmulatedController::get_prev_position() const
 	return {};
 }
 
+PositionVisibility EmulatedController::GetPositionVisibility() const
+{
+	std::shared_lock lock(m_mutex);
+	for (const auto& controller : m_controllers)
+	{
+		if (controller->has_position())
+			return controller->GetPositionVisibility();
+	}
+	return PositionVisibility::NONE;
+}
+
 void EmulatedController::add_controller(std::shared_ptr<ControllerBase> controller)
 {
 	controller->connect();

--- a/src/input/emulated/EmulatedController.h
+++ b/src/input/emulated/EmulatedController.h
@@ -67,6 +67,7 @@ public:
 	bool has_position() const;
 	glm::vec2 get_position() const;
 	glm::vec2 get_prev_position() const;
+	PositionVisibility GetPositionVisibility() const;
 
 	void add_controller(std::shared_ptr<ControllerBase> controller);
 	void remove_controller(const std::shared_ptr<ControllerBase>& controller);

--- a/src/input/emulated/WPADController.cpp
+++ b/src/input/emulated/WPADController.cpp
@@ -1,3 +1,4 @@
+#include <api/Controller.h>
 #include "input/emulated/WPADController.h"
 
 #include "input/emulated/ClassicController.h"
@@ -308,10 +309,13 @@ void WPADController::KPADRead(KPADStatus_t& status, const BtnRepeat& repeat)
 			status.mpls.dir.Z.z = attitude[8];
 		}
 	}
-
-	if (has_position())
+	auto visibility = GetPositionVisibility();
+	if (has_position() && visibility != PositionVisibility::NONE)
 	{
-		status.dpd_valid_fg = 2;
+		if (visibility == PositionVisibility::FULL)
+			status.dpd_valid_fg = 2;
+		else
+			status.dpd_valid_fg = -1;
 
 		const auto position = get_position();
 

--- a/src/input/emulated/WPADController.cpp
+++ b/src/input/emulated/WPADController.cpp
@@ -311,7 +311,7 @@ void WPADController::KPADRead(KPADStatus_t& status, const BtnRepeat& repeat)
 
 	if (has_position())
 	{
-		status.dpd_valid_fg = 1;
+		status.dpd_valid_fg = 2;
 
 		const auto position = get_position();
 
@@ -324,6 +324,8 @@ void WPADController::KPADRead(KPADStatus_t& status, const BtnRepeat& repeat)
 		status.vec.y = delta.y;
 		status.speed = glm::length(delta);
 	}
+	else
+		status.dpd_valid_fg = 0;
 
 	switch (type())
 	{


### PR DESCRIPTION
`dpd_valid_fg` was  (and probably still is) reported incorrectly. 

From testing on my own Wii U, I observed:
- `1` is hard to get consistently
- `2` is returned when aiming normally
- `-1` when only one IR cluster is visible
-  `0`  when not aiming at the sensor bar at all and IR position values no longer change

I haven't tested in any games on Cemu (my Wiimotes refuse to connect to my PC).
Hopefully other people can test it.