### PR TITLE
build: Better support for cross-compiling on ARM macOS.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
         path: ./bin/Cemu.exe
 
   build-macos:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
     - name: "Checkout repo"
       uses: actions/checkout@v4
@@ -224,17 +224,14 @@ jobs:
     - name: "Install system dependencies"
       run: |
         brew update
-        brew install llvm@15 ninja nasm automake libtool
-        brew install cmake ninja
+        brew install ninja nasm automake libtool
 
-    - name: "Build and install molten-vk"
+    - name: "Install molten-vk"
       run: |
-        git clone https://github.com/KhronosGroup/MoltenVK.git
-        cd MoltenVK
-        git checkout bf097edc74ec3b6dfafdcd5a38d3ce14b11952d6
-        ./fetchDependencies --macos
-        make macos
-        make install
+        curl -L -O https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.9/MoltenVK-macos.tar
+        tar xf MoltenVK-macos.tar
+        sudo mkdir -p /usr/local/lib
+        sudo cp MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib /usr/local/lib
 
     - name: "Setup cmake"
       uses: jwlawson/actions-setup-cmake@v2
@@ -265,9 +262,8 @@ jobs:
         cd build
         cmake .. ${{ env.BUILD_FLAGS }} \
         -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} \
+        -DCMAKE_OSX_ARCHITECTURES=x86_64 \
         -DMACOS_BUNDLE=ON \
-        -DCMAKE_C_COMPILER=/usr/local/opt/llvm@15/bin/clang \
-        -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@15/bin/clang++ \
         -G Ninja
         
     - name: "Build Cemu"

--- a/BUILD.md
+++ b/BUILD.md
@@ -16,11 +16,11 @@
          - [Compiling Errors](#compiling-errors)
          - [Building Errors](#building-errors)
 - [macOS](#macos)
-   - [On Apple Silicon Macs, Rosetta 2 and the x86_64 version of Homebrew must be used](#on-apple-silicon-macs-rosetta-2-and-the-x86_64-version-of-homebrew-must-be-used)
    - [Installing brew](#installing-brew)
-   - [Installing Dependencies](#installing-dependencies)
-   - [Build Cemu using CMake and Clang](#build-cemu-using-cmake-and-clang)
-   - [Updating Cemu and source code](#updating-cemu-and-source-code)
+   - [Installing Tool Dependencies](#installing-tool-dependencies)
+   - [Installing Library Dependencies](#installing-library-dependencies)
+   - [Build Cemu using CMake](#build-cemu-using-cmake)
+- [Updating Cemu and source code](#updating-cemu-and-source-code)
 
 ## Windows
 
@@ -141,31 +141,41 @@ If you are getting a different error than any of the errors listed above, you ma
 
 ## macOS
 
-To compile Cemu, a recent enough compiler and STL with C++20 support is required! LLVM 13 and
-below, built in LLVM, and Xcode LLVM don't support the C++20 feature set required. The OpenGL graphics
-API isn't support on macOS, Vulkan must be used. Additionally Vulkan must be used through the
-Molten-VK compatibility layer
-
-### On Apple Silicon Macs, Rosetta 2 and the x86_64 version of Homebrew must be used
-
-You can skip this section if you have an Intel Mac. Every time you compile, you need to perform steps 2.
-
-1. `softwareupdate --install-rosetta` # Install Rosetta 2 if you don't have it. This only has to be done once
-2. `arch -x86_64 zsh` # run an x64 shell
+To compile Cemu, a recent enough compiler and STL with C++20 support is required! LLVM 13 and below
+don't support the C++20 feature set required, so either install LLVM from Homebrew or make sure that
+you have a recent enough version of Xcode. Xcode 15 is known to work. The OpenGL graphics API isn't
+supported on macOS, so Vulkan must be used through the Molten-VK compatibility layer.
 
 ### Installing brew
 
 1. `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
-2. `eval "$(/usr/local/Homebrew/bin/brew shellenv)"` # set x86_64 brew env
+2. Set up the Homebrew shell environment:
+   1. **On an Intel Mac:** `eval "$(/usr/local/Homebrew/bin/brew shellenv)"`
+   2. **On an Apple Silicon Mac:** eval `"$(/opt/homebrew/bin/brew shellenv)"`
 
-### Installing Dependencies
+### Installing Tool Dependencies
 
-`brew install boost git cmake llvm ninja nasm molten-vk automake libtool`
+The native versions of these can be used regardless of what type of Mac you have.
 
-### Build Cemu using CMake and Clang
+`brew install git cmake ninja nasm automake libtool`
+
+### Installing Library Dependencies
+
+**On Apple Silicon Macs, Rosetta 2 and the x86_64 version of Homebrew must be used to install these dependencies:**
+1. `softwareupdate --install-rosetta` # Install Rosetta 2 if you don't have it. This only has to be done once
+2. `arch -x86_64 zsh` # run an x64 shell
+3. `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+4. `eval "$(/usr/local/Homebrew/bin/brew shellenv)"`
+
+Then install the dependencies:
+
+`brew install boost molten-vk`
+
+### Build Cemu using CMake
+
 1. `git clone --recursive https://github.com/cemu-project/Cemu`
 2. `cd Cemu`
-3. `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -G Ninja`
+3. `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_OSX_ARCHITECTURES=x86_64 -G Ninja`
 4. `cmake --build build`
 5. You should now have a Cemu executable file in the /bin folder, which you can run using `./bin/Cemu_release`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 
 if (APPLE)
     enable_language(OBJC OBJCXX)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0")
 endif()
 
 if (UNIX AND NOT APPLE)

--- a/dependencies/ih264d/CMakeLists.txt
+++ b/dependencies/ih264d/CMakeLists.txt
@@ -117,7 +117,13 @@ add_library (ih264d
 "decoder/ivd.h"
 )
 
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+if (CMAKE_OSX_ARCHITECTURES)
+set(IH264D_ARCHITECTURE ${CMAKE_OSX_ARCHITECTURES})
+else()
+set(IH264D_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
+if (IH264D_ARCHITECTURE STREQUAL "x86_64" OR IH264D_ARCHITECTURE STREQUAL "amd64" OR IH264D_ARCHITECTURE STREQUAL "AMD64")
 set(LIBAVCDEC_X86_INCLUDES "common/x86" "decoder/x86")
 include_directories("common/" "decoder/" ${LIBAVCDEC_X86_INCLUDES})
 target_sources(ih264d PRIVATE
@@ -140,7 +146,7 @@ target_sources(ih264d PRIVATE
 "decoder/x86/ih264d_function_selector_sse42.c"
 "decoder/x86/ih264d_function_selector_ssse3.c"
 )
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+elseif(IH264D_ARCHITECTURE STREQUAL "aarch64" OR IH264D_ARCHITECTURE STREQUAL "arm64")
 enable_language( C CXX ASM )
 set(LIBAVCDEC_ARM_INCLUDES "common/armv8" "decoder/arm")
 include_directories("common/" "decoder/" ${LIBAVCDEC_ARM_INCLUDES})
@@ -178,7 +184,7 @@ target_sources(ih264d PRIVATE
 )
 target_compile_options(ih264d PRIVATE -DARMV8)
 else()
-message(FATAL_ERROR "ih264d unknown architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+message(FATAL_ERROR "ih264d unknown architecture: ${IH264D_ARCHITECTURE}")
 endif()
 
 if(MSVC)

--- a/src/asm/CMakeLists.txt
+++ b/src/asm/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(CemuAsm C)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+if (CMAKE_OSX_ARCHITECTURES)
+    set(CEMU_ASM_ARCHITECTURE ${CMAKE_OSX_ARCHITECTURES})
+else()
+    set(CEMU_ASM_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
+if (CEMU_ASM_ARCHITECTURE MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 
 	if (WIN32)
 
@@ -40,8 +46,8 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 
 	endif()
 
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(AARCH64)")
+elseif(CEMU_ASM_ARCHITECTURE MATCHES "(aarch64)|(AARCH64)|(arm64)|(ARM64)")
 	add_library(CemuAsm stub.cpp)
 else()
-	message(STATUS "CemuAsm - Unsupported arch: ${CMAKE_SYSTEM_PROCESSOR}")
+	message(STATUS "CemuAsm - Unsupported arch: ${CEMU_ASM_ARCHITECTURE}")
 endif()


### PR DESCRIPTION
## Description

This implements and utilizes better support for cross-compiling on ARM macOS.

On the build side:
* Fixes architecture detection for ih264d and CemuAsm by using the value of `CMAKE_OSX_ARCHITECTURES` when available. Also added support for detecting the `arm64` value used on Mac while I was there for future ARM support.
* Sets `CMAKE_OSX_DEPLOYMENT_TARGET` to the minimum supported OS version to make sure the output executable has the correct support.
* Updates build instructions:
  * An x86_64 shell is no longer necessary for cross-compiling; it works fine as long as you pass the right architecture to CMake and install x86_64 versions of MoltenVK and Boost. I split up the dependencies section into tools and libraries, put instructions for installing x86_64 libraries from Homebrew, and removed references to needing to compile in an x86_64 shell every time.
  * Homebrew LLVM is no longer necessary to compile Cemu on newer versions of Xcode. In fact I was having some trouble with LLVM 15 not working right with newer macOS SDK versions.

On the CI side:
* Updates to the latest macOS GitHub Actions runners, which use Apple Silicon Macs. It's likely that once GitHub deprecates the macOS versions that use Intel runners, there will only be free ARM runners left, so it's best to get support for this going before that happens. Plus these runners tend to perform better than the older Intel Mac runners.
* Speeds up build times by using the pre-built MoltenVK releases instead of building from source. We can still get the older v1.2.9 this way without spending a lot of time building everything (usually about 16 minutes), and for future use it is a universal binary so it works for any architecture.
* Adds architecture specifier and removes LLVM compiler override, for the same reasons as the build instructions updates.
* Removes redundant `cmake` install as it is installed by `setup-cmake-action` later.

## Testing

I tested both building on my Mac and building in GitHub Actions. From my testing, the Mac CI build now takes about 7 minutes and 30 seconds to complete with `vcpkg` dependencies cached.

I also downloaded the resulting GItHub Actions build and ran a few games to check everything is working.