### PR TITLE
Allow the appimage to update with appimageupdate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream
+        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream desktop-file-utils
 
     - name: "Build AppImage"
       run: |

--- a/.github/workflows/deploy_experimental_release.yml
+++ b/.github/workflows/deploy_experimental_release.yml
@@ -126,6 +126,7 @@ jobs:
           echo "Cemu Version is $VERSION"
           ls cemu-appimage-x64
           mv cemu-appimage-x64/Cemu-*-x86_64.AppImage upload/Cemu-$VERSION-x86_64.AppImage
+          mv cemu-appimage-x64/Cemu-*-x86_64.AppImage.zsync upload/Cemu-$VERSION-x86_64.AppImage.zsync
         
       - name: Create release from linux-bin
         run: |

--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -6,8 +6,8 @@ fi
 
 curl -sSfLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
 chmod a+x linuxdeploy*.AppImage
-curl -sSfL https://github.com"$(curl https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous | grep "mkappimage-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)" -o mkappimage.AppImage
-chmod a+x mkappimage.AppImage
+curl -sSfL "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -o appimagetool
+chmod a+x appimagetool
 curl -sSfLO "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 chmod a+x linuxdeploy-plugin-gtk.sh
 curl -sSfLO "https://github.com/darealshinji/linuxdeploy-plugin-checkrt/releases/download/continuous/linuxdeploy-plugin-checkrt.sh"
@@ -34,9 +34,10 @@ chmod +x AppDir/usr/bin/Cemu
 
 cp /usr/lib/x86_64-linux-gnu/{libsepol.so.1,libffi.so.7,libpcre.so.3,libGLU.so.1,libthai.so.0} AppDir/usr/lib
 
-export UPD_INFO="gh-releases-zsync|cemu-project|Cemu|ci|Cemu.AppImage.zsync"
+export UPD_INFO="gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Cemu|latest|Cemu-*x86_64.AppImage.zsync"
+export APPIMAGE_EXTRACT_AND_RUN=1
 export NO_STRIP=1
-./linuxdeploy-x86_64.AppImage --appimage-extract-and-run \
+./linuxdeploy-x86_64.AppImage \
   --appdir="${GITHUB_WORKSPACE}"/AppDir/ \
   -d "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.desktop \
   -i "${GITHUB_WORKSPACE}"/AppDir/info.cemu.Cemu.png \
@@ -52,7 +53,8 @@ echo "Cemu Version Cemu-${GITVERSION}"
 rm AppDir/usr/lib/libwayland-client.so.0
 cp /lib/x86_64-linux-gnu/libstdc++.so.6 AppDir/usr/lib/
 echo -e "export LC_ALL=C\nexport FONTCONFIG_PATH=/etc/fonts" >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
-VERSION="${GITVERSION}" ./mkappimage.AppImage --appimage-extract-and-run "${GITHUB_WORKSPACE}"/AppDir
+./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 -u "${UPD_INFO}" \
+	"${GITHUB_WORKSPACE}"/AppDir Cemu-"${GITVERSION}"-x86_64.AppImage
 
 mkdir -p "${GITHUB_WORKSPACE}"/artifacts/
-mv Cemu-"${GITVERSION}"-x86_64.AppImage "${GITHUB_WORKSPACE}"/artifacts/
+mv Cemu-"${GITVERSION}"-x86_64.AppImage* "${GITHUB_WORKSPACE}"/artifacts/


### PR DESCRIPTION
This change allows delta updates with [appimageupdatetool](https://github.com/AppImageCommunity/AppImageUpdate)

I noticed that there was old release info in the build script, but checking the releases it seems it never got implemented?

Also was there a specific reason to be using mkappimage instead of appimagetool? as far as I know the only difference used to be that mkappimage was pulling the static runtime, but that is something that now appimagetool does as well, so functionality wise there is no difference I think.

Note that ideally the zsync should be released on the latest release and not in the pre-releases, else the entire update info and the release tags would need to be changed to allow updates on pre-releases.