### PR TITLE
Create GamePad window at correct size

### DIFF
--- a/src/gui/PadViewFrame.cpp
+++ b/src/gui/PadViewFrame.cpp
@@ -20,18 +20,24 @@
 
 extern WindowInfo g_window_info;
 
+#define PAD_MIN_WIDTH  320
+#define PAD_MIN_HEIGHT 180
+
 PadViewFrame::PadViewFrame(wxFrame* parent)
-	: wxFrame(nullptr, wxID_ANY, _("GamePad View"), wxDefaultPosition, wxSize(854, 480), wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxCLOSE_BOX | wxWANTS_CHARS)
+	: wxFrame(nullptr, wxID_ANY, _("GamePad View"), wxDefaultPosition, wxDefaultSize, wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxSYSTEM_MENU | wxCAPTION | wxCLIP_CHILDREN | wxRESIZE_BORDER | wxCLOSE_BOX | wxWANTS_CHARS)
 {
 	gui_initHandleContextFromWxWidgetsWindow(g_window_info.window_pad, this);
-	
+
 	SetIcon(wxICON(M_WND_ICON128));
 	wxWindow::EnableTouchEvents(wxTOUCH_PAN_GESTURES);
 
-	SetMinClientSize({ 320, 180 });
+	SetMinClientSize({ PAD_MIN_WIDTH, PAD_MIN_HEIGHT });
 
 	SetPosition({ g_window_info.restored_pad_x, g_window_info.restored_pad_y });
-	SetSize({ g_window_info.restored_pad_width, g_window_info.restored_pad_height });
+	if (g_window_info.restored_pad_width >= PAD_MIN_WIDTH && g_window_info.restored_pad_height >= PAD_MIN_HEIGHT)
+		SetClientSize({ g_window_info.restored_pad_width, g_window_info.restored_pad_height });
+	else
+		SetClientSize(wxSize(854, 480));
 
 	if (g_window_info.pad_maximized)
 		Maximize();
@@ -72,7 +78,7 @@ void PadViewFrame::InitializeRenderCanvas()
 			m_render_canvas = GLCanvas_Create(this, wxSize(854, 480), false);
 		sizer->Add(m_render_canvas, 1, wxEXPAND, 0, nullptr);
 	}
-	SetSizerAndFit(sizer);
+	SetSizer(sizer);
 	Layout();
 
 	m_render_canvas->Bind(wxEVT_KEY_UP, &PadViewFrame::OnKeyUp, this);


### PR DESCRIPTION
Don't change the size on canvas initialization

This fixes the issue mentioned in response to #1224 that the GamePad window cannot be shrunk bellow 854x480.