### PR TITLE
Update appimage.sh to support runtime libstdc++.so.6 loading

### DIFF
--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -10,6 +10,8 @@ curl -sSfL https://github.com"$(curl https://github.com/probonopd/go-appimage/re
 chmod a+x mkappimage.AppImage
 curl -sSfLO "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 chmod a+x linuxdeploy-plugin-gtk.sh
+curl -sSfLO "https://github.com/darealshinji/linuxdeploy-plugin-checkrt/releases/download/continuous/linuxdeploy-plugin-checkrt.sh"
+chmod a+x linuxdeploy-plugin-checkrt.sh
 
 if [[ ! -e /usr/lib/x86_64-linux-gnu ]]; then
 	sed -i 's#lib\/x86_64-linux-gnu#lib64#g' linuxdeploy-plugin-gtk.sh
@@ -39,7 +41,8 @@ export NO_STRIP=1
   -d "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.desktop \
   -i "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.png \
   -e "${GITHUB_WORKSPACE}"/AppDir/usr/bin/Cemu \
-  --plugin gtk
+  --plugin gtk \
+  --plugin checkrt
 
 if ! GITVERSION="$(git rev-parse --short HEAD 2>/dev/null)"; then
 	GITVERSION=experimental


### PR DESCRIPTION
Add [checkrt](https://github.com/darealshinji/linuxdeploy-plugin-checkrt) plugin in order to detect the correct `libstdc++.so.6` version at runtime. The current method of bundling `libstdc++.so.6` is wrong and may cause conflicts ([1](https://discourse.appimage.org/t/im-a-big-fan-of-this-but-graphics-driver-libstdc-conflict/171/3), [2](https://github.com/cemu-project/Cemu/issues/1280)) if the base system contains fresh packages.  For context, this is the [recommended](https://github.com/AppImage/AppImageKit/wiki/Creating-AppImages/cc2441518975caca23e9ce2dba6f08a22c678d1e#libstdcso6) way to do this.