### PR TITLE
Vulkan: remove present fence and PreparePresentationFrame

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -875,11 +875,6 @@ void LatteRenderTarget_getScreenImageArea(sint32* x, sint32* y, sint32* width, s
 
 void LatteRenderTarget_copyToBackbuffer(LatteTextureView* textureView, bool isPadView)
 {
-	if (g_renderer->GetType() == RendererAPI::Vulkan)
-	{
-		((VulkanRenderer*)g_renderer.get())->PreparePresentationFrame(!isPadView);
-	}
-
 	// make sure texture is updated to latest data in cache
 	LatteTexture_UpdateDataToLatest(textureView->baseTexture);
 	// mark source texture as still in use

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/SwapchainInfoVk.h
@@ -26,10 +26,7 @@ struct SwapchainInfoVk
 
 	bool IsValid() const;
 
-	void WaitAvailableFence();
-	void ResetAvailableFence() const;
-
-	bool AcquireImage(uint64 timeout);
+	bool AcquireImage();
 	// retrieve semaphore of last acquire for submitting a wait operation
 	// only one wait operation must be submitted per acquire (which submits a single signal operation)
 	// therefore subsequent calls will return a NULL handle
@@ -84,9 +81,7 @@ struct SwapchainInfoVk
 private:
 	uint32 m_acquireIndex = 0;
 	std::vector<VkSemaphore> m_acquireSemaphores; // indexed by m_acquireIndex
-	VkFence m_imageAvailableFence{};
 	VkSemaphore m_currentSemaphore = VK_NULL_HANDLE;
-	VkFence m_awaitableFence = VK_NULL_HANDLE;
 
 	std::array<uint32, 2> m_swapchainQueueFamilyIndices;
 	VkExtent2D m_actualExtent{};

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2594,7 +2594,7 @@ bool VulkanRenderer::AcquireNextSwapchainImage(bool mainWindow)
 	if (!UpdateSwapchainProperties(mainWindow))
 		return false;
 
-	bool result = chainInfo.AcquireImage(UINT64_MAX);
+	bool result = chainInfo.AcquireImage();
 	if (!result)
 		return false;
 
@@ -2607,8 +2607,6 @@ void VulkanRenderer::RecreateSwapchain(bool mainWindow, bool skipCreate)
 	SubmitCommandBuffer();
 	WaitDeviceIdle();
 	auto& chainInfo = GetChainInfo(mainWindow);
-	// make sure fence has no signal operation submitted
-	chainInfo.WaitAvailableFence();
 
 	Vector2i size;
 	if (mainWindow)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -1824,11 +1824,6 @@ void VulkanRenderer::DrawEmptyFrame(bool mainWindow)
 	SwapBuffers(mainWindow, !mainWindow);
 }
 
-void VulkanRenderer::PreparePresentationFrame(bool mainWindow)
-{
-	AcquireNextSwapchainImage(mainWindow);
-}
-
 void VulkanRenderer::InitFirstCommandBuffer()
 {
 	cemu_assert_debug(m_state.currentCommandBuffer == nullptr);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -228,7 +228,6 @@ public:
 	uint64 GenUniqueId(); // return unique id (uses incrementing counter)
 
 	void DrawEmptyFrame(bool mainWindow) override;
-	void PreparePresentationFrame(bool mainWindow);
 
 	void InitFirstCommandBuffer();
 	void ProcessFinishedCommandBuffers();


### PR DESCRIPTION
Removing PreparePresentationFrame:
PreparePresentationFrame was a hacky workaround because the VulkanRenderer did not adhere to the same interface as the OpenGL renderer. It became redundant at some point during the swapchain refactors. Everything acquires it's own image or reuses a previously acquired image now so there's no need to depart from the generic interface anymore.

Removing the fence:
I was reading [this article from 2022](https://www.collabora.com/news-and-blog/blog/2022/06/09/bridging-the-synchronization-gap-on-linux/) where at some point it mentions that on Intel ANV ``we run into problems when implementing vkWaitForFences() for the fence from vkAcquireNextImageKHR(). That has to be done via DRM_IOCTL_I915_GEM_WAIT which can't tell the difference between the compositor's work and work which has since been submitted by the client. If you call vkWaitForFences() on such a fence after submitting any client work, it basically ends up being a vkDeviceWaitIdle() which isn't at all what you want.``
This issue has likely been fixed on the driver-side at this point, however it's probably a good idea to get rid of the fence wait anyway in case any drivers run into the same issue.
If I understand correctly the reason why vkAcquireNextImageKHR provides the ability to wait for a fence is so applications can synchronise access to the image from the CPU. Since cemu doesn't touch the swapchain image with the CPU the fence is unnecessary. 
Previously I tried removing the _semaphores_ and keeping the fence but this caused issues on moltenVK. I have tested this version without the fence on macOS and there are no issues. In theory the fence and the semaphore synchronise to the same event (image released by presentation engine), so submitting a command buffer after waiting for the fence would also require that the commands in that command buffer execute after the image is actually released by the presentation engine unless the GPU can time travel. It's not surprising that synchronising this way causes a bug though, since normally fences aren't used to synchronize work on the GPU.

I've also adjusted the timeout value to 1 second so that even with bad drivers the thread will never lock up completely.