### PR TITLE
Add supported localizations to macOS plist

### DIFF
--- a/src/resource/MacOSXBundleInfo.plist.in
+++ b/src/resource/MacOSXBundleInfo.plist.in
@@ -30,6 +30,28 @@
     	<string>${MACOSX_BUNDLE_CATEGORY}</string>
      	<key>LSMinimumSystemVersion</key>
     	<string>${MACOSX_MINIMUM_SYSTEM_VERSION}</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+ 		<string>ca</string>
+   		<string>de</string>
+     		<string>en</string>
+       		<string>es</string>
+		<string>fr</string>
+		<string>he</string>
+		<string>hu</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>nb</string>
+		<string>nl</string>
+		<string>pl</string>
+  		<string>pt</string>
+		<string>ru</string>
+  		<string>sv</string>
+    		<string>tr</string>
+      		<string>uk</string>
+		<string>zh</string>
+	</array>
      	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR adds all languages which have an available UI translation in Cemu to the macOS property list as recommended by [wxWidgets docs](https://docs.wxwidgets.org/3.2/overview_i18n.html).
This should allow macOS to recognize that the application supports a specific language and therefore translate system-provided menus accordingly (e.g. the "Windows" one).
Previously, macOS-provided menus were always displayed in English. After this change, they should always appear in the system language, if it's among the languages listed in the `CFBundleLocalizations` array.

Should fix the issue reported in https://github.com/cemu-project/Cemu/issues/735#issuecomment-2006455073 _(EDIT: it seems to mitigate the issue but doesn't solve it completely)_
Testing by non-English macOS users is appreciated.