### PR TITLE
nsysnet: Check for null timeout in select call

### DIFF
--- a/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
+++ b/src/Cafe/OS/libs/nsysnet/nsysnet.cpp
@@ -1210,6 +1210,14 @@ void nsysnetExport_select(PPCInterpreter_t* hCPU)
 
 	timeval tv = { 0 };
 
+	if (timeOut == NULL)
+	{
+		// return immediately
+		cemuLog_log(LogType::Socket, "select returned immediately because of null timeout");
+		osLib_returnFromFunction(hCPU, 0);
+		return;
+	}
+
 	uint64 msTimeout = (_swapEndianU32(timeOut->tv_usec) / 1000) + (_swapEndianU32(timeOut->tv_sec) * 1000);
 	uint32 startTime = GetTickCount();
 	while (true)


### PR DESCRIPTION
After bisecting an error with Skylanders Superchargers and Imaginators, I found that after this commit https://github.com/cemu-project/Cemu/commit/bab1616565b8fab99c52e0bedb275ae90a7b53df was added, the nsysnet select method was being called with a non-null write fdset, but a null timeout. I have added a null check to the code to return early if this timeOut is null.