### PR TITLE
Linux: Allow connecting Wiimotes via L2CAP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libudev-dev nasm ninja-build
+        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libudev-dev nasm ninja-build libbluetooth-dev
 
     - name: "Setup cmake"
       uses: jwlawson/actions-setup-cmake@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         sudo apt update -qq
-        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream
+        sudo apt install -y clang-15 cmake freeglut3-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev nasm ninja-build appstream libbluetooth-dev
 
     - name: "Build AppImage"
       run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -46,10 +46,10 @@ To compile Cemu, a recent enough compiler and STL with C++20 support is required
 ### Dependencies
 
 #### For Arch and derivatives:
-`sudo pacman -S --needed base-devel clang cmake freeglut git glm gtk3 libgcrypt libpulse libsecret linux-headers llvm nasm ninja systemd unzip zip`
+`sudo pacman -S --needed base-devel bluez-libs clang cmake freeglut git glm gtk3 libgcrypt libpulse libsecret linux-headers llvm nasm ninja systemd unzip zip`
 
 #### For Debian, Ubuntu and derivatives:
-`sudo apt install -y cmake curl clang-15 freeglut3-dev git libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libtool nasm ninja-build`
+`sudo apt install -y cmake curl clang-15 freeglut3-dev git libbluetooth-dev libgcrypt20-dev libglm-dev libgtk-3-dev libpulse-dev libsecret-1-dev libsystemd-dev libtool nasm ninja-build`
 
 You may also need to install `libusb-1.0-0-dev` as a workaround for an issue with the vcpkg hidapi package.
 
@@ -57,7 +57,7 @@ At Step 3 in [Build Cemu using cmake and clang](#build-cemu-using-cmake-and-clan
    `cmake -S . -B build -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja`
 
 #### For Fedora and derivatives:
-`sudo dnf install clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel libtool libusb1-devel llvm nasm ninja-build perl-core systemd-devel zlib-devel zlib-static`
+`sudo dnf install bluez-libs clang cmake cubeb-devel freeglut-devel git glm-devel gtk3-devel kernel-headers libgcrypt-devel libsecret-devel libtool libusb1-devel llvm nasm ninja-build perl-core systemd-devel zlib-devel zlib-static`
 
 ### Build Cemu
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ if (UNIX AND NOT APPLE)
 		add_compile_definitions(HAS_WAYLAND)
 	endif()
 	find_package(GTK3 REQUIRED)
+	find_package(bluez REQUIRED)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 if (UNIX AND NOT APPLE)
 	option(ENABLE_WAYLAND "Build with Wayland support" ON)
 	option(ENABLE_FERAL_GAMEMODE "Enables Feral Interactive GameMode Support" ON)
+	option(ENABLE_BLUEZ "Build with Bluez support" ON)
 endif()
 
 option(ENABLE_OPENGL "Enables the OpenGL backend" ON)
@@ -178,7 +179,12 @@ if (UNIX AND NOT APPLE)
 		add_compile_definitions(HAS_WAYLAND)
 	endif()
 	find_package(GTK3 REQUIRED)
-	find_package(bluez REQUIRED)
+
+	if(ENABLE_BLUEZ)
+		find_package(bluez REQUIRED)
+		set(ENABLE_WIIMOTE ON)
+		add_compile_definitions(HAS_BLUEZ)
+	endif()
 
 endif()
 

--- a/cmake/Findbluez.cmake
+++ b/cmake/Findbluez.cmake
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2022 Andrea Pappacoda <andrea@pappacoda.it>
+# SPDX-License-Identifier: ISC
+
+find_package(bluez CONFIG)
+if (NOT bluez_FOUND)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_search_module(bluez IMPORTED_TARGET GLOBAL bluez-1.0 bluez)
+    if (bluez_FOUND)
+      add_library(bluez::bluez ALIAS PkgConfig::bluez)
+    endif ()
+  endif ()
+endif ()
+
+find_package_handle_standard_args(bluez
+    REQUIRED_VARS
+    bluez_LINK_LIBRARIES
+    bluez_FOUND
+    VERSION_VAR bluez_VERSION
+)

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -250,9 +250,11 @@ void PairingDialog::WorkerThread()
 		UpdateCallback(PairingState::SearchFailed);
 		return;
 	}
+	stdx::scope_exit freeInfo([info]() { bt_free(info);});
 
 	//! Open dev to read name
 	const auto hostDesc = hci_open_dev(hostId);
+	stdx::scope_exit freeDev([hostDesc]() { hci_close_dev(hostDesc);});
 	char nameBuffer[HCI_MAX_NAME_LENGTH] = {};
 
 	// Get device name and compare. Would use product and vendor id from SDP, but many third-party Wiimotes don't store them

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -184,7 +184,7 @@ void PairingDialog::WorkerThread()
 		HBLUETOOTH_DEVICE_FIND deviceFind = BluetoothFindFirstDevice(&searchParams, &info);
 		if (deviceFind == nullptr)
 		{
-			UpdateCallback(PairingState::BluetoothFailed);
+			UpdateCallback(PairingState::SearchFailed);
 			return;
 		}
 

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -258,14 +258,16 @@ void PairingDialog::WorkerThread()
 	char nameBuffer[HCI_MAX_NAME_LENGTH] = {};
 
 	// Get device name and compare. Would use product and vendor id from SDP, but many third-party Wiimotes don't store them
-	auto& addr = info->bdaddr;
+	const auto& addr = info->bdaddr;
 	if (hci_read_remote_name(hostDesc, &addr, HCI_MAX_NAME_LENGTH, nameBuffer,
 							 2000) != 0 || !isWiimoteName(nameBuffer))
 	{
 		UpdateCallback(PairingState::SearchFailed);
 		return;
 	}
-	cemuLog_log(LogType::Force, "Pairing Dialog: Found '{}' with address {:02x}", nameBuffer, fmt::join(addr.b, ":"));
+	const auto& b = addr.b;
+	cemuLog_log(LogType::Force, "Pairing Dialog: Found '{}' with address '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}'",
+		nameBuffer, b[5], b[4], b[3], b[2], b[1], b[0]);
 
 	UpdateCallback(PairingState::Finished);
 	L2CapWiimote::AddCandidateAddress(addr);

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -245,7 +245,7 @@ void PairingDialog::WorkerThread()
 	// Search for device
 	inquiry_info* infos = nullptr;
 	m_cancelButton->Disable();
-	const auto respCount = hci_inquiry(hostId, 5, 4, LIAC_LAP, &infos, IREQ_CACHE_FLUSH);
+	const auto respCount = hci_inquiry(hostId, 7, 4, LIAC_LAP, &infos, IREQ_CACHE_FLUSH);
 	m_cancelButton->Enable();
 	if (respCount <= 0)
 	{

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -4,233 +4,279 @@
 #if BOOST_OS_WINDOWS
 #include <bluetoothapis.h>
 #endif
+#if BOOST_OS_LINUX
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+#include <input/api/Wiimote/l2cap/L2CapWiimote.h>
+#endif
 
 wxDECLARE_EVENT(wxEVT_PROGRESS_PAIR, wxCommandEvent);
 wxDEFINE_EVENT(wxEVT_PROGRESS_PAIR, wxCommandEvent);
 
 PairingDialog::PairingDialog(wxWindow* parent)
-    : wxDialog(parent, wxID_ANY, _("Pairing..."), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxCLOSE_BOX)
+	: wxDialog(parent, wxID_ANY, _("Pairing..."), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxMINIMIZE_BOX | wxSYSTEM_MENU | wxTAB_TRAVERSAL | wxCLOSE_BOX)
 {
-    auto* sizer = new wxBoxSizer(wxVERTICAL);
-    m_gauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition, wxSize(350, 20), wxGA_HORIZONTAL);
-    m_gauge->SetValue(0);
-    sizer->Add(m_gauge, 0, wxALL | wxEXPAND, 5);
+	auto* sizer = new wxBoxSizer(wxVERTICAL);
+	m_gauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition, wxSize(350, 20), wxGA_HORIZONTAL);
+	m_gauge->SetValue(0);
+	sizer->Add(m_gauge, 0, wxALL | wxEXPAND, 5);
 
-    auto* rows = new wxFlexGridSizer(0, 2, 0, 0);
-    rows->AddGrowableCol(1);
+	auto* rows = new wxFlexGridSizer(0, 2, 0, 0);
+	rows->AddGrowableCol(1);
 
-    m_text = new wxStaticText(this, wxID_ANY, _("Searching for controllers..."));
-    rows->Add(m_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+	m_text = new wxStaticText(this, wxID_ANY, _("Searching for controllers..."));
+	rows->Add(m_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
-    {
-        auto* right_side = new wxBoxSizer(wxHORIZONTAL);
+	{
+		auto* right_side = new wxBoxSizer(wxHORIZONTAL);
 
-        m_cancelButton = new wxButton(this, wxID_ANY, _("Cancel"));
-        m_cancelButton->Bind(wxEVT_BUTTON, &PairingDialog::OnCancelButton, this);
-        right_side->Add(m_cancelButton, 0, wxALL, 5);
+		m_cancelButton = new wxButton(this, wxID_ANY, _("Cancel"));
+		m_cancelButton->Bind(wxEVT_BUTTON, &PairingDialog::OnCancelButton, this);
+		right_side->Add(m_cancelButton, 0, wxALL, 5);
 
-        rows->Add(right_side, 1, wxALIGN_RIGHT, 5);
-    }
+		rows->Add(right_side, 1, wxALIGN_RIGHT, 5);
+	}
 
-    sizer->Add(rows, 0, wxALL | wxEXPAND, 5);
+	sizer->Add(rows, 0, wxALL | wxEXPAND, 5);
 
-    SetSizerAndFit(sizer);
-    Centre(wxBOTH);
+	SetSizerAndFit(sizer);
+	Centre(wxBOTH);
 
-    Bind(wxEVT_CLOSE_WINDOW, &PairingDialog::OnClose, this);
-    Bind(wxEVT_PROGRESS_PAIR, &PairingDialog::OnGaugeUpdate, this);
+	Bind(wxEVT_CLOSE_WINDOW, &PairingDialog::OnClose, this);
+	Bind(wxEVT_PROGRESS_PAIR, &PairingDialog::OnGaugeUpdate, this);
 
-    m_thread = std::thread(&PairingDialog::WorkerThread, this);
+	m_thread = std::thread(&PairingDialog::WorkerThread, this);
 }
 
 PairingDialog::~PairingDialog()
 {
-    Unbind(wxEVT_CLOSE_WINDOW, &PairingDialog::OnClose, this);
+	Unbind(wxEVT_CLOSE_WINDOW, &PairingDialog::OnClose, this);
 }
 
 void PairingDialog::OnClose(wxCloseEvent& event)
 {
-    event.Skip();
+	event.Skip();
 
-    m_threadShouldQuit = true;
-    if (m_thread.joinable())
-        m_thread.join();
+	m_threadShouldQuit = true;
+	if (m_thread.joinable())
+		m_thread.join();
 }
 
 void PairingDialog::OnCancelButton(const wxCommandEvent& event)
 {
-    Close();
+	Close();
 }
 
 void PairingDialog::OnGaugeUpdate(wxCommandEvent& event)
 {
-    PairingState state = (PairingState)event.GetInt();
+	PairingState state = (PairingState)event.GetInt();
 
-    switch (state)
-    {
-    case PairingState::Pairing:
-    {
-        m_text->SetLabel(_("Found controller. Pairing..."));
-        m_gauge->SetValue(50);
-        break;
-    }
+	switch (state)
+	{
+	case PairingState::Pairing:
+	{
+		m_text->SetLabel(_("Found controller. Pairing..."));
+		m_gauge->SetValue(50);
+		break;
+	}
 
-    case PairingState::Finished:
-    {
-        m_text->SetLabel(_("Successfully paired the controller."));
-        m_gauge->SetValue(100);
-        m_cancelButton->SetLabel(_("Close"));
-        break;
-    }
+	case PairingState::Finished:
+	{
+		m_text->SetLabel(_("Successfully paired the controller."));
+		m_gauge->SetValue(100);
+		m_cancelButton->SetLabel(_("Close"));
+		break;
+	}
 
-    case PairingState::NoBluetoothAvailable:
-    {
-        m_text->SetLabel(_("Failed to find a suitable Bluetooth radio."));
-        m_gauge->SetValue(0);
-        m_cancelButton->SetLabel(_("Close"));
-        break;
-    }
+	case PairingState::NoBluetoothAvailable:
+	{
+		m_text->SetLabel(_("Failed to find a suitable Bluetooth radio."));
+		m_gauge->SetValue(0);
+		m_cancelButton->SetLabel(_("Close"));
+		break;
+	}
 
-    case PairingState::BluetoothFailed:
-    {
-        m_text->SetLabel(_("Failed to search for controllers."));
-        m_gauge->SetValue(0);
-        m_cancelButton->SetLabel(_("Close"));
-        break;
-    }
+	case PairingState::SearchFailed:
+	{
+		m_text->SetLabel(_("Failed to find controllers."));
+		m_gauge->SetValue(0);
+		m_cancelButton->SetLabel(_("Close"));
+		break;
+	}
 
-    case PairingState::PairingFailed:
-    {
-        m_text->SetLabel(_("Failed to pair with the found controller."));
-        m_gauge->SetValue(0);
-        m_cancelButton->SetLabel(_("Close"));
-        break;
-    }
+	case PairingState::PairingFailed:
+	{
+		m_text->SetLabel(_("Failed to pair with the found controller."));
+		m_gauge->SetValue(0);
+		m_cancelButton->SetLabel(_("Close"));
+		break;
+	}
 
-    case PairingState::BluetoothUnusable:
-    {
-        m_text->SetLabel(_("Please use your system's Bluetooth manager instead."));
-        m_gauge->SetValue(0);
-        m_cancelButton->SetLabel(_("Close"));
-        break;
-    }
+	case PairingState::BluetoothUnusable:
+	{
+		m_text->SetLabel(_("Please use your system's Bluetooth manager instead."));
+		m_gauge->SetValue(0);
+		m_cancelButton->SetLabel(_("Close"));
+		break;
+	}
 
-
-    default:
-    {
-        break;
-    }
-    }
+	default:
+	{
+		break;
+	}
+	}
 }
-
-void PairingDialog::WorkerThread()
-{
-    const std::wstring wiimoteName = L"Nintendo RVL-CNT-01";
-    const std::wstring wiiUProControllerName = L"Nintendo RVL-CNT-01-UC";
 
 #if BOOST_OS_WINDOWS
-    const GUID bthHidGuid = {0x00001124,0x0000,0x1000,{0x80,0x00,0x00,0x80,0x5F,0x9B,0x34,0xFB}};
+void PairingDialog::WorkerThread()
+{
+	const std::wstring wiimoteName = L"Nintendo RVL-CNT-01";
+	const std::wstring wiiUProControllerName = L"Nintendo RVL-CNT-01-UC";
 
-    const BLUETOOTH_FIND_RADIO_PARAMS radioFindParams =
-    {
-        .dwSize = sizeof(BLUETOOTH_FIND_RADIO_PARAMS)
-    };
+	const GUID bthHidGuid = {0x00001124, 0x0000, 0x1000, {0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB}};
 
-    HANDLE radio = INVALID_HANDLE_VALUE;
-    HBLUETOOTH_RADIO_FIND radioFind = BluetoothFindFirstRadio(&radioFindParams, &radio);
-    if (radioFind == nullptr)
-    {
-        UpdateCallback(PairingState::NoBluetoothAvailable);
-        return;
-    }
+	const BLUETOOTH_FIND_RADIO_PARAMS radioFindParams =
+		{
+			.dwSize = sizeof(BLUETOOTH_FIND_RADIO_PARAMS)};
 
-    BluetoothFindRadioClose(radioFind);
+	HANDLE radio = INVALID_HANDLE_VALUE;
+	HBLUETOOTH_RADIO_FIND radioFind = BluetoothFindFirstRadio(&radioFindParams, &radio);
+	if (radioFind == nullptr)
+	{
+		UpdateCallback(PairingState::NoBluetoothAvailable);
+		return;
+	}
 
-    BLUETOOTH_RADIO_INFO radioInfo =
-    {
-        .dwSize = sizeof(BLUETOOTH_RADIO_INFO)
-    };
+	BluetoothFindRadioClose(radioFind);
 
-    DWORD result = BluetoothGetRadioInfo(radio, &radioInfo);
-    if (result != ERROR_SUCCESS)
-    {
-        UpdateCallback(PairingState::NoBluetoothAvailable);
-        return;
-    }
+	BLUETOOTH_RADIO_INFO radioInfo =
+		{
+			.dwSize = sizeof(BLUETOOTH_RADIO_INFO)};
 
-    const BLUETOOTH_DEVICE_SEARCH_PARAMS searchParams =
-    {
-        .dwSize               = sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS),
+	DWORD result = BluetoothGetRadioInfo(radio, &radioInfo);
+	if (result != ERROR_SUCCESS)
+	{
+		UpdateCallback(PairingState::NoBluetoothAvailable);
+		return;
+	}
 
-        .fReturnAuthenticated = FALSE,
-        .fReturnRemembered    = FALSE,
-        .fReturnUnknown       = TRUE,
-        .fReturnConnected     = FALSE,
+	const BLUETOOTH_DEVICE_SEARCH_PARAMS searchParams =
+		{
+			.dwSize = sizeof(BLUETOOTH_DEVICE_SEARCH_PARAMS),
 
-        .fIssueInquiry        = TRUE,
-        .cTimeoutMultiplier   = 5,
+			.fReturnAuthenticated = FALSE,
+			.fReturnRemembered = FALSE,
+			.fReturnUnknown = TRUE,
+			.fReturnConnected = FALSE,
 
-        .hRadio               = radio
-    };
+			.fIssueInquiry = TRUE,
+			.cTimeoutMultiplier = 5,
 
-    BLUETOOTH_DEVICE_INFO info =
-    {
-        .dwSize = sizeof(BLUETOOTH_DEVICE_INFO)
-    };
+			.hRadio = radio};
 
-    while (!m_threadShouldQuit)
-    {
-        HBLUETOOTH_DEVICE_FIND deviceFind = BluetoothFindFirstDevice(&searchParams, &info);
-        if (deviceFind == nullptr)
-        {
-            UpdateCallback(PairingState::BluetoothFailed);
-            return;
-        }
+	BLUETOOTH_DEVICE_INFO info =
+		{
+			.dwSize = sizeof(BLUETOOTH_DEVICE_INFO)};
 
-        while (!m_threadShouldQuit)
-        {
-            if (info.szName == wiimoteName || info.szName == wiiUProControllerName)
-            {
-                BluetoothFindDeviceClose(deviceFind);
+	while (!m_threadShouldQuit)
+	{
+		HBLUETOOTH_DEVICE_FIND deviceFind = BluetoothFindFirstDevice(&searchParams, &info);
+		if (deviceFind == nullptr)
+		{
+			UpdateCallback(PairingState::BluetoothFailed);
+			return;
+		}
 
-                UpdateCallback(PairingState::Pairing);
+		while (!m_threadShouldQuit)
+		{
+			if (info.szName == wiimoteName || info.szName == wiiUProControllerName)
+			{
+				BluetoothFindDeviceClose(deviceFind);
 
-                wchar_t passwd[6] = { radioInfo.address.rgBytes[0], radioInfo.address.rgBytes[1], radioInfo.address.rgBytes[2], radioInfo.address.rgBytes[3], radioInfo.address.rgBytes[4], radioInfo.address.rgBytes[5] };
-                DWORD bthResult = BluetoothAuthenticateDevice(nullptr, radio, &info, passwd, 6);
-                if (bthResult != ERROR_SUCCESS)
-                {
-                    UpdateCallback(PairingState::PairingFailed);
-                    return;
-                }
+				UpdateCallback(PairingState::Pairing);
 
-                bthResult = BluetoothSetServiceState(radio, &info, &bthHidGuid, BLUETOOTH_SERVICE_ENABLE);
-                if (bthResult != ERROR_SUCCESS)
-                {
-                    UpdateCallback(PairingState::PairingFailed);
-                    return;
-                }
+				wchar_t passwd[6] = {radioInfo.address.rgBytes[0], radioInfo.address.rgBytes[1], radioInfo.address.rgBytes[2], radioInfo.address.rgBytes[3], radioInfo.address.rgBytes[4], radioInfo.address.rgBytes[5]};
+				DWORD bthResult = BluetoothAuthenticateDevice(nullptr, radio, &info, passwd, 6);
+				if (bthResult != ERROR_SUCCESS)
+				{
+					UpdateCallback(PairingState::PairingFailed);
+					return;
+				}
 
-                UpdateCallback(PairingState::Finished);
-                return;
-            }
+				bthResult = BluetoothSetServiceState(radio, &info, &bthHidGuid, BLUETOOTH_SERVICE_ENABLE);
+				if (bthResult != ERROR_SUCCESS)
+				{
+					UpdateCallback(PairingState::PairingFailed);
+					return;
+				}
 
-            BOOL nextDevResult = BluetoothFindNextDevice(deviceFind, &info);
-            if (nextDevResult == FALSE)
-            {
-                break;
-            }
-        }
+				UpdateCallback(PairingState::Finished);
+				return;
+			}
 
-        BluetoothFindDeviceClose(deviceFind);
-    }
-#else
-    UpdateCallback(PairingState::BluetoothUnusable);
-#endif
+			BOOL nextDevResult = BluetoothFindNextDevice(deviceFind, &info);
+			if (nextDevResult == FALSE)
+			{
+				break;
+			}
+		}
+
+		BluetoothFindDeviceClose(deviceFind);
+	}
 }
+#elif BOOST_OS_LINUX
+void PairingDialog::WorkerThread()
+{
+	constexpr static uint8_t liacLap[] = {0x00, 0x8b, 0x9e};
 
+	constexpr static auto isWiimoteName = [](std::string_view name) {
+		return name == "Nintendo RVL-CNT-01" || name == "Nintendo RVL-CNT-01-TR";
+	};
+
+	// Get default BT device
+	const auto hostId = hci_get_route(nullptr);
+	if (hostId < 0)
+	{
+		UpdateCallback(PairingState::NoBluetoothAvailable);
+		return;
+	}
+
+	// Search for device
+	inquiry_info* info = nullptr;
+	const auto respCount = hci_inquiry(hostId, 5, 1, liacLap, &info, IREQ_CACHE_FLUSH);
+	if (respCount <= 0)
+	{
+		UpdateCallback(PairingState::SearchFailed);
+		return;
+	}
+
+	//! Open dev to read name
+	const auto hostDesc = hci_open_dev(hostId);
+	char nameBuffer[HCI_MAX_NAME_LENGTH] = {};
+
+	// Get device name and compare. Would use product and vendor id from SDP, but many third-party Wiimotes don't store them
+	auto& addr = info->bdaddr;
+	if (hci_read_remote_name(hostDesc, &addr, HCI_MAX_NAME_LENGTH, nameBuffer,
+							 2000) != 0 || !isWiimoteName(nameBuffer))
+	{
+		UpdateCallback(PairingState::SearchFailed);
+		return;
+	}
+	cemuLog_log(LogType::Force, "Pairing Dialog: Found '{}' with address {:02x}", nameBuffer, fmt::join(addr.b, ":"));
+
+	UpdateCallback(PairingState::Finished);
+	L2CapWiimote::AddCandidateAddress(addr);
+}
+#else
+void PairingDialog::WorkerThread()
+{
+	UpdateCallback(PairingState::BluetoothUnusable);
+}
+#endif
 void PairingDialog::UpdateCallback(PairingState state)
 {
-    auto* event = new wxCommandEvent(wxEVT_PROGRESS_PAIR);
-    event->SetInt((int)state);
-    wxQueueEvent(this, event);
+	auto* event = new wxCommandEvent(wxEVT_PROGRESS_PAIR);
+	event->SetInt((int)state);
+	wxQueueEvent(this, event);
 }

--- a/src/gui/input/PairingDialog.cpp
+++ b/src/gui/input/PairingDialog.cpp
@@ -228,7 +228,7 @@ void PairingDialog::WorkerThread()
 #elif BOOST_OS_LINUX
 void PairingDialog::WorkerThread()
 {
-	constexpr static uint8_t liacLap[] = {0x00, 0x8b, 0x9e};
+	constexpr static uint8_t LIAC_LAP[] = {0x00, 0x8b, 0x9e};
 
 	constexpr static auto isWiimoteName = [](std::string_view name) {
 		return name == "Nintendo RVL-CNT-01" || name == "Nintendo RVL-CNT-01-TR";
@@ -245,7 +245,7 @@ void PairingDialog::WorkerThread()
 	// Search for device
 	inquiry_info* infos = nullptr;
 	m_cancelButton->Disable();
-	const auto respCount = hci_inquiry(hostId, 5, 4, liacLap, &infos, IREQ_CACHE_FLUSH);
+	const auto respCount = hci_inquiry(hostId, 5, 4, LIAC_LAP, &infos, IREQ_CACHE_FLUSH);
 	m_cancelButton->Enable();
 	if (respCount <= 0)
 	{

--- a/src/gui/input/PairingDialog.h
+++ b/src/gui/input/PairingDialog.h
@@ -17,7 +17,7 @@ private:
         Pairing,
         Finished,
         NoBluetoothAvailable,
-        BluetoothFailed,
+	  	SearchFailed,
         PairingFailed,
         BluetoothUnusable
     };

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -102,3 +102,8 @@ endif()
 if (ENABLE_WXWIDGETS)
 	target_link_libraries(CemuInput PRIVATE wx::base wx::core)
 endif()
+
+
+if (UNIX AND NOT APPLE)
+	target_link_libraries(CemuInput PRIVATE bluez::bluez)
+endif ()

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -73,6 +73,11 @@ if (ENABLE_WIIMOTE)
 			api/Wiimote/hidapi/HidapiWiimote.cpp
 			api/Wiimote/hidapi/HidapiWiimote.h
 	)
+	if (UNIX AND NOT APPLE)
+		target_sources(CemuInput PRIVATE
+			api/Wiimote/l2cap/L2CapWiimote.cpp
+			api/Wiimote/l2cap/L2CapWiimote.h)
+	endif()
 endif ()
 
 

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -4,6 +4,10 @@
 
 #include "input/api/Wiimote/hidapi/HidapiWiimote.h"
 
+#if BOOST_OS_LINUX
+#include "input/api/Wiimote/l2cap/L2CapWiimote.h"
+#endif
+
 #include <numbers>
 #include <queue>
 
@@ -45,7 +49,12 @@ std::vector<std::shared_ptr<ControllerBase>> WiimoteControllerProvider::get_cont
         return writeable && not_already_connected;
     };
 
-	for (auto& device : WiimoteDevice_t::get_devices())
+	auto devices = HidapiWiimote::get_devices();
+#if BOOST_OS_LINUX
+	const auto& l2capDevices = L2CapWiimote::get_devices();
+	std::ranges::copy(l2capDevices, std::back_inserter(devices));
+#endif
+	for (auto& device : devices)
 	{
         if (!valid_new_device(device))
             continue;

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -49,12 +49,17 @@ std::vector<std::shared_ptr<ControllerBase>> WiimoteControllerProvider::get_cont
 		ssize_t lowestReplaceableIndex = -1;
 		for (ssize_t i = m_wiimotes.size() - 1; i >= 0; --i)
 		{
-			const auto& wiimote = m_wiimotes[i];
-			if (wiimote.device && *wiimote.device == *device)
+			const auto& wiimoteDevice = m_wiimotes[i].device;
+			if (wiimoteDevice)
 			{
-				isDuplicate = true;
-				break;
+				if (*wiimoteDevice == *device)
+				{
+					isDuplicate = true;
+					break;
+				}
+				continue;
 			}
+
 			lowestReplaceableIndex = i;
 		}
 		if (isDuplicate)

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -955,14 +955,17 @@ void WiimoteControllerProvider::writer_thread()
 		if (index != (size_t)-1 && !data.empty())
 		{
 			auto& wiimote = m_wiimotes[index];
+			if (!wiimote.device)
+				continue;
 			if (wiimote.rumble)
 				data[1] |= 1;
 			if (!wiimote.device->write_data(data))
+			{
 				wiimote.device.reset();
-			if (wiimote.device)
-				wiimote.data_ts = std::chrono::high_resolution_clock::now();
-			else
 				wiimote.rumble = false;
+			}
+			else
+				wiimote.data_ts = std::chrono::high_resolution_clock::now();
 		}
 		device_lock.unlock();
 

--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -1,10 +1,11 @@
 #include "input/api/Wiimote/WiimoteControllerProvider.h"
 #include "input/api/Wiimote/NativeWiimoteController.h"
 #include "input/api/Wiimote/WiimoteMessages.h"
-#if HAS_HIDAPI
+
+#ifdef HAS_HIDAPI
 #include "input/api/Wiimote/hidapi/HidapiWiimote.h"
 #endif
-#if BOOST_OS_LINUX
+#ifdef HAS_BLUEZ
 #include "input/api/Wiimote/l2cap/L2CapWiimote.h"
 #endif
 
@@ -150,11 +151,11 @@ void WiimoteControllerProvider::connectionThread()
 	while (m_running.load(std::memory_order_relaxed))
 	{
 		std::vector<WiimoteDevicePtr> devices;
-#if HAS_HIDAPI
+#ifdef HAS_HIDAPI
 		const auto& hidDevices = HidapiWiimote::get_devices();
 		std::ranges::move(hidDevices, std::back_inserter(devices));
 #endif
-#if BOOST_OS_LINUX
+#ifdef HAS_BLUEZ
 		const auto& l2capDevices = L2CapWiimote::get_devices();
 		std::ranges::move(l2capDevices, std::back_inserter(devices));
 #endif

--- a/src/input/api/Wiimote/WiimoteControllerProvider.h
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.h
@@ -79,7 +79,7 @@ private:
 	std::thread m_reader_thread, m_writer_thread;
 	std::shared_mutex m_device_mutex;
 
-	std::jthread m_connectionThread;
+	std::thread m_connectionThread;
 	std::vector<WiimoteDevicePtr> m_connectedDevices;
 	std::mutex m_connectedDeviceMutex;
 	struct Wiimote
@@ -104,7 +104,7 @@ private:
 
 	void reader_thread();
 	void writer_thread();
-	void connectionThread(std::stop_token);
+	void connectionThread();
 
 	void calibrate(size_t index);
 	IRMode set_ir_camera(size_t index, bool state);

--- a/src/input/api/Wiimote/WiimoteControllerProvider.h
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.h
@@ -77,16 +77,17 @@ public:
 private:
 	std::atomic_bool m_running = false;
 	std::thread m_reader_thread, m_writer_thread;
-
 	std::shared_mutex m_device_mutex;
 
+	std::jthread m_connectionThread;
+	std::vector<WiimoteDevicePtr> m_connectedDevices;
+	std::mutex m_connectedDeviceMutex;
 	struct Wiimote
 	{
 		Wiimote(WiimoteDevicePtr device)
 			: device(std::move(device)) {}
 
 		WiimoteDevicePtr device;
-		std::atomic_bool connected = true;
 		std::atomic_bool rumble = false;
 
 		std::shared_mutex mutex;
@@ -103,6 +104,7 @@ private:
 
 	void reader_thread();
 	void writer_thread();
+	void connectionThread(std::stop_token);
 
 	void calibrate(size_t index);
 	IRMode set_ir_camera(size_t index, bool state);

--- a/src/input/api/Wiimote/WiimoteDevice.h
+++ b/src/input/api/Wiimote/WiimoteDevice.h
@@ -10,7 +10,6 @@ public:
 	virtual std::optional<std::vector<uint8_t>> read_data() = 0;
 
 	virtual bool operator==(WiimoteDevice& o) const = 0;
-	bool operator!=(WiimoteDevice& o) const { return *this == o; }
 };
 
 using WiimoteDevicePtr = std::shared_ptr<WiimoteDevice>;

--- a/src/input/api/Wiimote/WiimoteDevice.h
+++ b/src/input/api/Wiimote/WiimoteDevice.h
@@ -9,7 +9,7 @@ public:
 	virtual bool write_data(const std::vector<uint8>& data) = 0;
 	virtual std::optional<std::vector<uint8_t>> read_data() = 0;
 
-	virtual bool operator==(WiimoteDevice& o) const = 0;
+	virtual bool operator==(const WiimoteDevice& o) const = 0;
 };
 
 using WiimoteDevicePtr = std::shared_ptr<WiimoteDevice>;

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
@@ -47,8 +47,11 @@ std::vector<WiimoteDevicePtr> HidapiWiimote::get_devices() {
     return wiimote_devices;
 }
 
-bool HidapiWiimote::operator==(WiimoteDevice& o) const  {
-    return static_cast<HidapiWiimote const&>(o).m_path == m_path;
+bool HidapiWiimote::operator==(WiimoteDevice& rhs) const  {
+    auto other = dynamic_cast<HidapiWiimote*>(&rhs);
+	if (!other)
+		return false;
+	return m_path == other->m_path;
 }
 
 HidapiWiimote::~HidapiWiimote() {

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.cpp
@@ -47,8 +47,8 @@ std::vector<WiimoteDevicePtr> HidapiWiimote::get_devices() {
     return wiimote_devices;
 }
 
-bool HidapiWiimote::operator==(WiimoteDevice& rhs) const  {
-    auto other = dynamic_cast<HidapiWiimote*>(&rhs);
+bool HidapiWiimote::operator==(const WiimoteDevice& rhs) const  {
+    auto other = dynamic_cast<const HidapiWiimote*>(&rhs);
 	if (!other)
 		return false;
 	return m_path == other->m_path;

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.h
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.h
@@ -10,7 +10,7 @@ public:
 
     bool write_data(const std::vector<uint8> &data) override;
     std::optional<std::vector<uint8>> read_data() override;
-    bool operator==(WiimoteDevice& o) const override;
+    bool operator==(const WiimoteDevice& o) const override;
 
     static std::vector<WiimoteDevicePtr> get_devices();
 

--- a/src/input/api/Wiimote/hidapi/HidapiWiimote.h
+++ b/src/input/api/Wiimote/hidapi/HidapiWiimote.h
@@ -19,5 +19,3 @@ private:
     const std::string m_path;
 
 };
-
-using WiimoteDevice_t = HidapiWiimote;

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -1,0 +1,127 @@
+#include "L2CapWiimote.h"
+#include <bluetooth/l2cap.h>
+
+namespace {
+	// TODO: Add procedure to get addresses. Should add to PairingDialog
+	std::vector<bdaddr_t> s_address;
+	std::mutex s_addressMutex;
+
+	bool AttemptConnect(int sockFd, sockaddr_l2 const& addr)
+	{
+		for (auto i = 0; i < 3; ++i)
+		{
+			if (connect(sockFd, reinterpret_cast<sockaddr const*>(&addr),
+						sizeof(sockaddr_l2)) == 0)
+				return true;
+			cemuLog_logDebug(LogType::Force, "Connection attempt {} failed with error {:x}: {} ", i + 1, errno,
+							 std::strerror(errno));
+			if (i == 2)
+				break;
+			std::this_thread::sleep_for(std::chrono::milliseconds(300));
+		}
+		return false;
+	}
+	bool AttemptSetNonBlock(int& sockFd)
+	{
+		return fcntl(sockFd, F_SETFL, fcntl(sockFd, F_GETFL) | O_NONBLOCK) == 0;
+	}
+}
+
+L2CapWiimote::L2CapWiimote(int recvFd,int sendFd)
+: m_recvFd(recvFd), m_sendFd(sendFd)
+{
+
+}
+
+L2CapWiimote::~L2CapWiimote()
+{
+	::close(m_recvFd);
+	::close(m_sendFd);
+}
+
+std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
+{
+	s_addressMutex.lock();
+	const auto addresses = s_address;
+	s_addressMutex.unlock();
+
+
+	std::vector<WiimoteDevicePtr> outDevices;
+	for (auto addr : addresses)
+	{
+		// Socket for sending data to controller, PSM 0x11
+		auto sendFd = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+		if (sendFd < 0) {
+			cemuLog_logDebug(LogType::Force, "Failed to open send socket: {}", strerror(errno));
+			continue;
+		}
+
+		sockaddr_l2 sendAddr{};
+		sendAddr.l2_family = AF_BLUETOOTH;
+		sendAddr.l2_psm = htobs(0x11);
+		sendAddr.l2_bdaddr = addr;
+
+		if (!AttemptConnect(sendFd, sendAddr) || !AttemptSetNonBlock(sendFd)) {
+			cemuLog_logDebug(LogType::Force,"Failed to connect send socket to '{:02x}': {}",
+							 fmt::join(addr.b, ":"), strerror(errno));
+			close(sendFd);
+			continue;
+		}
+
+		// Socket for receiving data from controller, PSM 0x13
+		auto recvFd = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
+		if (recvFd < 0) {
+			cemuLog_logDebug(LogType::Force,"Failed to open recv socket: {}", strerror(errno));
+			close(sendFd);
+			continue;
+		}
+		sockaddr_l2 recvAddr{};
+		recvAddr.l2_family = AF_BLUETOOTH;
+		recvAddr.l2_psm = htobs(0x13);
+		recvAddr.l2_bdaddr = addr;
+
+		if (!AttemptConnect(recvFd, recvAddr) || !AttemptSetNonBlock(recvFd)) {
+			cemuLog_logDebug(LogType::Force,"Failed to connect recv socket to '{:02x}': {}",
+							 fmt::join(addr.b, ":"), strerror(errno));
+			close(sendFd);
+			close(recvFd);
+			continue;
+		}
+
+		outDevices.push_back(std::make_unique<L2CapWiimote>(sendFd, recvFd));
+	}
+	return outDevices;
+}
+
+bool L2CapWiimote::write_data(const std::vector<uint8>& data)
+{
+	const auto size = data.size();
+	cemu_assert_debug(size < 23);
+	uint8 buffer[23];
+	// All outgoing messages must be prefixed with 0xA2
+	buffer[0] = 0xA2;
+	std::memcpy(buffer + 1, data.data(), size);
+	const auto outSize = size + 1;
+	return send(m_sendFd, buffer, outSize, 0) != outSize;
+}
+
+std::optional<std::vector<uint8>> L2CapWiimote::read_data()
+{
+	uint8 buffer[23];
+	const auto nBytes = recv(m_sendFd, buffer, 23, 0);
+
+	// All incoming messages must be prefixed with 0xA1
+	if (nBytes < 2 || buffer[0] != 0xA1)
+		return {};
+	return std::vector(buffer + 1, buffer + 1 + nBytes - 1);
+}
+
+
+bool L2CapWiimote::operator==(WiimoteDevice& rhs) const
+{
+	auto mote = dynamic_cast<const L2CapWiimote*>(&rhs);
+	if (!mote)
+		return false;
+	return m_recvFd == mote->m_recvFd || m_recvFd == mote->m_sendFd;
+}
+

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -16,8 +16,8 @@ namespace {
 	}
 }
 
-L2CapWiimote::L2CapWiimote(int recvFd,int sendFd)
-: m_recvFd(recvFd), m_sendFd(sendFd)
+L2CapWiimote::L2CapWiimote(int recvFd,int sendFd, bdaddr_t addr)
+: m_recvFd(recvFd), m_sendFd(sendFd), m_addr(addr)
 {
 
 }
@@ -83,7 +83,7 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 			continue;
 		}
 
-		outDevices.emplace_back(std::make_shared<L2CapWiimote>(sendFd, recvFd));
+		outDevices.emplace_back(std::make_shared<L2CapWiimote>(sendFd, recvFd, addr));
 	}
 	return outDevices;
 }
@@ -117,5 +117,5 @@ bool L2CapWiimote::operator==(const WiimoteDevice& rhs) const
 	auto mote = dynamic_cast<const L2CapWiimote*>(&rhs);
 	if (!mote)
 		return false;
-	return m_recvFd == mote->m_recvFd || m_recvFd == mote->m_sendFd;
+	return bacmp(&m_addr, &mote->m_addr) == 0;
 }

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -2,7 +2,7 @@
 #include <bluetooth/l2cap.h>
 
 namespace {
-	// TODO: Add procedure to get addresses. Should add to PairingDialog
+	// TODO: Get addresses upon user request via PairingDialog
 	std::vector<bdaddr_t> s_address;
 	std::mutex s_addressMutex;
 
@@ -37,6 +37,12 @@ L2CapWiimote::~L2CapWiimote()
 {
 	::close(m_recvFd);
 	::close(m_sendFd);
+}
+
+void L2CapWiimote::AddCandidateAddresses(const std::vector<bdaddr_t>& addrs)
+{
+	std::scoped_lock lock(s_addressMutex);
+	std::ranges::copy(addrs, std::back_inserter(s_address));
 }
 
 std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
@@ -124,4 +130,3 @@ bool L2CapWiimote::operator==(WiimoteDevice& rhs) const
 		return false;
 	return m_recvFd == mote->m_recvFd || m_recvFd == mote->m_sendFd;
 }
-

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -112,7 +112,7 @@ std::optional<std::vector<uint8>> L2CapWiimote::read_data()
 }
 
 
-bool L2CapWiimote::operator==(WiimoteDevice& rhs) const
+bool L2CapWiimote::operator==(const WiimoteDevice& rhs) const
 {
 	auto mote = dynamic_cast<const L2CapWiimote*>(&rhs);
 	if (!mote)

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -2,7 +2,6 @@
 #include <bluetooth/l2cap.h>
 
 namespace {
-	// TODO: Get addresses upon user request via PairingDialog
 	std::vector<bdaddr_t> s_address;
 	std::mutex s_addressMutex;
 
@@ -39,10 +38,10 @@ L2CapWiimote::~L2CapWiimote()
 	::close(m_sendFd);
 }
 
-void L2CapWiimote::AddCandidateAddresses(const std::vector<bdaddr_t>& addrs)
+void L2CapWiimote::AddCandidateAddress(bdaddr_t addr)
 {
 	std::scoped_lock lock(s_addressMutex);
-	std::ranges::copy(addrs, std::back_inserter(s_address));
+	s_address.push_back(addr);
 }
 
 std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
@@ -108,7 +107,7 @@ bool L2CapWiimote::write_data(const std::vector<uint8>& data)
 	buffer[0] = 0xA2;
 	std::memcpy(buffer + 1, data.data(), size);
 	const auto outSize = size + 1;
-	return send(m_sendFd, buffer, outSize, 0) != outSize;
+	return send(m_sendFd, buffer, outSize, 0) == outSize;
 }
 
 std::optional<std::vector<uint8>> L2CapWiimote::read_data()

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -22,6 +22,11 @@ namespace {
 	}
 }
 
+static bool operator==(const bdaddr_t& a, const bdaddr_t& b)
+{
+	return bacmp(&a, &b) == 0;
+}
+
 L2CapWiimote::L2CapWiimote(int recvFd,int sendFd, bdaddr_t addr)
 : m_recvFd(recvFd), m_sendFd(sendFd), m_addr(addr)
 {
@@ -37,7 +42,7 @@ L2CapWiimote::~L2CapWiimote()
 void L2CapWiimote::AddCandidateAddress(bdaddr_t addr)
 {
 	std::scoped_lock lock(s_addressMutex);
-	s_address.push_back(addr);
+	vectorAppendUnique(s_address,addr);
 }
 
 std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
@@ -125,5 +130,5 @@ bool L2CapWiimote::operator==(const WiimoteDevice& rhs) const
 	auto mote = dynamic_cast<const L2CapWiimote*>(&rhs);
 	if (!mote)
 		return false;
-	return bacmp(&m_addr, &mote->m_addr) == 0;
+	return m_addr == mote->m_addr;
 }

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -88,7 +88,7 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 			continue;
 		}
 
-		outDevices.push_back(std::make_unique<L2CapWiimote>(sendFd, recvFd));
+		outDevices.emplace_back(std::make_shared<L2CapWiimote>(sendFd, recvFd));
 	}
 	return outDevices;
 }

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -5,20 +5,10 @@ namespace {
 	std::vector<bdaddr_t> s_address;
 	std::mutex s_addressMutex;
 
-	bool AttemptConnect(int sockFd, sockaddr_l2 const& addr)
+	bool AttemptConnect(int& sockFd, const sockaddr_l2& addr)
 	{
-		for (auto i = 0; i < 3; ++i)
-		{
-			if (connect(sockFd, reinterpret_cast<sockaddr const*>(&addr),
-						sizeof(sockaddr_l2)) == 0)
-				return true;
-			cemuLog_logDebug(LogType::Force, "Connection attempt {} failed with error {:x}: {} ", i + 1, errno,
-							 std::strerror(errno));
-			if (i == 2)
-				break;
-			std::this_thread::sleep_for(std::chrono::milliseconds(300));
-		}
-		return false;
+		return connect(sockFd, reinterpret_cast<const sockaddr*>(&addr),
+					   sizeof(sockaddr_l2)) == 0;
 	}
 	bool AttemptSetNonBlock(int& sockFd)
 	{

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -1,63 +1,70 @@
 #include "L2CapWiimote.h"
 #include <bluetooth/l2cap.h>
 
-namespace {
-	std::vector<bdaddr_t> s_address;
-	std::mutex s_addressMutex;
+constexpr auto comparator = [](const bdaddr_t& a, const bdaddr_t& b) {
+	return bacmp(&a, &b);
+};
 
-	bool AttemptConnect(int& sockFd, const sockaddr_l2& addr)
-	{
-		auto res = connect(sockFd, reinterpret_cast<const sockaddr*>(&addr),
-						   sizeof(sockaddr_l2));
-		if (res == 0)
-			return true;
-		if (res != ECONNREFUSED)
-			return false;
-		return connect(sockFd, reinterpret_cast<const sockaddr*>(&addr),
-				sizeof(sockaddr_l2)) == 0;
-	}
-	bool AttemptSetNonBlock(int& sockFd)
-	{
-		return fcntl(sockFd, F_SETFL, fcntl(sockFd, F_GETFL) | O_NONBLOCK) == 0;
-	}
+static auto s_addresses = std::map<bdaddr_t, bool, decltype(comparator)>(comparator);
+static std::mutex s_addressMutex;
+
+static bool AttemptConnect(int sockFd, const sockaddr_l2& addr)
+{
+	auto res = connect(sockFd, reinterpret_cast<const sockaddr*>(&addr),
+					   sizeof(sockaddr_l2));
+	if (res == 0)
+		return true;
+	return connect(sockFd, reinterpret_cast<const sockaddr*>(&addr),
+				   sizeof(sockaddr_l2)) == 0;
 }
 
-static bool operator==(const bdaddr_t& a, const bdaddr_t& b)
+static bool AttemptSetNonBlock(int sockFd)
 {
-	return bacmp(&a, &b) == 0;
+	return fcntl(sockFd, F_SETFL, fcntl(sockFd, F_GETFL) | O_NONBLOCK) == 0;
 }
 
-L2CapWiimote::L2CapWiimote(int recvFd,int sendFd, bdaddr_t addr)
-: m_recvFd(recvFd), m_sendFd(sendFd), m_addr(addr)
+L2CapWiimote::L2CapWiimote(int recvFd, int sendFd, bdaddr_t addr)
+	: m_recvFd(recvFd), m_sendFd(sendFd), m_addr(addr)
 {
-
 }
 
 L2CapWiimote::~L2CapWiimote()
 {
-	::close(m_recvFd);
-	::close(m_sendFd);
+	close(m_recvFd);
+	close(m_sendFd);
+	const auto& b = m_addr.b;
+	cemuLog_logDebug(LogType::Force, "Wiimote at {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} disconnected", b[5], b[4], b[3], b[2], b[1], b[0]);
+
+	// Re-add to candidate vec
+	s_addressMutex.lock();
+	s_addresses[m_addr] = false;
+	s_addressMutex.unlock();
 }
 
 void L2CapWiimote::AddCandidateAddress(bdaddr_t addr)
 {
 	std::scoped_lock lock(s_addressMutex);
-	vectorAppendUnique(s_address,addr);
+	s_addresses.try_emplace(addr, false);
 }
 
 std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 {
 	s_addressMutex.lock();
-	const auto addresses = s_address;
+	std::vector<bdaddr_t> unconnected;
+	for (const auto& [addr, connected] : s_addresses)
+	{
+		if (!connected)
+			unconnected.push_back(addr);
+	}
 	s_addressMutex.unlock();
 
-
 	std::vector<WiimoteDevicePtr> outDevices;
-	for (auto addr : addresses)
+	for (const auto& addr : unconnected)
 	{
 		// Socket for sending data to controller, PSM 0x11
 		auto sendFd = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
-		if (sendFd < 0) {
+		if (sendFd < 0)
+		{
 			cemuLog_logDebug(LogType::Force, "Failed to open send socket: {}", strerror(errno));
 			continue;
 		}
@@ -67,18 +74,20 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 		sendAddr.l2_psm = htobs(0x11);
 		sendAddr.l2_bdaddr = addr;
 
-		if (!AttemptConnect(sendFd, sendAddr) || !AttemptSetNonBlock(sendFd)) {
+		if (!AttemptConnect(sendFd, sendAddr) || !AttemptSetNonBlock(sendFd))
+		{
 			const auto& b = addr.b;
-			cemuLog_logDebug(LogType::Force,"Failed to connect send socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
-				b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
+			cemuLog_logDebug(LogType::Force, "Failed to connect send socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
+							 b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
 			close(sendFd);
 			continue;
 		}
 
 		// Socket for receiving data from controller, PSM 0x13
 		auto recvFd = socket(PF_BLUETOOTH, SOCK_SEQPACKET, BTPROTO_L2CAP);
-		if (recvFd < 0) {
-			cemuLog_logDebug(LogType::Force,"Failed to open recv socket: {}", strerror(errno));
+		if (recvFd < 0)
+		{
+			cemuLog_logDebug(LogType::Force, "Failed to open recv socket: {}", strerror(errno));
 			close(sendFd);
 			continue;
 		}
@@ -87,16 +96,20 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 		recvAddr.l2_psm = htobs(0x13);
 		recvAddr.l2_bdaddr = addr;
 
-		if (!AttemptConnect(recvFd, recvAddr) || !AttemptSetNonBlock(recvFd)) {
+		if (!AttemptConnect(recvFd, recvAddr) || !AttemptSetNonBlock(recvFd))
+		{
 			const auto& b = addr.b;
-			cemuLog_logDebug(LogType::Force,"Failed to connect recv socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
-				b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
+			cemuLog_logDebug(LogType::Force, "Failed to connect recv socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
+							 b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
 			close(sendFd);
 			close(recvFd);
 			continue;
 		}
-
 		outDevices.emplace_back(std::make_shared<L2CapWiimote>(sendFd, recvFd, addr));
+
+		s_addressMutex.lock();
+		s_addresses[addr] = true;
+		s_addressMutex.unlock();
 	}
 	return outDevices;
 }
@@ -126,11 +139,10 @@ std::optional<std::vector<uint8>> L2CapWiimote::read_data()
 	return std::vector(buffer + 1, buffer + 1 + nBytes - 1);
 }
 
-
 bool L2CapWiimote::operator==(const WiimoteDevice& rhs) const
 {
 	auto mote = dynamic_cast<const L2CapWiimote*>(&rhs);
 	if (!mote)
 		return false;
-	return m_addr == mote->m_addr;
+	return bacmp(&m_addr, &mote->m_addr) == 0;
 }

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.cpp
@@ -68,8 +68,9 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 		sendAddr.l2_bdaddr = addr;
 
 		if (!AttemptConnect(sendFd, sendAddr) || !AttemptSetNonBlock(sendFd)) {
-			cemuLog_logDebug(LogType::Force,"Failed to connect send socket to '{:02x}': {}",
-							 fmt::join(addr.b, ":"), strerror(errno));
+			const auto& b = addr.b;
+			cemuLog_logDebug(LogType::Force,"Failed to connect send socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
+				b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
 			close(sendFd);
 			continue;
 		}
@@ -87,8 +88,9 @@ std::vector<WiimoteDevicePtr> L2CapWiimote::get_devices()
 		recvAddr.l2_bdaddr = addr;
 
 		if (!AttemptConnect(recvFd, recvAddr) || !AttemptSetNonBlock(recvFd)) {
-			cemuLog_logDebug(LogType::Force,"Failed to connect recv socket to '{:02x}': {}",
-							 fmt::join(addr.b, ":"), strerror(errno));
+			const auto& b = addr.b;
+			cemuLog_logDebug(LogType::Force,"Failed to connect recv socket to '{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}': {}",
+				b[5], b[4], b[3], b[2], b[1], b[0], strerror(errno));
 			close(sendFd);
 			close(recvFd);
 			continue;

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.h
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.h
@@ -10,7 +10,7 @@ class L2CapWiimote : public WiimoteDevice
 
 	bool write_data(const std::vector<uint8>& data) override;
 	std::optional<std::vector<uint8>> read_data() override;
-	bool operator==(WiimoteDevice& o) const override;
+	bool operator==(const WiimoteDevice& o) const override;
 
 	static void AddCandidateAddress(bdaddr_t addr);
 	static std::vector<WiimoteDevicePtr> get_devices();

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.h
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.h
@@ -5,7 +5,7 @@
 class L2CapWiimote : public WiimoteDevice
 {
   public:
-	L2CapWiimote(int recvFd, int sendFd);
+	L2CapWiimote(int recvFd, int sendFd, bdaddr_t addr);
 	~L2CapWiimote() override;
 
 	bool write_data(const std::vector<uint8>& data) override;
@@ -17,5 +17,6 @@ class L2CapWiimote : public WiimoteDevice
   private:
 	int m_recvFd;
 	int m_sendFd;
+	bdaddr_t m_addr;
 };
 

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.h
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <api/Wiimote/WiimoteDevice.h>
+#include <bluetooth/bluetooth.h>
+
+class L2CapWiimote : public WiimoteDevice
+{
+  public:
+	L2CapWiimote(int recvFd, int sendFd);
+	~L2CapWiimote() override;
+
+	bool write_data(const std::vector<uint8>& data) override;
+	std::optional<std::vector<uint8>> read_data() override;
+	bool operator==(WiimoteDevice& o) const override;
+
+	static std::vector<WiimoteDevicePtr> get_devices();
+  private:
+	int m_recvFd;
+	int m_sendFd;
+};
+

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.h
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <api/Wiimote/WiimoteDevice.h>
+#include <input/api/Wiimote/WiimoteDevice.h>
 #include <bluetooth/bluetooth.h>
 
 class L2CapWiimote : public WiimoteDevice
@@ -12,7 +12,7 @@ class L2CapWiimote : public WiimoteDevice
 	std::optional<std::vector<uint8>> read_data() override;
 	bool operator==(WiimoteDevice& o) const override;
 
-	static void AddCandidateAddresses(const std::vector<bdaddr_t>& addrs);
+	static void AddCandidateAddress(bdaddr_t addr);
 	static std::vector<WiimoteDevicePtr> get_devices();
   private:
 	int m_recvFd;

--- a/src/input/api/Wiimote/l2cap/L2CapWiimote.h
+++ b/src/input/api/Wiimote/l2cap/L2CapWiimote.h
@@ -12,6 +12,7 @@ class L2CapWiimote : public WiimoteDevice
 	std::optional<std::vector<uint8>> read_data() override;
 	bool operator==(WiimoteDevice& o) const override;
 
+	static void AddCandidateAddresses(const std::vector<bdaddr_t>& addrs);
 	static std::vector<WiimoteDevicePtr> get_devices();
   private:
 	int m_recvFd;


### PR DESCRIPTION
Requires Bluez.

This supports 3rd-party Wiimotes that are "invisible to scans"

Pairing a controller is done through the `Pair Wii or Wii U Controller` button dialog. The pairing is temporary, and will only last as long as Cemu is open. 

If the controller is disconnected while Cemu is open, it can be reconnected by putting the controller into sync mode. You do not need to click `Pair Wii or Wii U Controller` again.

~~At the moment not recommended to merge, disconnecting the controller after pairing causes hitching every 2 seconds because `connect` takes too long to timeout.~~ Fixed by https://github.com/cemu-project/Cemu/pull/1353/commits/ae2f5d23b32c547b63c020dacac5c1f3fed8bf2c