### PR TITLE
fix a crash when GL_VERSION is null

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -386,7 +386,7 @@ void OpenGLRenderer::GetVendorInformation()
 	cemuLog_log(LogType::Force, "GL_RENDERER: {}", glRendererString ? glRendererString : "unknown");
 	cemuLog_log(LogType::Force, "GL_VERSION: {}", glVersionString ? glVersionString : "unknown");
 
-	if(boost::icontains(glVersionString, "Mesa"))
+	if(glVersionString && boost::icontains(glVersionString, "Mesa"))
 	{
 		m_vendor = GfxVendor::Mesa;
 		return;


### PR DESCRIPTION
This fixes a crash when GL_VERSION is null for any reason. For instance when OpenGL fails to initialize.