### PR TITLE
GraphicPacksWindow2: Disable update button when a game is running

### DIFF
--- a/src/gui/DownloadGraphicPacksWindow.cpp
+++ b/src/gui/DownloadGraphicPacksWindow.cpp
@@ -110,14 +110,6 @@ void deleteDownloadedGraphicPacks()
 
 void DownloadGraphicPacksWindow::UpdateThread()
 {
-	if (CafeSystem::IsTitleRunning())
-	{
-		wxMessageBox(_("Graphic packs cannot be updated while a game is running."), _("Graphic packs"), 5, this->GetParent());
-		// cancel update
-		m_threadState = ThreadFinished;
-		return;
-	}
-	
 	// get github url
 	std::string githubAPIUrl;
 	curlDownloadFileState_t tempDownloadState;
@@ -326,8 +318,6 @@ DownloadGraphicPacksWindow::DownloadGraphicPacksWindow(wxWindow* parent)
 
 
 	m_downloadState = std::make_unique<curlDownloadFileState_t>();
-
-	m_thread = std::thread(&DownloadGraphicPacksWindow::UpdateThread, this);
 }
 
 DownloadGraphicPacksWindow::~DownloadGraphicPacksWindow()
@@ -344,6 +334,12 @@ const std::string& DownloadGraphicPacksWindow::GetException() const
 
 int DownloadGraphicPacksWindow::ShowModal()
 {
+	if(CafeSystem::IsTitleRunning())
+	{
+		wxMessageBox(_("Graphic packs cannot be updated while a game is running."), _("Graphic packs"), 5, this->GetParent());
+		return wxID_CANCEL;
+	}
+	m_thread = std::thread(&DownloadGraphicPacksWindow::UpdateThread, this);
 	wxDialog::ShowModal();
 	return m_threadState == ThreadCanceled ? wxID_CANCEL : wxID_OK;
 }

--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -300,6 +300,7 @@ GraphicPacksWindow2::GraphicPacksWindow2(wxWindow* parent, uint64_t title_id_fil
 		auto* row = new wxBoxSizer(wxHORIZONTAL);
 		m_update_graphicPacks = new wxButton(m_right_panel, wxID_ANY, _("Download latest community graphic packs"));
 		m_update_graphicPacks->Bind(wxEVT_BUTTON, &GraphicPacksWindow2::OnCheckForUpdates, this);
+		m_update_graphicPacks->Enable(!CafeSystem::IsTitleRunning());
 		row->Add(m_update_graphicPacks, 0, wxALL, 5);
 
 		sizer->Add(row, 0, wxALL | wxEXPAND, 5);
@@ -674,6 +675,11 @@ void GraphicPacksWindow2::OnInstalledGamesChanged(wxCommandEvent& event)
 	m_filter_installed_games = m_installed_games_only->GetValue();
 	FillGraphicPackList();
 	event.Skip();
+}
+
+void GraphicPacksWindow2::OnTitleRunningStateChanged(bool running)
+{
+	m_update_graphicPacks->Enable(!running);
 }
 
 void GraphicPacksWindow2::ReloadPack(const GraphicPackPtr& graphic_pack) const

--- a/src/gui/GraphicPacksWindow2.cpp
+++ b/src/gui/GraphicPacksWindow2.cpp
@@ -300,7 +300,6 @@ GraphicPacksWindow2::GraphicPacksWindow2(wxWindow* parent, uint64_t title_id_fil
 		auto* row = new wxBoxSizer(wxHORIZONTAL);
 		m_update_graphicPacks = new wxButton(m_right_panel, wxID_ANY, _("Download latest community graphic packs"));
 		m_update_graphicPacks->Bind(wxEVT_BUTTON, &GraphicPacksWindow2::OnCheckForUpdates, this);
-		m_update_graphicPacks->Enable(!CafeSystem::IsTitleRunning());
 		row->Add(m_update_graphicPacks, 0, wxALL, 5);
 
 		sizer->Add(row, 0, wxALL | wxEXPAND, 5);
@@ -320,6 +319,7 @@ GraphicPacksWindow2::GraphicPacksWindow2(wxWindow* parent, uint64_t title_id_fil
 
 	SetSizer(main_sizer);
 
+	UpdateTitleRunning(CafeSystem::IsTitleRunning());
 	FillGraphicPackList();
 }
 
@@ -677,9 +677,13 @@ void GraphicPacksWindow2::OnInstalledGamesChanged(wxCommandEvent& event)
 	event.Skip();
 }
 
-void GraphicPacksWindow2::OnTitleRunningStateChanged(bool running)
+void GraphicPacksWindow2::UpdateTitleRunning(bool running)
 {
 	m_update_graphicPacks->Enable(!running);
+	if(running)
+		m_update_graphicPacks->SetToolTip(_("Graphic packs cannot be updated while a game is running."));
+	else
+		m_update_graphicPacks->SetToolTip(nullptr);
 }
 
 void GraphicPacksWindow2::ReloadPack(const GraphicPackPtr& graphic_pack) const

--- a/src/gui/GraphicPacksWindow2.h
+++ b/src/gui/GraphicPacksWindow2.h
@@ -21,6 +21,7 @@ public:
 	~GraphicPacksWindow2();
 
 	static void RefreshGraphicPacks();
+	void OnTitleRunningStateChanged(bool running);
 
 private:
 	std::string m_filter;

--- a/src/gui/GraphicPacksWindow2.h
+++ b/src/gui/GraphicPacksWindow2.h
@@ -21,7 +21,7 @@ public:
 	~GraphicPacksWindow2();
 
 	static void RefreshGraphicPacks();
-	void OnTitleRunningStateChanged(bool running);
+	void UpdateTitleRunning(bool running);
 
 private:
 	std::string m_filter;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2326,8 +2326,8 @@ void MainWindow::UpdateChildWindowTitleRunningState()
 {
 	const bool running = CafeSystem::IsTitleRunning();
 
-	if(auto graphicsPackWindow = dynamic_cast<GraphicPacksWindow2*>(m_graphic_pack_window))
-		graphicsPackWindow->UpdateTitleRunning(running);
+	if(auto graphicPacksWindow = dynamic_cast<GraphicPacksWindow2*>(m_graphic_pack_window))
+		graphicPacksWindow->UpdateTitleRunning(running);
 }
 
 void MainWindow::RestoreSettingsAfterGameExited()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2327,7 +2327,7 @@ void MainWindow::UpdateChildWindowTitleRunningState()
 	const bool running = CafeSystem::IsTitleRunning();
 
 	if(auto graphicsPackWindow = dynamic_cast<GraphicPacksWindow2*>(m_graphic_pack_window))
-		graphicsPackWindow->OnTitleRunningStateChanged(running);
+		graphicsPackWindow->UpdateTitleRunning(running);
 }
 
 void MainWindow::RestoreSettingsAfterGameExited()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2326,8 +2326,8 @@ void MainWindow::UpdateChildWindowTitleRunningState()
 {
 	const bool running = CafeSystem::IsTitleRunning();
 
-	if(auto graphicPacksWindow = dynamic_cast<GraphicPacksWindow2*>(m_graphic_pack_window))
-		graphicPacksWindow->UpdateTitleRunning(running);
+	if(m_graphic_pack_window)
+		m_graphic_pack_window->UpdateTitleRunning(running);
 }
 
 void MainWindow::RestoreSettingsAfterGameExited()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -625,6 +625,7 @@ bool MainWindow::FileLoad(const fs::path launchPath, wxLaunchGameEvent::INITIATE
 	CreateCanvas();
 	CafeSystem::LaunchForegroundTitle();
 	RecreateMenu();
+	UpdateChildWindowTitleRunningState();
 
 	return true;
 }
@@ -683,6 +684,7 @@ void MainWindow::OnFileMenu(wxCommandEvent& event)
 		RecreateMenu();
         CreateGameListAndStatusBar();
         DoLayout();
+		UpdateChildWindowTitleRunningState();
 	}
 }
 
@@ -2318,6 +2320,14 @@ void MainWindow::RecreateMenu()
 	// hide new menu in fullscreen
 	if (IsFullScreen())
 		SetMenuVisible(false);
+}
+
+void MainWindow::UpdateChildWindowTitleRunningState()
+{
+	const bool running = CafeSystem::IsTitleRunning();
+
+	if(auto graphicsPackWindow = dynamic_cast<GraphicPacksWindow2*>(m_graphic_pack_window))
+		graphicsPackWindow->OnTitleRunningStateChanged(running);
 }
 
 void MainWindow::RestoreSettingsAfterGameExited()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -21,6 +21,7 @@ class DebuggerWindow2;
 struct GameEntry;
 class DiscordPresence;
 class TitleManager;
+class GraphicPacksWindow2;
 class wxLaunchGameEvent;
 
 wxDECLARE_EVENT(wxEVT_LAUNCH_GAME, wxLaunchGameEvent);
@@ -164,7 +165,7 @@ private:
 	MemorySearcherTool* m_toolWindow = nullptr;
 	TitleManager* m_title_manager = nullptr;
 	PadViewFrame* m_padView = nullptr;
-	wxWindow* m_graphic_pack_window = nullptr;
+	GraphicPacksWindow2* m_graphic_pack_window = nullptr;
 
 	wxTimer* m_timer;
 	wxPoint m_mouse_position{};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -146,6 +146,7 @@ public:
 
 private:
 	void RecreateMenu();
+	void UpdateChildWindowTitleRunningState();
 	static wxString GetInitialWindowTitle();
 	void ShowGettingStartedDialog();
 


### PR DESCRIPTION
Constructing DownloadGraphicPacksWindow launches a thread to run the graphic packs update tasks on. When a game is running the thread instead calls wxMessageBox to display an error and immediately returns. On windows this likely uses the system's MessageBox functions, which I believe spawn a window controlled by some system-level process meaning the application only has to read the result. However linux doesn't have native messagebox functionality like that and in order for an application to display any kind of window it has to manage it's event loop. For whatever reason wxMessageBox in the update thread gets stuck and the messagebox cannot be closed. The debugger shows that both the main UI thread and the graphic pack update thread are running a GTK event loop, either waiting for a condition variable or stuck in a poll syscall. This looks like a deadlock, but it's not as when I press the close button on the DownloadGraphicPacksWindow it does actually call OnClose(), which then also locks up the main thread because it tries to join the spawned update thread that is stuck in wxMessageBox.
I don't know if this is a bug in wxWidgets or if calling wxwidgets functions from multiple threads just isn't supported.
I worked around this issue by changing DownloadGraphicPacksWindow so it doesn't launch the thread upon construction but in ShowModal instead and shows the message box on the main UI thread if a title is running.
But then I realised it's kind of bad design to have the button be clickable if it'll immediately tell you it can't perform the action, so I also decided to update the button from FileLoad so it's greyed out when a game starts and made clickable when a game stops. For this I made the new function MainWindow::UpdateChildWindowTitleRunningState in case other windows need similar updates. This effectively means that the message box in DownloadGraphicPacksWindow serves only as a run-time check.