### PR TITLE
Fix GamePad window size

### DIFF
--- a/src/gui/PadViewFrame.cpp
+++ b/src/gui/PadViewFrame.cpp
@@ -72,7 +72,7 @@ void PadViewFrame::InitializeRenderCanvas()
 			m_render_canvas = GLCanvas_Create(this, wxSize(854, 480), false);
 		sizer->Add(m_render_canvas, 1, wxEXPAND, 0, nullptr);
 	}
-	SetSizer(sizer);
+	SetSizerAndFit(sizer);
 	Layout();
 
 	m_render_canvas->Bind(wxEVT_KEY_UP, &PadViewFrame::OnKeyUp, this);


### PR DESCRIPTION
The gamepad window was the wrong size.

I don't know wxWidgets well enough to say why this fix works or whether it will cause issues.

| before | after |
|-|-|
| ![Screenshot from 2024-05-27 11-34-59](https://github.com/cemu-project/Cemu/assets/334272/c9cf4a50-6595-48dc-ad44-2962143cdd84) | ![Screenshot from 2024-05-27 11-33-21](https://github.com/cemu-project/Cemu/assets/334272/57a12340-00df-46b6-92d2-8ea1ca85e52c) |