### PR TITLE
imgui: Makes the window edges rounded

### DIFF
--- a/src/imgui/imgui_extension.cpp
+++ b/src/imgui/imgui_extension.cpp
@@ -127,6 +127,7 @@ void ImGui_UpdateWindowInformation(bool mainWindow)
 	ImGuiIO& io = ImGui::GetIO();
 	io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
 	io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0f); // Makes the window edges rounded
 #if BOOST_OS_WINDOWS
 	io.ImeWindowHandle = mainWindow ? g_window_info.window_main.hwnd : g_window_info.window_pad.hwnd;
 #else


### PR DESCRIPTION
I added the fact that all imgui popups have rounded edges.
I find that it gives a more modern look.

Without rounded edges:
![image](https://github.com/user-attachments/assets/bbe03bfe-46a1-469a-ae3f-dd8fcc24cea1)
![image](https://github.com/user-attachments/assets/f8b8a3b8-6f21-4d26-8772-047a15c0d67e)

With rounded edges:
![image](https://github.com/user-attachments/assets/8c201f40-8c7f-4707-b05b-9f0d24e833e7)
![image](https://github.com/user-attachments/assets/b2d6d47d-14bd-4dd8-a792-6ad85543d303)