### PR TITLE
CI: fix macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
       run: |
         brew update
         brew install llvm@15 ninja nasm automake libtool
-        brew install cmake python3 ninja
+        brew install cmake ninja
 
     - name: "Build and install molten-vk"
       run: |


### PR DESCRIPTION
do not manually install python, it comes preinstalled on the GH runner and updating it through brew is broken