### PR TITLE
CI: Don't strip AppImage symbols

### DIFF
--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -33,6 +33,7 @@ chmod +x AppDir/usr/bin/Cemu
 cp /usr/lib/x86_64-linux-gnu/{libsepol.so.1,libffi.so.7,libpcre.so.3,libGLU.so.1,libthai.so.0} AppDir/usr/lib
 
 export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
+export NO_STRIP=1
 ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \
   --appdir="${GITHUB_WORKSPACE}"/AppDir/ \
   -d "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.desktop \


### PR DESCRIPTION
As it turns out fixing the symbols in the debug output for AppImage builds was very simple.
Linux deploy strips binaries by default. They helpfully provide the ``NO_STRIP`` environment variable to not strip...
https://github.com/linuxdeploy/linuxdeploy/issues/72
``NO_STRIP`` not set:
![image](https://github.com/cemu-project/Cemu/assets/7033575/3b461b59-1e6d-4d14-a538-d856957d9f5a)
``NO_STRIP`` set to 1:
![image](https://github.com/cemu-project/Cemu/assets/7033575/f7139645-4d99-4cff-ac18-2285a17f69c9)
