### PR TITLE
OpenGL: fix loading cached shaders from GL cache files

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/OpenGL/RendererShaderGL.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/RendererShaderGL.cpp
@@ -26,10 +26,10 @@ bool RendererShaderGL::loadBinary()
 	std::vector<uint8> cacheFileData;
 	if (!s_programBinaryCache->GetFile({h1, h2 }, cacheFileData))
 		return false;
-	if (cacheFileData.empty())
+	if (cacheFileData.size() <= sizeof(uint32))
 		return false;
 
-	uint32 shaderBinFormat = *(uint32*)(cacheFileData.data() + 0);
+	uint32 shaderBinFormat = *(uint32*)(cacheFileData.data());
 
 	m_program = glCreateProgram();
 	glProgramBinary(m_program, shaderBinFormat, cacheFileData.data()+4, cacheFileData.size()-4);

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/RendererShaderGL.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/RendererShaderGL.cpp
@@ -23,14 +23,11 @@ bool RendererShaderGL::loadBinary()
 	cemu_assert_debug(m_baseHash != 0);
 	uint64 h1, h2;
 	GenerateShaderPrecompiledCacheFilename(m_type, m_baseHash, m_auxHash, h1, h2);
-	sint32 fileSize = 0;
 	std::vector<uint8> cacheFileData;
 	if (!s_programBinaryCache->GetFile({h1, h2 }, cacheFileData))
 		return false;
-	if (fileSize < sizeof(uint32))
-	{
+	if (cacheFileData.empty())
 		return false;
-	}
 
 	uint32 shaderBinFormat = *(uint32*)(cacheFileData.data() + 0);
 


### PR DESCRIPTION
The code that uses glProgramBinary to load compiled shaders from shaderCache/precompiled/\<TitleID\>_gl.bin files is unreachable. The fileSize variable is never changed so the function always fails. This means Cemu has been relying entirely on driver cache implementations for some time. (they must be pretty effective since nobody seems to have noticed this)