### PR TITLE
appimage.sh: Do not copy `libstdc++.so.6` to `usr/lib/`

### DIFF
--- a/dist/linux/appimage.sh
+++ b/dist/linux/appimage.sh
@@ -50,7 +50,6 @@ fi
 echo "Cemu Version Cemu-${GITVERSION}"
 
 rm AppDir/usr/lib/libwayland-client.so.0
-cp /lib/x86_64-linux-gnu/libstdc++.so.6 AppDir/usr/lib/
 echo -e "export LC_ALL=C\nexport FONTCONFIG_PATH=/etc/fonts" >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 VERSION="${GITVERSION}" ./mkappimage.AppImage --appimage-extract-and-run "${GITHUB_WORKSPACE}"/AppDir
 


### PR DESCRIPTION
This is supposed to be handled by checkrt now, but if the library is available in `usr/lib/` in the AppImage, it will be loaded from there instead.

Fixes https://github.com/cemu-project/Cemu/pull/1292