### PR TITLE
DebugSymbolStorage: fix infinite loop

### DIFF
--- a/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
+++ b/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
@@ -43,16 +43,14 @@ public:
 		return t;
 	}
 
-	static void ClearRange(MPTR address, uint32 length)
+	static void ClearRange(MPTR base, uint32 length)
 	{
 		s_lock.lock();
-		while (length > 0)
+		for (MPTR address = base; address < base + length; address += 4)
 		{
 			auto itr = s_typeStorage.find(address);
 			if (itr != s_typeStorage.end())
 				s_typeStorage.erase(itr);
-			address += 4;
-			length -= 4;
 		}
 		s_lock.unlock();
 	}

--- a/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
+++ b/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
@@ -53,8 +53,8 @@ public:
 			auto itr = s_typeStorage.find(address);
 			if (itr != s_typeStorage.end())
 				s_typeStorage.erase(itr);
-			// break if length has surpassed zero and wrapped around
-			if (length < 4)
+			
+			if (length <= 4)
 				break;
 			address += 4;
 			length -= 4;

--- a/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
+++ b/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
@@ -43,14 +43,21 @@ public:
 		return t;
 	}
 
-	static void ClearRange(MPTR base, uint32 length)
+	static void ClearRange(MPTR address, uint32 length)
 	{
+		if (length == 0)
+			return;
 		s_lock.lock();
-		for (MPTR address = base; address < base + length; address += 4)
+		for (;;)
 		{
 			auto itr = s_typeStorage.find(address);
 			if (itr != s_typeStorage.end())
 				s_typeStorage.erase(itr);
+			// break if length has surpassed zero and wrapped around
+			if (length - (uint32)4u > length)
+				break;
+			address += 4;
+			length -= 4;
 		}
 		s_lock.unlock();
 	}

--- a/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
+++ b/src/Cafe/HW/Espresso/Debugger/DebugSymbolStorage.h
@@ -54,7 +54,7 @@ public:
 			if (itr != s_typeStorage.end())
 				s_typeStorage.erase(itr);
 			// break if length has surpassed zero and wrapped around
-			if (length - (uint32)4u > length)
+			if (length < 4)
 				break;
 			address += 4;
 			length -= 4;


### PR DESCRIPTION
This fixes a bug where ClearRange goes into an infinite loop when length is not divisible by 4. Because length is unsigned it wraps around to UINT32_MAX and never becomes zero. Because of this bug, if a user disables a graphic pack like "Graphics" for botw while the game is running length is equal to 9 and the UI thread freezes and never recovers.