### PR TITLE
Avoid current app from showing up as "???" for others in Friend List + View friends' status

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -217,9 +217,8 @@ namespace iosu
 			auto fixed_presence_msg = '\0' + frd->presence.msg; // avoid first character of comment from being cut off
 			friendData->friendExtraData.gameModeDescription.assignFromUTF8(fixed_presence_msg);
 			
-			auto comment_utf16 = StringHelpers::FromUtf8(frd->comment.commentString);
-			comment_utf16.insert(0, 1, '\0'); // avoid first character of comment from being cut off
-			memcpy(friendData->friendExtraData.comment, comment_utf16.c_str(), 36);
+			auto fixed_comment = '\0' + frd->comment.commentString; // avoid first character of comment from being cut off
+			friendData->friendExtraData.comment.assignFromUTF8(fixed_comment);
 			
 			// set valid dates
 			friendData->uknDate.year = 2018;

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -213,6 +213,9 @@ namespace iosu
 			friendData->friendExtraData.gameKey.titleId = frd->presence.gameKey.titleId;
 			friendData->friendExtraData.gameKey.ukn08 = frd->presence.gameKey.ukn;
 			NexPresenceToGameMode(&frd->presence, &friendData->friendExtraData.gameMode);
+
+			auto fixed_presence_msg = '\0' + frd->presence.msg; // avoid first character of comment from being cut off
+			friendData->friendExtraData.gameModeDescription.assignFromUTF8(fixed_presence_msg);
 			
 			auto comment_utf16 = StringHelpers::FromUtf8(frd->comment.commentString);
 			comment_utf16.insert(0, 1, '\0'); // avoid first character of comment from being cut off

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -213,7 +213,11 @@ namespace iosu
 			friendData->friendExtraData.gameKey.titleId = frd->presence.gameKey.titleId;
 			friendData->friendExtraData.gameKey.ukn08 = frd->presence.gameKey.ukn;
 			NexPresenceToGameMode(&frd->presence, &friendData->friendExtraData.gameMode);
-
+			
+			auto comment_utf16 = StringHelpers::FromUtf8(frd->comment.commentString);
+			comment_utf16.insert(0, 1, '\0'); // avoid first character of comment from being cut off
+			memcpy(friendData->friendExtraData.comment, comment_utf16.c_str(), 36);
+			
 			// set valid dates
 			friendData->uknDate.year = 2018;
 			friendData->uknDate.day = 1;
@@ -716,7 +720,7 @@ namespace iosu
 				static constexpr uint32 MY_COMMENT_LENGTH = 0x12; // are comments utf16? Buffer length is 0x24
 				if(numVecIn != 0 || numVecOut != 1)
 					return FPResult_InvalidIPCParam;
-				if (vecOut->size != MY_COMMENT_LENGTH * sizeof(uint16be))
+				if(vecOut->size != MY_COMMENT_LENGTH*sizeof(uint16be))
 				{
 					cemuLog_log(LogType::Force, "GetMyComment: Unexpected output size");
 					return FPResult_InvalidIPCParam;

--- a/src/Cafe/IOSU/legacy/iosu_fpd.h
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.h
@@ -94,7 +94,7 @@ namespace iosu
 					/* +0x1EC */ uint8 isOnline;
 					/* +0x1ED */ uint8 _padding1ED[3];
 					// some other sub struct?
-					/* +0x1F0 */ char comment[36]; // pops up every few seconds in friend list
+					/* +0x1F0 */ CafeWideString<0x12> comment; // pops up every few seconds in friend list
 					/* +0x214 */ uint32be _padding214;
 					/* +0x218 */ FPDDate approvalTime;
 					/* +0x220 */ FPDDate lastOnline;

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -1,6 +1,7 @@
 #include "prudp.h"
 #include "nex.h"
 #include "nexFriends.h"
+#include "Cafe/CafeSystem.h"
 
 static const int NOTIFICATION_SRV_FRIEND_OFFLINE = 0x0A; // the opposite event (friend online) is notified via _PRESENCE_CHANGE
 static const int NOTIFICATION_SRV_FRIEND_PRESENCE_CHANGE = 0x18;
@@ -912,6 +913,18 @@ void NexFriends::markFriendRequestsAsReceived(uint64* messageIdList, sint32 coun
 void NexFriends::updateMyPresence(nexPresenceV2& myPresence)
 {
 	this->myPresence = myPresence;
+
+	if (GetTitleIdHigh(CafeSystem::GetForegroundTitleId()) == 0x00050000)
+	{
+		myPresence.gameKey.titleId = CafeSystem::GetForegroundTitleId();
+		myPresence.gameKey.ukn = CafeSystem::GetForegroundTitleVersion();
+	}
+	else
+	{
+		myPresence.gameKey.titleId = 0; // icon will not be ??? or invalid to others
+		myPresence.gameKey.ukn = 0;
+	}
+
 	if (nexCon == nullptr || nexCon->getState() != nexService::STATE_CONNECTED)
 	{
 		// not connected
@@ -920,6 +933,7 @@ void NexFriends::updateMyPresence(nexPresenceV2& myPresence)
 	uint8 tempNexBufferArray[1024];
 	nexPacketBuffer packetBuffer(tempNexBufferArray, sizeof(tempNexBufferArray), true);
 	myPresence.writeData(&packetBuffer);
+
 	nexCon->callMethod(NEX_PROTOCOL_FRIENDS_WIIU, 13, &packetBuffer, +[](nexServiceResponse_t* nexResponse){}, false);
 }
 

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -933,7 +933,6 @@ void NexFriends::updateMyPresence(nexPresenceV2& myPresence)
 	uint8 tempNexBufferArray[1024];
 	nexPacketBuffer packetBuffer(tempNexBufferArray, sizeof(tempNexBufferArray), true);
 	myPresence.writeData(&packetBuffer);
-
 	nexCon->callMethod(NEX_PROTOCOL_FRIENDS_WIIU, 13, &packetBuffer, +[](nexServiceResponse_t* nexResponse){}, false);
 }
 

--- a/src/Cemu/nex/nexFriends.h
+++ b/src/Cemu/nex/nexFriends.h
@@ -439,7 +439,7 @@ public:
 public:
 	nexNNAInfo		nnaInfo;
 	nexPresenceV2	presence;
-	nexComment		gameModeMessage;
+	nexComment		comment;
 	uint64			friendsSinceTimestamp;
 	uint64			lastOnlineTimestamp;
 	uint64			ukn6;

--- a/src/Cemu/nex/nexFriends.h
+++ b/src/Cemu/nex/nexFriends.h
@@ -431,7 +431,7 @@ public:
 	{
 		nnaInfo.readData(pb);
 		presence.readData(pb);
-		gameModeMessage.readData(pb);
+		comment.readData(pb);
 		friendsSinceTimestamp = pb->readU64();
 		lastOnlineTimestamp = pb->readU64();
 		ukn6 = pb->readU64();


### PR DESCRIPTION
iosu_fpd.cpp, nexFriends.cpp and nexFriends.h are edited to have these changes:
- Starting a friend session on a non-game application (system app, etc) will force myPresence.gameKey.titleId and myPresence.gameKey.ukn to be 0 in order to avoid the app from showing up as "???" for other people in Friend List and instead have no icon just like in real hardware
- Updating the gamemode will force myPresence.gameKey.titleId and myPresence.gameKey.ukn to be the current foreground title id/version (or 0 if not a game app) in order to avoid the app from showing up as "???" for other people in Friend List (the titleid is incorrect when the gamemode is updated, not sure why)
- Renamed nexFriend->gameModeMessage to nexFriend->comment since it is the status comment of an account, nothing to do with GameMode
- When calling NexFriendToFPDFriendData, the gamemode description and status comment from NexFriend will be copied over to FriendData, allowing friends comments and gamemode description to be read in Friend List
- Somewhat implemented GetMyPlayingGame (might be not too accurate)