### PR TITLE
resource: move fontawesome to .rodata

### DIFF
--- a/src/resource/embedded/fontawesome.S
+++ b/src/resource/embedded/fontawesome.S
@@ -1,4 +1,4 @@
-.section .text
+.rodata
 .global g_fontawesome_data, g_fontawesome_size
 
 g_fontawesome_data:


### PR DESCRIPTION
I've started to actually learn how the GNU assembler/linker work. No idea why I thought it was a good idea at the time to put a font in the .text segment. Fontawesome does _not_ need to execute :sweat_smile: