### PR TITLE
Add support for iterating directories in graphics pack content folders.

### DIFF
--- a/src/Cafe/Filesystem/fsc.h
+++ b/src/Cafe/Filesystem/fsc.h
@@ -212,4 +212,4 @@ bool FSCDeviceHostFS_Mount(std::string_view mountPath, std::string_view hostTarg
 
 // redirect device
 void fscDeviceRedirect_map();
-void fscDeviceRedirect_add(std::string_view virtualSourcePath, const fs::path& targetFilePath, sint32 priority);
+void fscDeviceRedirect_add(std::string_view virtualSourcePath, size_t fileSize, const fs::path& targetFilePath, sint32 priority);

--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -830,7 +830,7 @@ void GraphicPack2::_iterateReplacedFiles(const fs::path& currentPath, bool isAOC
 			{
 				virtualMountPath = fs::path("vol/content/") / virtualMountPath;
 			}
-			fscDeviceRedirect_add(virtualMountPath.generic_string(), it.path().generic_string(), m_fs_priority);
+			fscDeviceRedirect_add(virtualMountPath.generic_string(), it.file_size(), it.path().generic_string(), m_fs_priority);
 		}		
 	}
 }


### PR DESCRIPTION
Allows games to see new files in graphics packs when iterating directories.

Example: Bayonetta 2, when you patch its code to load files outside CPKs, uses directory iterate functions to find files. This change allows it to find files in graphics packs.