### PR TITLE
nsyshid: Tidyups and Fixes

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/Skylander.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.cpp
@@ -978,7 +978,7 @@ namespace nsyshid
 	{
 		for (const auto& it : GetListSkylanders())
 		{
-			if(it.first.first == skyId && it.first.second == skyVar)
+			if (it.first.first == skyId && it.first.second == skyVar)
 			{
 				return it.second;
 			}

--- a/src/Cafe/OS/libs/nsyshid/Skylander.h
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.h
@@ -50,7 +50,7 @@ namespace nsyshid
 			std::unique_ptr<FileStream> skyFile;
 			uint8 status = 0;
 			std::queue<uint8> queuedStatus;
-			std::array<uint8, SKY_BLOCK_SIZE> data{};
+			std::array<uint8, SKY_FIGURE_SIZE> data{};
 			uint32 lastId = 0;
 			void Save();
 

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -519,7 +519,7 @@ struct CemuConfig
 	struct
 	{
 		ConfigValue<bool> emulate_skylander_portal{false};
-		ConfigValue<bool> emulate_infinity_base{true};
+		ConfigValue<bool> emulate_infinity_base{false};
 	}emulated_usb_devices{};
 
 	private:

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
@@ -398,7 +398,7 @@ CreateInfinityFigureDialog::CreateInfinityFigureDialog(wxWindow* parent, uint8 s
 		{
 			wxMessageDialog idError(this, "Error Converting Figure Number!", "Number Entered is Invalid");
 			idError.ShowModal();
-			this->EndModal(0);;
+			this->EndModal(0);
 		}
 		uint32 figNum = longFigNum & 0xFFFFFFFF;
 		auto figure = nsyshid::g_infinitybase.FindFigure(figNum);
@@ -408,7 +408,7 @@ CreateInfinityFigureDialog::CreateInfinityFigureDialog(wxWindow* parent, uint8 s
 						   "BIN files (*.bin)|*.bin", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
 
 		if (saveFileDialog.ShowModal() == wxID_CANCEL)
-			this->EndModal(0);;
+			this->EndModal(0);
 
 		m_filePath = saveFileDialog.GetPath();
 


### PR DESCRIPTION
A user on Discord reported that Skylanders wasn't working in the latest releases - I found that the code that I changed to represent the Skylander File Sizes was incorrectly used, and the game would only read the first 16 bytes of the Skylander file in to the game, which caused issues when trying to load figures in to the game, causing an error to appear saying that there is an issue with the Skylander toy. Also have done some formatting to a couple of classes, and made the default for the emulated infinity base setting to be default, so users will need to turn this on again if they want to use this feature - users who have used the last few releases will have had this enabled by default.