### PR TITLE
Include cstdarg in precompiled.h

### DIFF
--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -31,6 +31,7 @@
 #endif
 
 // c includes
+#include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
 #include <cmath>


### PR DESCRIPTION
This fixes the following build error:

src/Common/unix/FileStream_unix.cpp: In member function ‘void FileStream::writeStringFmt(const char*, ...)’: src/Common/unix/FileStream_unix.cpp:184:9: error: ‘va_start’ was not declared in this scope
  184 |         va_start(args, format);
      |         ^~~~~~~~

I'm guessing cstdarg is no longer automatically pulled into the includes with gcc 14.1