### PR TITLE
nsyshid: Emulate Dimensions Toypad

### DIFF
--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -465,6 +465,8 @@ add_library(CemuCafe
   OS/libs/nsyshid/BackendLibusb.h
   OS/libs/nsyshid/BackendWindowsHID.cpp
   OS/libs/nsyshid/BackendWindowsHID.h
+  OS/libs/nsyshid/Dimensions.cpp
+  OS/libs/nsyshid/Dimensions.h
   OS/libs/nsyshid/Infinity.cpp
   OS/libs/nsyshid/Infinity.h
   OS/libs/nsyshid/Skylander.cpp

--- a/src/Cafe/OS/libs/nsyshid/BackendEmulated.cpp
+++ b/src/Cafe/OS/libs/nsyshid/BackendEmulated.cpp
@@ -1,4 +1,6 @@
 #include "BackendEmulated.h"
+
+#include "Dimensions.h"
 #include "Infinity.h"
 #include "Skylander.h"
 #include "config/CemuConfig.h"
@@ -31,6 +33,13 @@ namespace nsyshid::backend::emulated
 			cemuLog_logDebug(LogType::Force, "Attaching Emulated Base");
 			// Add Infinity Base
 			auto device = std::make_shared<InfinityBaseDevice>();
+			AttachDevice(device);
+		}
+		if (GetConfig().emulated_usb_devices.emulate_dimensions_toypad && !FindDeviceById(0x0E6F, 0x0241))
+		{
+			cemuLog_logDebug(LogType::Force, "Attaching Emulated Toypad");
+			// Add Dimensions Toypad
+			auto device = std::make_shared<DimensionsToypadDevice>();
 			AttachDevice(device);
 		}
 	}

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
@@ -516,6 +516,7 @@ namespace nsyshid
 			}
 			else if (!m_figureAddedRemovedResponses.empty() && m_isAwake)
 			{
+				std::lock_guard lock(m_dimensionsMutex);
 				response = m_figureAddedRemovedResponses.front();
 				m_figureAddedRemovedResponses.pop();
 				responded = true;

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
@@ -1,0 +1,1076 @@
+#include "Dimensions.h"
+
+#include "nsyshid.h"
+#include "Backend.h"
+
+#include "Common/FileStream.h"
+
+#include <array>
+#include <random>
+
+namespace nsyshid
+{
+	static constexpr std::array<uint8, 16> COMMAND_KEY = {0x55, 0xFE, 0xF6, 0xB0, 0x62, 0xBF, 0x0B, 0x41,
+														  0xC9, 0xB3, 0x7C, 0xB4, 0x97, 0x3E, 0x29, 0x7B};
+
+	static constexpr std::array<uint8, 17> CHAR_CONSTANT = {0xB7, 0xD5, 0xD7, 0xE6, 0xE7, 0xBA, 0x3C, 0xA8,
+															0xD8, 0x75, 0x47, 0x68, 0xCF, 0x23, 0xE9, 0xFE, 0xAA};
+
+	static constexpr std::array<uint8, 25> PWD_CONSTANT = {0x28, 0x63, 0x29, 0x20, 0x43, 0x6F, 0x70, 0x79,
+														   0x72, 0x69, 0x67, 0x68, 0x74, 0x20, 0x4C, 0x45,
+														   0x47, 0x4F, 0x20, 0x32, 0x30, 0x31, 0x34, 0xAA, 0xAA};
+
+	DimensionsUSB g_dimensionstoypad;
+
+	const std::map<const uint32, const char*> s_listMinis = {
+		{0, "Blank Tag"},
+		{1, "Batman"},
+		{2, "Gandalf"},
+		{3, "Wyldstyle"},
+		{4, "Aquaman"},
+		{5, "Bad Cop"},
+		{6, "Bane"},
+		{7, "Bart Simpson"},
+		{8, "Benny"},
+		{9, "Chell"},
+		{10, "Cole"},
+		{11, "Cragger"},
+		{12, "Cyborg"},
+		{13, "Cyberman"},
+		{14, "Doc Brown"},
+		{15, "The Doctor"},
+		{16, "Emmet"},
+		{17, "Eris"},
+		{18, "Gimli"},
+		{19, "Gollum"},
+		{20, "Harley Quinn"},
+		{21, "Homer Simpson"},
+		{22, "Jay"},
+		{23, "Joker"},
+		{24, "Kai"},
+		{25, "ACU Trooper"},
+		{26, "Gamer Kid"},
+		{27, "Krusty the Clown"},
+		{28, "Laval"},
+		{29, "Legolas"},
+		{30, "Lloyd"},
+		{31, "Marty McFly"},
+		{32, "Nya"},
+		{33, "Owen Grady"},
+		{34, "Peter Venkman"},
+		{35, "Slimer"},
+		{36, "Scooby-Doo"},
+		{37, "Sensei Wu"},
+		{38, "Shaggy"},
+		{39, "Stay Puft"},
+		{40, "Superman"},
+		{41, "Unikitty"},
+		{42, "Wicked Witch of the West"},
+		{43, "Wonder Woman"},
+		{44, "Zane"},
+		{45, "Green Arrow"},
+		{46, "Supergirl"},
+		{47, "Abby Yates"},
+		{48, "Finn the Human"},
+		{49, "Ethan Hunt"},
+		{50, "Lumpy Space Princess"},
+		{51, "Jake the Dog"},
+		{52, "Harry Potter"},
+		{53, "Lord Voldemort"},
+		{54, "Michael Knight"},
+		{55, "B.A. Baracus"},
+		{56, "Newt Scamander"},
+		{57, "Sonic the Hedgehog"},
+		{58, "Future Update (unreleased)"},
+		{59, "Gizmo"},
+		{60, "Stripe"},
+		{61, "E.T."},
+		{62, "Tina Goldstein"},
+		{63, "Marceline the Vampire Queen"},
+		{64, "Batgirl"},
+		{65, "Robin"},
+		{66, "Sloth"},
+		{67, "Hermione Granger"},
+		{68, "Chase McCain"},
+		{69, "Excalibur Batman"},
+		{70, "Raven"},
+		{71, "Beast Boy"},
+		{72, "Betelgeuse"},
+		{73, "Lord Vortech (unreleased)"},
+		{74, "Blossom"},
+		{75, "Bubbles"},
+		{76, "Buttercup"},
+		{77, "Starfire"},
+		{78, "World 15 (unreleased)"},
+		{79, "World 16 (unreleased)"},
+		{80, "World 17 (unreleased)"},
+		{81, "World 18 (unreleased)"},
+		{82, "World 19 (unreleased)"},
+		{83, "World 20 (unreleased)"},
+		{768, "Unknown 768"},
+		{769, "Supergirl Red Lantern"},
+		{770, "Unknown 770"}};
+
+	const std::map<const uint32, const char*> s_listTokens = {
+		{1000, "Police Car"},
+		{1001, "Aerial Squad Car"},
+		{1002, "Missile Striker"},
+		{1003, "Gravity Sprinter"},
+		{1004, "Street Shredder"},
+		{1005, "Sky Clobberer"},
+		{1006, "Batmobile"},
+		{1007, "Batblaster"},
+		{1008, "Sonic Batray"},
+		{1009, "Benny's Spaceship"},
+		{1010, "Lasercraft"},
+		{1011, "The Annihilator"},
+		{1012, "DeLorean Time Machine"},
+		{1013, "Electric Time Machine"},
+		{1014, "Ultra Time Machine"},
+		{1015, "Hoverboard"},
+		{1016, "Cyclone Board"},
+		{1017, "Ultimate Hoverjet"},
+		{1018, "Eagle Interceptor"},
+		{1019, "Eagle Sky Blazer"},
+		{1020, "Eagle Swoop Diver"},
+		{1021, "Swamp Skimmer"},
+		{1022, "Cragger's Fireship"},
+		{1023, "Croc Command Sub"},
+		{1024, "Cyber-Guard"},
+		{1025, "Cyber-Wrecker"},
+		{1026, "Laser Robot Walker"},
+		{1027, "K-9"},
+		{1028, "K-9 Ruff Rover"},
+		{1029, "K-9 Laser Cutter"},
+		{1030, "TARDIS"},
+		{1031, "Laser-Pulse TARDIS"},
+		{1032, "Energy-Burst TARDIS"},
+		{1033, "Emmet's Excavator"},
+		{1034, "Destroy Dozer"},
+		{1035, "Destruct-o-Mech"},
+		{1036, "Winged Monkey"},
+		{1037, "Battle Monkey"},
+		{1038, "Commander Monkey"},
+		{1039, "Axe Chariot"},
+		{1040, "Axe Hurler"},
+		{1041, "Soaring Chariot"},
+		{1042, "Shelob the Great"},
+		{1043, "8-Legged Stalker"},
+		{1044, "Poison Slinger"},
+		{1045, "Homer's Car"},
+		{1047, "The SubmaHomer"},
+		{1046, "The Homercraft"},
+		{1048, "Taunt-o-Vision"},
+		{1050, "The MechaHomer"},
+		{1049, "Blast Cam"},
+		{1051, "Velociraptor"},
+		{1053, "Venom Raptor"},
+		{1052, "Spike Attack Raptor"},
+		{1054, "Gyrosphere"},
+		{1055, "Sonic Beam Gyrosphere"},
+		{1056, " Gyrosphere"},
+		{1057, "Clown Bike"},
+		{1058, "Cannon Bike"},
+		{1059, "Anti-Gravity Rocket Bike"},
+		{1060, "Mighty Lion Rider"},
+		{1061, "Lion Blazer"},
+		{1062, "Fire Lion"},
+		{1063, "Arrow Launcher"},
+		{1064, "Seeking Shooter"},
+		{1065, "Triple Ballista"},
+		{1066, "Mystery Machine"},
+		{1067, "Mystery Tow & Go"},
+		{1068, "Mystery Monster"},
+		{1069, "Boulder Bomber"},
+		{1070, "Boulder Blaster"},
+		{1071, "Cyclone Jet"},
+		{1072, "Storm Fighter"},
+		{1073, "Lightning Jet"},
+		{1074, "Electro-Shooter"},
+		{1075, "Blade Bike"},
+		{1076, "Flight Fire Bike"},
+		{1077, "Blades of Fire"},
+		{1078, "Samurai Mech"},
+		{1079, "Samurai Shooter"},
+		{1080, "Soaring Samurai Mech"},
+		{1081, "Companion Cube"},
+		{1082, "Laser Deflector"},
+		{1083, "Gold Heart Emitter"},
+		{1084, "Sentry Turret"},
+		{1085, "Turret Striker"},
+		{1086, "Flight Turret Carrier"},
+		{1087, "Scooby Snack"},
+		{1088, "Scooby Fire Snack"},
+		{1089, "Scooby Ghost Snack"},
+		{1090, "Cloud Cuckoo Car"},
+		{1091, "X-Stream Soaker"},
+		{1092, "Rainbow Cannon"},
+		{1093, "Invisible Jet"},
+		{1094, "Laser Shooter"},
+		{1095, "Torpedo Bomber"},
+		{1096, "NinjaCopter"},
+		{1097, "Glaciator"},
+		{1098, "Freeze Fighter"},
+		{1099, "Travelling Time Train"},
+		{1100, "Flight Time Train"},
+		{1101, "Missile Blast Time Train"},
+		{1102, "Aqua Watercraft"},
+		{1103, "Seven Seas Speeder"},
+		{1104, "Trident of Fire"},
+		{1105, "Drill Driver"},
+		{1106, "Bane Dig 'n' Drill"},
+		{1107, "Bane Drill 'n' Blast"},
+		{1108, "Quinn Mobile"},
+		{1109, "Quinn Ultra Racer"},
+		{1110, "Missile Launcher"},
+		{1111, "The Joker's Chopper"},
+		{1112, "Mischievous Missile Blaster"},
+		{1113, "Lock 'n' Laser Jet"},
+		{1114, "Hover Pod"},
+		{1115, "Krypton Striker"},
+		{1116, "Super Stealth Pod"},
+		{1117, "Dalek"},
+		{1118, "Fire 'n' Ride Dalek"},
+		{1119, "Silver Shooter Dalek"},
+		{1120, "Ecto-1"},
+		{1121, "Ecto-1 Blaster"},
+		{1122, "Ecto-1 Water Diver"},
+		{1123, "Ghost Trap"},
+		{1124, "Ghost Stun 'n' Trap"},
+		{1125, "Proton Zapper"},
+		{1126, "Unknown"},
+		{1127, "Unknown"},
+		{1128, "Unknown"},
+		{1129, "Unknown"},
+		{1130, "Unknown"},
+		{1131, "Unknown"},
+		{1132, "Lloyd's Golden Dragon"},
+		{1133, "Sword Projector Dragon"},
+		{1134, "Unknown"},
+		{1135, "Unknown"},
+		{1136, "Unknown"},
+		{1137, "Unknown"},
+		{1138, "Unknown"},
+		{1139, "Unknown"},
+		{1140, "Unknown"},
+		{1141, "Unknown"},
+		{1142, "Unknown"},
+		{1143, "Unknown"},
+		{1144, "Mega Flight Dragon"},
+		{1145, "Unknown"},
+		{1146, "Unknown"},
+		{1147, "Unknown"},
+		{1148, "Unknown"},
+		{1149, "Unknown"},
+		{1150, "Unknown"},
+		{1151, "Unknown"},
+		{1152, "Unknown"},
+		{1153, "Unknown"},
+		{1154, "Unknown"},
+		{1155, "Flying White Dragon"},
+		{1156, "Golden Fire Dragon"},
+		{1157, "Ultra Destruction Dragon"},
+		{1158, "Arcade Machine"},
+		{1159, "8-Bit Shooter"},
+		{1160, "The Pixelator"},
+		{1161, "G-6155 Spy Hunter"},
+		{1162, "Interdiver"},
+		{1163, "Aerial Spyhunter"},
+		{1164, "Slime Shooter"},
+		{1165, "Slime Exploder"},
+		{1166, "Slime Streamer"},
+		{1167, "Terror Dog"},
+		{1168, "Terror Dog Destroyer"},
+		{1169, "Soaring Terror Dog"},
+		{1170, "Ancient Psychic Tandem War Elephant"},
+		{1171, "Cosmic Squid"},
+		{1172, "Psychic Submarine"},
+		{1173, "BMO"},
+		{1174, "DOGMO"},
+		{1175, "SNAKEMO"},
+		{1176, "Jakemobile"},
+		{1177, "Snail Dude Jake"},
+		{1178, "Hover Jake"},
+		{1179, "Lumpy Car"},
+		{1181, "Lumpy Land Whale"},
+		{1180, "Lumpy Truck"},
+		{1182, "Lunatic Amp"},
+		{1183, "Shadow Scorpion"},
+		{1184, "Heavy Metal Monster"},
+		{1185, "B.A.'s Van"},
+		{1186, "Fool Smasher"},
+		{1187, "Pain Plane"},
+		{1188, "Phone Home"},
+		{1189, "Mobile Uplink"},
+		{1190, "Super-Charged Satellite"},
+		{1191, "Niffler"},
+		{1192, "Sinister Scorpion"},
+		{1193, "Vicious Vulture"},
+		{1194, "Swooping Evil"},
+		{1195, "Brutal Bloom"},
+		{1196, "Crawling Creeper"},
+		{1197, "Ecto-1 (2016)"},
+		{1198, "Ectozer"},
+		{1199, "PerfEcto"},
+		{1200, "Flash 'n' Finish"},
+		{1201, "Rampage Record Player"},
+		{1202, "Stripe's Throne"},
+		{1203, "R.C. Racer"},
+		{1204, "Gadget-O-Matic"},
+		{1205, "Scarlet Scorpion"},
+		{1206, "Hogwarts Express"},
+		{1208, "Steam Warrior"},
+		{1207, "Soaring Steam Plane"},
+		{1209, "Enchanted Car"},
+		{1210, "Shark Sub"},
+		{1211, "Monstrous Mouth"},
+		{1212, "IMF Scrambler"},
+		{1213, "Shock Cycle"},
+		{1214, "IMF Covert Jet"},
+		{1215, "IMF Sports Car"},
+		{1216, "IMF Tank"},
+		{1217, "IMF Splorer"},
+		{1218, "Sonic Speedster"},
+		{1219, "Blue Typhoon"},
+		{1220, "Moto Bug"},
+		{1221, "The Tornado"},
+		{1222, "Crabmeat"},
+		{1223, "Eggcatcher"},
+		{1224, "K.I.T.T."},
+		{1225, "Goliath Armored Semi"},
+		{1226, "K.I.T.T. Jet"},
+		{1227, "Police Helicopter"},
+		{1228, "Police Hovercraft"},
+		{1229, "Police Plane"},
+		{1230, "Bionic Steed"},
+		{1231, "Bat-Raptor"},
+		{1232, "Ultrabat"},
+		{1233, "Batwing"},
+		{1234, "The Black Thunder"},
+		{1235, "Bat-Tank"},
+		{1236, "Skeleton Organ"},
+		{1237, "Skeleton Jukebox"},
+		{1238, "Skele-Turkey"},
+		{1239, "One-Eyed Willy's Pirate Ship"},
+		{1240, "Fanged Fortune"},
+		{1241, "Inferno Cannon"},
+		{1242, "Buckbeak"},
+		{1243, "Giant Owl"},
+		{1244, "Fierce Falcon"},
+		{1245, "Saturn's Sandworm"},
+		{1247, "Haunted Vacuum"},
+		{1246, "Spooky Spider"},
+		{1248, "PPG Smartphone"},
+		{1249, "PPG Hotline"},
+		{1250, "Powerpuff Mag-Net"},
+		{1253, "Mega Blast Bot"},
+		{1251, "Ka-Pow Cannon"},
+		{1252, "Slammin' Guitar"},
+		{1254, "Octi"},
+		{1255, "Super Skunk"},
+		{1256, "Sonic Squid"},
+		{1257, "T-Car"},
+		{1258, "T-Forklift"},
+		{1259, "T-Plane"},
+		{1260, "Spellbook of Azarath"},
+		{1261, "Raven Wings"},
+		{1262, "Giant Hand"},
+		{1263, "Titan Robot"},
+		{1264, "T-Rocket"},
+		{1265, "Robot Retriever"}};
+
+	DimensionsToypadDevice::DimensionsToypadDevice()
+		: Device(0x0E6F, 0x0241, 1, 2, 0)
+	{
+		m_IsOpened = false;
+	}
+
+	bool DimensionsToypadDevice::Open()
+	{
+		if (!IsOpened())
+		{
+			m_IsOpened = true;
+		}
+		return true;
+	}
+
+	void DimensionsToypadDevice::Close()
+	{
+		if (IsOpened())
+		{
+			m_IsOpened = false;
+		}
+	}
+
+	bool DimensionsToypadDevice::IsOpened()
+	{
+		return m_IsOpened;
+	}
+
+	Device::ReadResult DimensionsToypadDevice::Read(ReadMessage* message)
+	{
+		memcpy(message->data, g_dimensionstoypad.GetStatus().data(), message->length);
+		message->bytesRead = message->length;
+		return Device::ReadResult::Success;
+	}
+
+	Device::WriteResult DimensionsToypadDevice::Write(WriteMessage* message)
+	{
+		g_dimensionstoypad.SendCommand(message->data, message->length);
+		message->bytesWritten = message->length;
+		return Device::WriteResult::Success;
+	}
+
+	bool DimensionsToypadDevice::GetDescriptor(uint8 descType,
+											   uint8 descIndex,
+											   uint8 lang,
+											   uint8* output,
+											   uint32 outputMaxLength)
+	{
+		uint8 configurationDescriptor[0x29];
+
+		uint8* currentWritePtr;
+
+		// configuration descriptor
+		currentWritePtr = configurationDescriptor + 0;
+		*(uint8*)(currentWritePtr + 0) = 9;			// bLength
+		*(uint8*)(currentWritePtr + 1) = 2;			// bDescriptorType
+		*(uint16be*)(currentWritePtr + 2) = 0x0029; // wTotalLength
+		*(uint8*)(currentWritePtr + 4) = 1;			// bNumInterfaces
+		*(uint8*)(currentWritePtr + 5) = 1;			// bConfigurationValue
+		*(uint8*)(currentWritePtr + 6) = 0;			// iConfiguration
+		*(uint8*)(currentWritePtr + 7) = 0x80;		// bmAttributes
+		*(uint8*)(currentWritePtr + 8) = 0xFA;		// MaxPower
+		currentWritePtr = currentWritePtr + 9;
+		// configuration descriptor
+		*(uint8*)(currentWritePtr + 0) = 9;	   // bLength
+		*(uint8*)(currentWritePtr + 1) = 0x04; // bDescriptorType
+		*(uint8*)(currentWritePtr + 2) = 0;	   // bInterfaceNumber
+		*(uint8*)(currentWritePtr + 3) = 0;	   // bAlternateSetting
+		*(uint8*)(currentWritePtr + 4) = 2;	   // bNumEndpoints
+		*(uint8*)(currentWritePtr + 5) = 3;	   // bInterfaceClass
+		*(uint8*)(currentWritePtr + 6) = 0;	   // bInterfaceSubClass
+		*(uint8*)(currentWritePtr + 7) = 0;	   // bInterfaceProtocol
+		*(uint8*)(currentWritePtr + 8) = 0;	   // iInterface
+		currentWritePtr = currentWritePtr + 9;
+		// configuration descriptor
+		*(uint8*)(currentWritePtr + 0) = 9;			// bLength
+		*(uint8*)(currentWritePtr + 1) = 0x21;		// bDescriptorType
+		*(uint16be*)(currentWritePtr + 2) = 0x0111; // bcdHID
+		*(uint8*)(currentWritePtr + 4) = 0x00;		// bCountryCode
+		*(uint8*)(currentWritePtr + 5) = 0x01;		// bNumDescriptors
+		*(uint8*)(currentWritePtr + 6) = 0x22;		// bDescriptorType
+		*(uint16be*)(currentWritePtr + 7) = 0x001D; // wDescriptorLength
+		currentWritePtr = currentWritePtr + 9;
+		// endpoint descriptor 1
+		*(uint8*)(currentWritePtr + 0) = 7;		  // bLength
+		*(uint8*)(currentWritePtr + 1) = 0x05;	  // bDescriptorType
+		*(uint8*)(currentWritePtr + 2) = 0x81;	  // bEndpointAddress
+		*(uint8*)(currentWritePtr + 3) = 0x03;	  // bmAttributes
+		*(uint16be*)(currentWritePtr + 4) = 0x40; // wMaxPacketSize
+		*(uint8*)(currentWritePtr + 6) = 0x01;	  // bInterval
+		currentWritePtr = currentWritePtr + 7;
+		// endpoint descriptor 2
+		*(uint8*)(currentWritePtr + 0) = 7;		  // bLength
+		*(uint8*)(currentWritePtr + 1) = 0x05;	  // bDescriptorType
+		*(uint8*)(currentWritePtr + 1) = 0x02;	  // bEndpointAddress
+		*(uint8*)(currentWritePtr + 2) = 0x03;	  // bmAttributes
+		*(uint16be*)(currentWritePtr + 3) = 0x40; // wMaxPacketSize
+		*(uint8*)(currentWritePtr + 5) = 0x01;	  // bInterval
+		currentWritePtr = currentWritePtr + 7;
+
+		cemu_assert_debug((currentWritePtr - configurationDescriptor) == 0x29);
+
+		memcpy(output, configurationDescriptor,
+			   std::min<uint32>(outputMaxLength, sizeof(configurationDescriptor)));
+		return true;
+	}
+
+	bool DimensionsToypadDevice::SetProtocol(uint8 ifIndex, uint8 protocol)
+	{
+		cemuLog_log(LogType::Force, "Toypad Protocol");
+		return true;
+	}
+
+	bool DimensionsToypadDevice::SetReport(ReportMessage* message)
+	{
+		cemuLog_log(LogType::Force, "Toypad Report");
+		return true;
+	}
+
+	std::array<uint8, 32> DimensionsUSB::GetStatus()
+	{
+		std::array<uint8, 32> response = {};
+
+		bool responded = false;
+		do
+		{
+			if (!m_figureAddedRemovedResponses.empty())
+			{
+				memcpy(response.data(), m_figureAddedRemovedResponses.front().data(),
+					   0x20);
+				m_figureAddedRemovedResponses.pop();
+				responded = true;
+			}
+			else if (!m_queries.empty())
+			{
+				memcpy(response.data(), m_queries.front().data(), 0x20);
+				m_queries.pop();
+				responded = true;
+			}
+			else
+			{
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			}
+		}
+		while (responded == false);
+		return response;
+	}
+
+	void DimensionsUSB::SendCommand(uint8* buf, sint32 originalLength)
+	{
+		const uint8 command = buf[2];
+		const uint8 sequence = buf[3];
+
+		std::array<uint8, 32> q_result{};
+
+		switch (command)
+		{
+		case 0xB0: // Wake
+		{
+			// Consistent device response to the wake command
+			q_result = {0x55, 0x0e, 0x01, 0x28, 0x63, 0x29,
+						0x20, 0x4c, 0x45, 0x47, 0x4f, 0x20,
+						0x32, 0x30, 0x31, 0x34, 0x46};
+			break;
+		}
+		case 0xB1: // Seed
+		{
+			// Initialise a random number generator using the seed provided
+			g_dimensionstoypad.GenerateRandomNumber(&buf[4], sequence, q_result);
+			break;
+		}
+		case 0xB3: // Challenge
+		{
+			// Get the next number in the sequence based on the RNG from 0xB1 command
+			g_dimensionstoypad.GetChallengeResponse(&buf[4], sequence, q_result);
+			break;
+		}
+		case 0xC0: // Color
+		case 0xC1: // Get Pad Color
+		case 0xC2: // Fade
+		case 0xC3: // Flash
+		case 0xC4: // Fade Random
+		case 0xC6: // Fade All
+		case 0xC7: // Flash All
+		case 0xC8: // Color All
+		{
+			// Send a blank response to acknowledge color has been sent to toypad
+			q_result = {0x55, 0x01, sequence};
+			q_result[3] = GenerateChecksum(q_result, 3);
+			break;
+		}
+		case 0xD2: // Read
+		{
+			// Read 4 pages from the figure at index (buf[4]), starting with page buf[5]
+			g_dimensionstoypad.QueryBlock(buf[4], buf[5], q_result, sequence);
+			break;
+		}
+		case 0xD3: // Write
+		{
+			// Write 4 bytes to page buf[5] to the figure at index buf[4]
+			g_dimensionstoypad.WriteBlock(buf[4], buf[5], &buf[6], q_result, sequence);
+			break;
+		}
+		case 0xD4: // Model
+		{
+			// Get the model id of the figure at index buf[4]
+			g_dimensionstoypad.GetModel(&buf[4], sequence, q_result);
+			break;
+		}
+		case 0xD0: // Tag List
+		case 0xE1: // PWD
+		case 0xE5: // Active
+		case 0xFF: // LEDS Query
+		{
+			// Further investigation required
+			cemuLog_log(LogType::Force, "Unimplemented LD Function: {:x}", command);
+			break;
+		}
+		default:
+		{
+			cemuLog_log(LogType::Force, "Unknown LD Function: {:x}", command);
+			break;
+		}
+		}
+
+		m_queries.push(q_result);
+	}
+
+	uint32 DimensionsUSB::LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index)
+	{
+		std::lock_guard lock(m_dimensionsMutex);
+		const uint32 id = GetFigureId(buf);
+
+		DimensionsMini& figure = GetFigureByIndex(index);
+		figure.dimFile = std::move(file);
+		figure.id = id;
+		figure.pad = pad;
+		figure.index = index + 1;
+		memcpy(figure.data.data(), buf.data(), buf.size());
+		// When a figure is added to the toypad, respond to the game with the pad they were added to, their index,
+		// the direction (0x00 in byte 6 for added) and their UID
+		std::array<uint8, 32> figureChangeResponse = {0x56, 0x0b, figure.pad, 0x00, figure.index, 0x00, buf[0], buf[1], buf[2], buf[4], buf[5], buf[6], buf[7]};
+		figureChangeResponse[13] = GenerateChecksum(figureChangeResponse, 13);
+		m_figureAddedRemovedResponses.push(figureChangeResponse);
+		return id;
+	}
+
+	bool DimensionsUSB::RemoveFigure(uint8 pad, uint8 index)
+	{
+		std::lock_guard lock(m_dimensionsMutex);
+		DimensionsMini& figure = GetFigureByIndex(index);
+		if (figure.index == 255)
+		{
+			return false;
+		}
+		// When a figure is removed from the toypad, respond to the game with the pad they were removed from, their index,
+		// the direction (0x01 in byte 6 for removed) and their UID
+		std::array<uint8, 32> figureChangeResponse = {0x56, 0x0b, figure.pad, 0x00, figure.index, 0x01,
+													  figure.data[0], figure.data[1], figure.data[2],
+													  figure.data[4], figure.data[5], figure.data[6], figure.data[7]};
+		figure.Save();
+		figure.dimFile.reset();
+		figure.index = 255;
+		figure.pad = 255;
+		figure.id = 0;
+		memcpy(&figureChangeResponse[6], figure.data.data(), 7);
+		figureChangeResponse[13] = GenerateChecksum(figureChangeResponse, 13);
+		m_figureAddedRemovedResponses.push(figureChangeResponse);
+		return true;
+	}
+
+	bool DimensionsUSB::CreateFigure(fs::path pathName, uint32 id)
+	{
+		FileStream* dimFile(FileStream::createFile2(pathName));
+		if (!dimFile)
+		{
+			return false;
+		}
+		std::array<uint8, 0x2D * 0x04> fileData{};
+		RandomUID(fileData.data());
+		fileData[7] = id & 0xFF;
+
+		std::array<uint8, 7> uid = {fileData[0], fileData[1], fileData[2], fileData[4], fileData[5], fileData[6], fileData[7]};
+
+		// Only characters are created with their ID encrypted and stored in pages 36 and 37,
+		// as well as a password stored in page 43. Blank tags have their information populated
+		// by the game when it calls the write_block command.
+		if (id != 0)
+		{
+			const std::array<uint8, 16> figureKey = GenerateFigureKey(fileData);
+
+			std::array<uint8, 8> valueToEncrypt = {uint8(id & 0xFF), uint8((id >> 8) & 0xFF), uint8((id >> 16) & 0xFF), uint8((id >> 24) & 0xFF),
+												   uint8(id & 0xFF), uint8((id >> 8) & 0xFF), uint8((id >> 16) & 0xFF), uint8((id >> 24) & 0xFF)};
+
+			std::array<uint8, 8> encrypted = Encrypt(valueToEncrypt.data(), figureKey);
+
+			std::memcpy(&fileData[36 * 4], &encrypted[0], 4);
+			std::memcpy(&fileData[37 * 4], &encrypted[4], 4);
+
+			std::memcpy(&fileData[43 * 4], PWDGenerate(fileData).data(), 4);
+		}
+		else
+		{
+			// Page 38 is used as verification for blank tags
+			fileData[(38 * 4) + 1] = 1;
+		}
+
+		if (fileData.size() != dimFile->writeData(fileData.data(), fileData.size()))
+		{
+			delete dimFile;
+			return false;
+		}
+		delete dimFile;
+		return true;
+	}
+
+	void DimensionsUSB::GenerateRandomNumber(uint8* buf, uint8 sequence,
+											 std::array<uint8, 32>& replyBuf)
+	{
+		// Decrypt payload into an 8 byte array
+		std::array<uint8, 8> value = Decrypt(buf, std::nullopt);
+		// Seed is the first 4 bytes (little endian) of the decrypted payload
+		uint32 seed = uint32(value[3]) << 24 | uint32(value[2]) << 16 | uint32(value[1]) << 8 | uint32(value[0]);
+		// Confirmation is the second 4 bytes (big endian) of the decrypted payload
+		uint32 conf = uint32(value[4]) << 24 | uint32(value[5]) << 16 | uint32(value[6]) << 8 | uint32(value[7]);
+		// Initialize rng using the seed from decrypted payload
+		InitializeRNG(seed);
+		// Encrypt 8 bytes, first 4 bytes is the decrypted confirmation from payload, 2nd 4 bytes are blank
+		std::array<uint8, 8> valueToEncrypt = {value[4], value[5], value[6], value[7], 0, 0, 0, 0};
+		std::array<uint8, 8> encrypted = Encrypt(valueToEncrypt.data(), std::nullopt);
+		replyBuf[0] = 0x55;
+		replyBuf[1] = 0x09;
+		replyBuf[2] = sequence;
+		// Copy encrypted value to response data
+		memcpy(&replyBuf[3], encrypted.data(), encrypted.size());
+		replyBuf[11] = GenerateChecksum(replyBuf, 11);
+	}
+
+	void DimensionsUSB::GetChallengeResponse(uint8* buf, uint8 sequence,
+											 std::array<uint8, 32>& replyBuf)
+	{
+		// Decrypt payload into an 8 byte array
+		std::array<uint8, 8> value = Decrypt(buf, std::nullopt);
+		// Confirmation is the first 4 bytes of the decrypted payload
+		uint32 conf = uint32(value[0]) << 24 | uint32(value[1]) << 16 | uint32(value[2]) << 8 | uint32(value[3]);
+		// Generate next random number based on RNG
+		uint32 nextRandom = GetNext();
+		// Encrypt an 8 byte array, first 4 bytes are the next random number (little endian)
+		// followed by the confirmation from the decrypted payload
+		std::array<uint8, 8> valueToEncrypt = {uint8(nextRandom & 0xFF), uint8((nextRandom >> 8) & 0xFF),
+											   uint8((nextRandom >> 16) & 0xFF), uint8((nextRandom >> 24) & 0xFF),
+											   value[0], value[1], value[2], value[3]};
+		std::array<uint8, 8> encrypted = Encrypt(valueToEncrypt.data(), std::nullopt);
+		replyBuf[0] = 0x55;
+		replyBuf[1] = 0x09;
+		replyBuf[2] = sequence;
+		// Copy encrypted value to response data
+		memcpy(&replyBuf[3], encrypted.data(), encrypted.size());
+		replyBuf[11] = GenerateChecksum(replyBuf, 11);
+	}
+
+	void DimensionsUSB::InitializeRNG(uint32 seed)
+	{
+		m_randomA = 0xF1EA5EED;
+		m_randomB = seed;
+		m_randomC = seed;
+		m_randomD = seed;
+
+		for (int i = 0; i < 42; i++)
+		{
+			GetNext();
+		}
+	}
+
+	uint32 DimensionsUSB::GetNext()
+	{
+		uint32 e = m_randomA - std::rotl(m_randomB, 21);
+		m_randomA = m_randomB ^ std::rotl(m_randomC, 19);
+		m_randomB = m_randomC + std::rotl(m_randomD, 6);
+		m_randomC = m_randomD + e;
+		m_randomD = e + m_randomA;
+		return m_randomD;
+	}
+
+	std::array<uint8, 8> DimensionsUSB::Decrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key)
+	{
+		// Value to decrypt is separated in to two little endian 32 bit unsigned integers
+		uint32 dataOne = uint32(buf[3]) << 24 | uint32(buf[2]) << 16 | uint32(buf[1]) << 8 | uint32(buf[0]);
+		uint32 dataTwo = uint32(buf[7]) << 24 | uint32(buf[6]) << 16 | uint32(buf[5]) << 8 | uint32(buf[4]);
+
+		// Use the key as 4 32 bit little endian unsigned integers
+		uint32 keyOne;
+		uint32 keyTwo;
+		uint32 keyThree;
+		uint32 keyFour;
+
+		if (key)
+		{
+			keyOne = uint32(key.value()[3]) << 24 | uint32(key.value()[2]) << 16 | uint32(key.value()[1]) << 8 | uint32(key.value()[0]);
+			keyTwo = uint32(key.value()[7]) << 24 | uint32(key.value()[6]) << 16 | uint32(key.value()[5]) << 8 | uint32(key.value()[4]);
+			keyThree = uint32(key.value()[11]) << 24 | uint32(key.value()[10]) << 16 | uint32(key.value()[9]) << 8 | uint32(key.value()[8]);
+			keyFour = uint32(key.value()[15]) << 24 | uint32(key.value()[14]) << 16 | uint32(key.value()[13]) << 8 | uint32(key.value()[12]);
+		}
+		else
+		{
+			keyOne = uint32(COMMAND_KEY[3]) << 24 | uint32(COMMAND_KEY[2]) << 16 | uint32(COMMAND_KEY[1]) << 8 | uint32(COMMAND_KEY[0]);
+			keyTwo = uint32(COMMAND_KEY[7]) << 24 | uint32(COMMAND_KEY[6]) << 16 | uint32(COMMAND_KEY[5]) << 8 | uint32(COMMAND_KEY[4]);
+			keyThree = uint32(COMMAND_KEY[11]) << 24 | uint32(COMMAND_KEY[10]) << 16 | uint32(COMMAND_KEY[9]) << 8 | uint32(COMMAND_KEY[8]);
+			keyFour = uint32(COMMAND_KEY[15]) << 24 | uint32(COMMAND_KEY[14]) << 16 | uint32(COMMAND_KEY[13]) << 8 | uint32(COMMAND_KEY[12]);
+		}
+
+		uint32 sum = 0xC6EF3720;
+		uint32 delta = 0x9E3779B9;
+
+		for (int i = 0; i < 32; i++)
+		{
+			dataTwo -= (((dataOne << 4) + keyThree) ^ (dataOne + sum) ^ ((dataOne >> 5) + keyFour));
+			dataOne -= (((dataTwo << 4) + keyOne) ^ (dataTwo + sum) ^ ((dataTwo >> 5) + keyTwo));
+			sum -= delta;
+		}
+
+		cemu_assert(sum == 0);
+
+		std::array<uint8, 8> decrypted = {uint8(dataOne & 0xFF), uint8((dataOne >> 8) & 0xFF),
+										  uint8((dataOne >> 16) & 0xFF), uint8((dataOne >> 24) & 0xFF),
+										  uint8(dataTwo & 0xFF), uint8((dataTwo >> 8) & 0xFF),
+										  uint8((dataTwo >> 16) & 0xFF), uint8((dataTwo >> 24) & 0xFF)};
+		return decrypted;
+	}
+	std::array<uint8, 8> DimensionsUSB::Encrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key)
+	{
+		// Value to encrypt is separated in to two little endian 32 bit unsigned integers
+		uint32 dataOne = uint32(buf[3]) << 24 | uint32(buf[2]) << 16 | uint32(buf[1]) << 8 | uint32(buf[0]);
+		uint32 dataTwo = uint32(buf[7]) << 24 | uint32(buf[6]) << 16 | uint32(buf[5]) << 8 | uint32(buf[4]);
+
+		// Use the key as 4 32 bit little endian unsigned integers
+		uint32 keyOne;
+		uint32 keyTwo;
+		uint32 keyThree;
+		uint32 keyFour;
+
+		if (key)
+		{
+			keyOne = uint32(key.value()[3]) << 24 | uint32(key.value()[2]) << 16 | uint32(key.value()[1]) << 8 | uint32(key.value()[0]);
+			keyTwo = uint32(key.value()[7]) << 24 | uint32(key.value()[6]) << 16 | uint32(key.value()[5]) << 8 | uint32(key.value()[4]);
+			keyThree = uint32(key.value()[11]) << 24 | uint32(key.value()[10]) << 16 | uint32(key.value()[9]) << 8 | uint32(key.value()[8]);
+			keyFour = uint32(key.value()[15]) << 24 | uint32(key.value()[14]) << 16 | uint32(key.value()[13]) << 8 | uint32(key.value()[12]);
+		}
+		else
+		{
+			keyOne = uint32(COMMAND_KEY[3]) << 24 | uint32(COMMAND_KEY[2]) << 16 | uint32(COMMAND_KEY[1]) << 8 | uint32(COMMAND_KEY[0]);
+			keyTwo = uint32(COMMAND_KEY[7]) << 24 | uint32(COMMAND_KEY[6]) << 16 | uint32(COMMAND_KEY[5]) << 8 | uint32(COMMAND_KEY[4]);
+			keyThree = uint32(COMMAND_KEY[11]) << 24 | uint32(COMMAND_KEY[10]) << 16 | uint32(COMMAND_KEY[9]) << 8 | uint32(COMMAND_KEY[8]);
+			keyFour = uint32(COMMAND_KEY[15]) << 24 | uint32(COMMAND_KEY[14]) << 16 | uint32(COMMAND_KEY[13]) << 8 | uint32(COMMAND_KEY[12]);
+		}
+
+		uint32 sum = 0;
+		uint32 delta = 0x9E3779B9;
+
+		for (int i = 0; i < 32; i++)
+		{
+			sum += delta;
+			dataOne += (((dataTwo << 4) + keyOne) ^ (dataTwo + sum) ^ ((dataTwo >> 5) + keyTwo));
+			dataTwo += (((dataOne << 4) + keyThree) ^ (dataOne + sum) ^ ((dataOne >> 5) + keyFour));
+		}
+
+		cemu_assert(sum == 0xC6EF3720);
+
+		std::array<uint8, 8> encrypted = {uint8(dataOne & 0xFF), uint8((dataOne >> 8) & 0xFF),
+										  uint8((dataOne >> 16) & 0xFF), uint8((dataOne >> 24) & 0xFF),
+										  uint8(dataTwo & 0xFF), uint8((dataTwo >> 8) & 0xFF),
+										  uint8((dataTwo >> 16) & 0xFF), uint8((dataTwo >> 24) & 0xFF)};
+		return encrypted;
+	}
+
+	std::array<uint8, 16> DimensionsUSB::GenerateFigureKey(const std::array<uint8, 0x2D * 0x04>& buf)
+	{
+		std::array<uint8, 7> uid = {buf[0], buf[1], buf[2], buf[4], buf[5], buf[6], buf[7]};
+
+		uint32 scrambleA = Scramble(uid, 3);
+		uint32 scrambleB = Scramble(uid, 4);
+		uint32 scrambleC = Scramble(uid, 5);
+		uint32 scrambleD = Scramble(uid, 6);
+
+		return {uint8((scrambleA >> 24) & 0xFF), uint8((scrambleA >> 16) & 0xFF),
+				uint8((scrambleA >> 8) & 0xFF), uint8(scrambleA & 0xFF),
+				uint8((scrambleB >> 24) & 0xFF), uint8((scrambleB >> 16) & 0xFF),
+				uint8((scrambleB >> 8) & 0xFF), uint8(scrambleB & 0xFF),
+				uint8((scrambleC >> 24) & 0xFF), uint8((scrambleC >> 16) & 0xFF),
+				uint8((scrambleC >> 8) & 0xFF), uint8(scrambleC & 0xFF),
+				uint8((scrambleD >> 24) & 0xFF), uint8((scrambleD >> 16) & 0xFF),
+				uint8((scrambleD >> 8) & 0xFF), uint8(scrambleD & 0xFF)};
+	}
+
+	uint32 DimensionsUSB::Scramble(const std::array<uint8, 7>& uid, uint8 count)
+	{
+		std::vector<uint8> toScramble;
+		toScramble.reserve(uid.size() + CHAR_CONSTANT.size());
+		for (uint8 x : uid)
+		{
+			toScramble.push_back(x);
+		}
+		for (uint8 c : CHAR_CONSTANT)
+		{
+			toScramble.push_back(c);
+		}
+		toScramble[(count * 4) - 1] = 0xaa;
+
+		std::array<uint8, 4> randomized = DimensionsRandomize(toScramble, count);
+
+		return uint32(randomized[0]) << 24 | uint32(randomized[1]) << 16 | uint32(randomized[2]) << 8 | uint32(randomized[3]);
+	}
+
+	std::array<uint8, 4> DimensionsUSB::PWDGenerate(const std::array<uint8, 0x2D * 0x04>& buf)
+	{
+		std::array<uint8, 7> uid = {buf[0], buf[1], buf[2], buf[4], buf[5], buf[6], buf[7]};
+
+		std::vector<uint8> pwdCalc = {PWD_CONSTANT.begin(), PWD_CONSTANT.end() - 1};
+		for (uint8 i = 0; i < uid.size(); i++)
+		{
+			pwdCalc.insert(pwdCalc.begin() + i, uid[i]);
+		}
+
+		return DimensionsRandomize(pwdCalc, 8);
+	}
+
+	std::array<uint8, 4> DimensionsUSB::DimensionsRandomize(const std::vector<uint8> key, uint8 count)
+	{
+		uint32 scrambled = 0;
+		for (uint8 i = 0; i < count; i++)
+		{
+			const uint32 v4 = std::rotr(scrambled, 25);
+			const uint32 v5 = std::rotr(scrambled, 10);
+			const uint32 b = uint32(key[(i * 4) + 3]) << 24 | uint32(key[(i * 4) + 2]) << 16 | uint32(key[(i * 4) + 1]) << 8 | uint32(key[(i * 4)]);
+			scrambled = b + v4 + v5 - scrambled;
+		}
+		return {uint8(scrambled & 0xFF), uint8(scrambled >> 8 & 0xFF), uint8(scrambled >> 16 & 0xFF), uint8(scrambled >> 24 & 0xFF)};
+	}
+
+	uint32 DimensionsUSB::GetFigureId(const std::array<uint8, 0x2D * 0x04>& buf)
+	{
+		const std::array<uint8, 16> figureKey = GenerateFigureKey(buf);
+
+		const std::array<uint8, 8> decrypted = Decrypt(&buf[36 * 4], figureKey);
+
+		const uint32 figNum = uint32(decrypted[3]) << 24 | uint32(decrypted[2]) << 16 | uint32(decrypted[1]) << 8 | uint32(decrypted[0]);
+		// Characters have their model number encrypted in page 36
+		if (figNum < 1000)
+		{
+			return figNum;
+		}
+		// Vehicles/Gadgets have their model number written as little endian in page 36
+		return uint32(buf[(36 * 4) + 3]) << 24 | uint32(buf[(36 * 4) + 2]) << 16 | uint32(buf[(36 * 4) + 1]) << 8 | uint32(buf[36 * 4]);
+	}
+
+	DimensionsUSB::DimensionsMini&
+	DimensionsUSB::GetFigureByIndex(uint8 index)
+	{
+		return figures[index];
+	}
+
+	void DimensionsUSB::QueryBlock(uint8 index, uint8 page,
+								   std::array<uint8, 32>& replyBuf,
+								   uint8 sequence)
+	{
+		std::lock_guard lock(m_dimensionsMutex);
+
+		replyBuf[0] = 0x55;
+		replyBuf[1] = 0x12;
+		replyBuf[2] = sequence;
+		replyBuf[3] = 0x00;
+
+		// Index from game begins at 1 rather than 0, so minus 1 here
+		if (const uint8 figureIndex = index - 1; figureIndex < 7)
+		{
+			const DimensionsMini& figure = GetFigureByIndex(figureIndex);
+
+			// Query 4 pages of 4 bytes from the figure, copy this to the response
+			if (figure.index != 255 && (4 * page) < ((0x2D * 4) - 16))
+			{
+				std::memcpy(&replyBuf[4], figure.data.data() + (4 * page), 16);
+			}
+		}
+		replyBuf[20] = GenerateChecksum(replyBuf, 20);
+	}
+
+	void DimensionsUSB::WriteBlock(uint8 index, uint8 page, const uint8* toWriteBuf,
+								   std::array<uint8, 32>& replyBuf, uint8 sequence)
+	{
+		std::lock_guard lock(m_dimensionsMutex);
+
+		replyBuf[0] = 0x55;
+		replyBuf[1] = 0x02;
+		replyBuf[2] = sequence;
+		replyBuf[3] = 0x00;
+
+		// Index from game begins at 1 rather than 0, so minus 1 here
+		if (const uint8 figureIndex = index - 1; figureIndex < 7)
+		{
+			DimensionsMini& figure = GetFigureByIndex(figureIndex);
+
+			// Copy 4 bytes to the page on the figure requested by the game
+			if (figure.index != 255 && page < 0x2D)
+			{
+				// Id is written to page 36
+				if (page == 36)
+				{
+					figure.id = uint32(toWriteBuf[3]) << 24 | uint32(toWriteBuf[2]) << 16 | uint32(toWriteBuf[1]) << 8 | uint32(toWriteBuf[0]);
+				}
+				std::memcpy(figure.data.data() + (page * 4), toWriteBuf, 4);
+				figure.Save();
+			}
+		}
+		replyBuf[4] = GenerateChecksum(replyBuf, 4);
+	}
+
+	void DimensionsUSB::GetModel(uint8* buf, uint8 sequence,
+								 std::array<uint8, 32>& replyBuf)
+	{
+		// Decrypt payload to 8 byte array, byte 1 is the index, 4-7 are the confirmation
+		std::array<uint8, 8> value = Decrypt(buf, std::nullopt);
+		uint8 index = value[0];
+		uint32 conf = uint32(value[4]) << 24 | uint32(value[5]) << 16 | uint32(value[6]) << 8 | uint32(value[7]);
+		// Response is the figure's id (little endian) followed by the confirmation from payload
+		// Index from game begins at 1 rather than 0, so minus 1 here
+		std::array<uint8, 8> valueToEncrypt = {};
+		if (const uint8 figureIndex = index - 1; figureIndex < 7)
+		{
+			const DimensionsMini& figure = GetFigureByIndex(figureIndex);
+			valueToEncrypt = {uint8(figure.id & 0xFF), uint8((figure.id >> 8) & 0xFF),
+							  uint8((figure.id >> 16) & 0xFF), uint8((figure.id >> 24) & 0xFF),
+							  value[4], value[5], value[6], value[7]};
+		}
+		std::array<uint8, 8> encrypted = Encrypt(valueToEncrypt.data(), std::nullopt);
+		replyBuf[0] = 0x55;
+		replyBuf[1] = 0x0a;
+		replyBuf[2] = sequence;
+		replyBuf[3] = 0x00;
+		memcpy(&replyBuf[4], encrypted.data(), encrypted.size());
+		replyBuf[12] = GenerateChecksum(replyBuf, 12);
+	}
+
+	void DimensionsUSB::RandomUID(uint8* uid_buffer)
+	{
+		uid_buffer[0] = 0x04;
+		uid_buffer[6] = 0x80;
+
+		std::random_device rd;
+		std::mt19937 mt(rd());
+		std::uniform_int_distribution<int> dist(0, 255);
+
+		uid_buffer[1] = dist(mt);
+		uid_buffer[2] = dist(mt);
+		uid_buffer[3] = dist(mt);
+		uid_buffer[4] = dist(mt);
+		uid_buffer[5] = dist(mt);
+	}
+
+	uint8 DimensionsUSB::GenerateChecksum(const std::array<uint8, 32>& data,
+										  int num_of_bytes) const
+	{
+		int checksum = 0;
+		for (int i = 0; i < num_of_bytes; i++)
+		{
+			checksum += data[i];
+		}
+		return (checksum & 0xFF);
+	}
+
+	void DimensionsUSB::DimensionsMini::Save()
+	{
+		if (!dimFile)
+			return;
+
+		dimFile->SetPosition(0);
+		dimFile->writeData(data.data(), data.size());
+	}
+
+	std::map<const uint32, const char*> DimensionsUSB::GetListMinifigs()
+	{
+		return s_listMinis;
+	}
+
+	std::string DimensionsUSB::FindFigure(uint32 figNum)
+	{
+		for (const auto& it : GetListMinifigs())
+		{
+			if (it.first == figNum)
+			{
+				return it.second;
+			}
+		}
+		return fmt::format("Unknown ({})", figNum);
+	}
+} // namespace nsyshid

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
@@ -1114,9 +1114,21 @@ namespace nsyshid
 		return s_listMinis;
 	}
 
+	std::map<const uint32, const char*> DimensionsUSB::GetListTokens()
+	{
+		return s_listTokens;
+	}
+
 	std::string DimensionsUSB::FindFigure(uint32 figNum)
 	{
 		for (const auto& it : GetListMinifigs())
+		{
+			if (it.first == figNum)
+			{
+				return it.second;
+			}
+		}
+		for (const auto& it : GetListTokens())
 		{
 			if (it.first == figNum)
 			{

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
@@ -619,7 +619,7 @@ namespace nsyshid
 		figure.id = id;
 		figure.pad = pad;
 		figure.index = index + 1;
-		memcpy(figure.data.data(), buf.data(), buf.size());
+		figure.data = buf;
 		// When a figure is added to the toypad, respond to the game with the pad they were added to, their index,
 		// the direction (0x00 in byte 6 for added) and their UID
 		std::array<uint8, 32> figureChangeResponse = {0x56, 0x0b, figure.pad, 0x00, figure.index, 0x00, buf[0], buf[1], buf[2], buf[4], buf[5], buf[6], buf[7]};

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.cpp
@@ -772,7 +772,7 @@ namespace nsyshid
 		// Seed is the first 4 bytes (little endian) of the decrypted payload
 		uint32 seed = (uint32&)value[0];
 		// Confirmation is the second 4 bytes (big endian) of the decrypted payload
-		uint32 conf = uint32be::from_bevalue((uint32&)value[4]);
+		uint32 conf = (uint32be&)value[4];
 		// Initialize rng using the seed from decrypted payload
 		InitializeRNG(seed);
 		// Encrypt 8 bytes, first 4 bytes is the decrypted confirmation from payload, 2nd 4 bytes are blank
@@ -792,7 +792,7 @@ namespace nsyshid
 		// Decrypt payload into an 8 byte array
 		std::array<uint8, 8> value = Decrypt(buf, std::nullopt);
 		// Confirmation is the first 4 bytes of the decrypted payload
-		uint32 conf = uint32be::from_bevalue((uint32&)value[0]);
+		uint32 conf = (uint32be&)value[0];
 		// Generate next random number based on RNG
 		uint32 nextRandom = GetNext();
 		// Encrypt an 8 byte array, first 4 bytes are the next random number (little endian)
@@ -961,7 +961,7 @@ namespace nsyshid
 
 		std::array<uint8, 4> randomized = DimensionsRandomize(toScramble, count);
 
-		return uint32be::from_bevalue((uint32&)randomized[0]);
+		return (uint32be&)randomized[0];
 	}
 
 	std::array<uint8, 4> DimensionsUSB::PWDGenerate(const std::array<uint8, 0x2D * 0x04>& buf)
@@ -1075,7 +1075,7 @@ namespace nsyshid
 		// Decrypt payload to 8 byte array, byte 1 is the index, 4-7 are the confirmation
 		std::array<uint8, 8> value = Decrypt(buf, std::nullopt);
 		uint8 index = value[0];
-		uint32 conf = uint32be::from_bevalue((uint32&)value[4]);
+		uint32 conf = (uint32be&)value[4];
 		// Response is the figure's id (little endian) followed by the confirmation from payload
 		// Index from game begins at 1 rather than 0, so minus 1 here
 		std::array<uint8, 8> valueToEncrypt = {};

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -70,6 +70,7 @@ namespace nsyshid
 		bool CreateFigure(fs::path pathName, uint32 id);
 		bool MoveFigure(uint8 pad, uint8 index, uint8 oldPad, uint8 oldIndex);
 		static std::map<const uint32, const char*> GetListMinifigs();
+		static std::map<const uint32, const char*> GetListTokens();
 		std::string FindFigure(uint32 figNum);
 
 	  protected:

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -1,0 +1,102 @@
+#include <mutex>
+
+#include "nsyshid.h"
+#include "Backend.h"
+
+#include "Common/FileStream.h"
+
+namespace nsyshid
+{
+	class DimensionsToypadDevice final : public Device
+	{
+	  public:
+		DimensionsToypadDevice();
+		~DimensionsToypadDevice() = default;
+
+		bool Open() override;
+
+		void Close() override;
+
+		bool IsOpened() override;
+
+		ReadResult Read(ReadMessage* message) override;
+
+		WriteResult Write(WriteMessage* message) override;
+
+		bool GetDescriptor(uint8 descType,
+						   uint8 descIndex,
+						   uint8 lang,
+						   uint8* output,
+						   uint32 outputMaxLength) override;
+
+		bool SetProtocol(uint8 ifIndex, uint8 protocol) override;
+
+		bool SetReport(ReportMessage* message) override;
+
+	  private:
+		bool m_IsOpened;
+	};
+
+	class DimensionsUSB
+	{
+	  public:
+		struct DimensionsMini final
+		{
+			std::unique_ptr<FileStream> dimFile;
+			std::array<uint8, 0x2D * 0x04> data{};
+			uint8 index = 255;
+			uint8 pad = 255;
+			uint32 id = 0;
+			void Save();
+		};
+
+		void SendCommand(uint8* buf, sint32 originalLength);
+		std::array<uint8, 32> GetStatus();
+
+		void GenerateRandomNumber(uint8* buf, uint8 sequence,
+						   std::array<uint8, 32>& replyBuf);
+		void InitializeRNG(uint32 seed);
+		void GetChallengeResponse(uint8* buf, uint8 sequence,
+									std::array<uint8, 32>& replyBuf);
+		void QueryBlock(uint8 index, uint8 page, std::array<uint8, 32>& replyBuf,
+						 uint8 sequence);
+		void WriteBlock(uint8 index, uint8 page, const uint8* toWriteBuf, std::array<uint8, 32>& replyBuf,
+						 uint8 sequence);
+		void GetModel(uint8* buf, uint8 sequence,
+					   std::array<uint8, 32>& replyBuf);
+
+		bool RemoveFigure(uint8 pad, uint8 index);
+		uint32 LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index);
+		bool CreateFigure(fs::path pathName, uint32 id);
+		static std::map<const uint32, const char*> GetListMinifigs();
+		std::string FindFigure(uint32 figNum);
+
+	  protected:
+		std::mutex m_dimensionsMutex;
+		std::array<DimensionsMini, 7> figures;
+
+	  private:
+		void RandomUID(uint8* uidBuffer);
+		uint8 GenerateChecksum(const std::array<uint8, 32>& data,
+								int numOfBytes) const;
+		std::array<uint8, 8> Decrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key);
+		std::array<uint8, 8> Encrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key);
+		std::array<uint8, 16> GenerateFigureKey(const std::array<uint8, 0x2D * 0x04>& uid);
+		std::array<uint8, 4> PWDGenerate(const std::array<uint8, 0x2D * 0x04>& uid);
+		std::array<uint8, 4> DimensionsRandomize(const std::vector<uint8> key, uint8 count);
+		uint32 GetFigureId(const std::array<uint8, 0x2D * 0x04>& buf);
+		uint32 Scramble(const std::array<uint8, 7>& uid, uint8 count);
+		uint32 GetNext();
+		DimensionsMini& GetFigureByIndex(uint8 index);
+
+		uint32 m_randomA;
+		uint32 m_randomB;
+		uint32 m_randomC;
+		uint32 m_randomD;
+
+		std::queue<std::array<uint8, 32>> m_figureAddedRemovedResponses;
+		std::queue<std::array<uint8, 32>> m_queries;
+	};
+	extern DimensionsUSB g_dimensionstoypad;
+
+} // namespace nsyshid

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -60,7 +60,7 @@ namespace nsyshid
 									std::array<uint8, 32>& replyBuf);
 		void QueryBlock(uint8 index, uint8 page, std::array<uint8, 32>& replyBuf,
 						 uint8 sequence);
-		void WriteBlock(uint8 index, uint8 page, std::span<const uint8, 16> toWriteBuf, std::array<uint8, 32>& replyBuf,
+		void WriteBlock(uint8 index, uint8 page, std::span<const uint8, 4> toWriteBuf, std::array<uint8, 32>& replyBuf,
 						 uint8 sequence);
 		void GetModel(std::span<const uint8, 8> buf, uint8 sequence,
 					   std::array<uint8, 32>& replyBuf);
@@ -76,7 +76,7 @@ namespace nsyshid
 		std::array<DimensionsMini, 7> figures;
 
 	  private:
-		void RandomUID(uint8* uidBuffer);
+		void RandomUID(std::array<uint8, 0x2D * 0x04>& uidBuffer);
 		uint8 GenerateChecksum(const std::array<uint8, 32>& data,
 								int numOfBytes) const;
 		std::array<uint8, 8> Decrypt(std::span<const uint8, 8> buf, std::optional<std::array<uint8, 16>> key);

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -1,4 +1,4 @@
-#include <shared_mutex>
+#include <mutex>
 
 #include "nsyshid.h"
 #include "Backend.h"
@@ -65,8 +65,10 @@ namespace nsyshid
 		void GetModel(std::span<const uint8, 8> buf, uint8 sequence,
 					  std::array<uint8, 32>& replyBuf);
 
-		bool RemoveFigure(uint8 pad, uint8 index, bool save, bool lock);
-		uint32 LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index, bool lock);
+		bool RemoveFigure(uint8 pad, uint8 index, bool fullRemove);
+		bool TempRemove(uint8 index);
+		bool CancelRemove(uint8 index);
+		uint32 LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index);
 		bool CreateFigure(fs::path pathName, uint32 id);
 		bool MoveFigure(uint8 pad, uint8 index, uint8 oldPad, uint8 oldIndex);
 		static std::map<const uint32, const char*> GetListMinifigs();
@@ -74,7 +76,7 @@ namespace nsyshid
 		std::string FindFigure(uint32 figNum);
 
 	  protected:
-		std::shared_mutex m_dimensionsMutex;
+		std::mutex m_dimensionsMutex;
 		std::array<DimensionsMini, 7> m_figures{};
 
 	  private:
@@ -95,6 +97,8 @@ namespace nsyshid
 		uint32 m_randomB;
 		uint32 m_randomC;
 		uint32 m_randomD;
+
+		bool m_isAwake = false;
 
 		std::queue<std::array<uint8, 32>> m_figureAddedRemovedResponses;
 		std::queue<std::array<uint8, 32>> m_queries;

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -50,19 +50,19 @@ namespace nsyshid
 			void Save();
 		};
 
-		void SendCommand(uint8* buf, sint32 originalLength);
+		void SendCommand(std::span<const uint8, 32> buf);
 		std::array<uint8, 32> GetStatus();
 
-		void GenerateRandomNumber(uint8* buf, uint8 sequence,
+		void GenerateRandomNumber(std::span<const uint8, 8> buf, uint8 sequence,
 						   std::array<uint8, 32>& replyBuf);
 		void InitializeRNG(uint32 seed);
-		void GetChallengeResponse(uint8* buf, uint8 sequence,
+		void GetChallengeResponse(std::span<const uint8, 8> buf, uint8 sequence,
 									std::array<uint8, 32>& replyBuf);
 		void QueryBlock(uint8 index, uint8 page, std::array<uint8, 32>& replyBuf,
 						 uint8 sequence);
-		void WriteBlock(uint8 index, uint8 page, const uint8* toWriteBuf, std::array<uint8, 32>& replyBuf,
+		void WriteBlock(uint8 index, uint8 page, std::span<const uint8, 16> toWriteBuf, std::array<uint8, 32>& replyBuf,
 						 uint8 sequence);
-		void GetModel(uint8* buf, uint8 sequence,
+		void GetModel(std::span<const uint8, 8> buf, uint8 sequence,
 					   std::array<uint8, 32>& replyBuf);
 
 		bool RemoveFigure(uint8 pad, uint8 index);
@@ -79,8 +79,8 @@ namespace nsyshid
 		void RandomUID(uint8* uidBuffer);
 		uint8 GenerateChecksum(const std::array<uint8, 32>& data,
 								int numOfBytes) const;
-		std::array<uint8, 8> Decrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key);
-		std::array<uint8, 8> Encrypt(const uint8* buf, std::optional<std::array<uint8, 16>> key);
+		std::array<uint8, 8> Decrypt(std::span<const uint8, 8> buf, std::optional<std::array<uint8, 16>> key);
+		std::array<uint8, 8> Encrypt(std::span<const uint8, 8> buf, std::optional<std::array<uint8, 16>> key);
 		std::array<uint8, 16> GenerateFigureKey(const std::array<uint8, 0x2D * 0x04>& uid);
 		std::array<uint8, 4> PWDGenerate(const std::array<uint8, 0x2D * 0x04>& uid);
 		std::array<uint8, 4> DimensionsRandomize(const std::vector<uint8> key, uint8 count);

--- a/src/Cafe/OS/libs/nsyshid/Dimensions.h
+++ b/src/Cafe/OS/libs/nsyshid/Dimensions.h
@@ -1,4 +1,4 @@
-#include <mutex>
+#include <shared_mutex>
 
 #include "nsyshid.h"
 #include "Backend.h"
@@ -54,31 +54,32 @@ namespace nsyshid
 		std::array<uint8, 32> GetStatus();
 
 		void GenerateRandomNumber(std::span<const uint8, 8> buf, uint8 sequence,
-						   std::array<uint8, 32>& replyBuf);
+								  std::array<uint8, 32>& replyBuf);
 		void InitializeRNG(uint32 seed);
 		void GetChallengeResponse(std::span<const uint8, 8> buf, uint8 sequence,
-									std::array<uint8, 32>& replyBuf);
+								  std::array<uint8, 32>& replyBuf);
 		void QueryBlock(uint8 index, uint8 page, std::array<uint8, 32>& replyBuf,
-						 uint8 sequence);
+						uint8 sequence);
 		void WriteBlock(uint8 index, uint8 page, std::span<const uint8, 4> toWriteBuf, std::array<uint8, 32>& replyBuf,
-						 uint8 sequence);
+						uint8 sequence);
 		void GetModel(std::span<const uint8, 8> buf, uint8 sequence,
-					   std::array<uint8, 32>& replyBuf);
+					  std::array<uint8, 32>& replyBuf);
 
-		bool RemoveFigure(uint8 pad, uint8 index);
-		uint32 LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index);
+		bool RemoveFigure(uint8 pad, uint8 index, bool save, bool lock);
+		uint32 LoadFigure(const std::array<uint8, 0x2D * 0x04>& buf, std::unique_ptr<FileStream> file, uint8 pad, uint8 index, bool lock);
 		bool CreateFigure(fs::path pathName, uint32 id);
+		bool MoveFigure(uint8 pad, uint8 index, uint8 oldPad, uint8 oldIndex);
 		static std::map<const uint32, const char*> GetListMinifigs();
 		std::string FindFigure(uint32 figNum);
 
 	  protected:
-		std::mutex m_dimensionsMutex;
-		std::array<DimensionsMini, 7> figures;
+		std::shared_mutex m_dimensionsMutex;
+		std::array<DimensionsMini, 7> m_figures{};
 
 	  private:
 		void RandomUID(std::array<uint8, 0x2D * 0x04>& uidBuffer);
 		uint8 GenerateChecksum(const std::array<uint8, 32>& data,
-								int numOfBytes) const;
+							   int numOfBytes) const;
 		std::array<uint8, 8> Decrypt(std::span<const uint8, 8> buf, std::optional<std::array<uint8, 16>> key);
 		std::array<uint8, 8> Encrypt(std::span<const uint8, 8> buf, std::optional<std::array<uint8, 16>> key);
 		std::array<uint8, 16> GenerateFigureKey(const std::array<uint8, 0x2D * 0x04>& uid);

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -346,6 +346,7 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	auto usbdevices = parser.get("EmulatedUsbDevices");
 	emulated_usb_devices.emulate_skylander_portal = usbdevices.get("EmulateSkylanderPortal", emulated_usb_devices.emulate_skylander_portal);
 	emulated_usb_devices.emulate_infinity_base = usbdevices.get("EmulateInfinityBase", emulated_usb_devices.emulate_infinity_base);
+	emulated_usb_devices.emulate_dimensions_toypad = usbdevices.get("EmulateDimensionsToypad", emulated_usb_devices.emulate_dimensions_toypad);
 }
 
 void CemuConfig::Save(XMLConfigParser& parser)
@@ -545,6 +546,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	auto usbdevices = config.set("EmulatedUsbDevices");
 	usbdevices.set("EmulateSkylanderPortal", emulated_usb_devices.emulate_skylander_portal.GetValue());
 	usbdevices.set("EmulateInfinityBase", emulated_usb_devices.emulate_infinity_base.GetValue());
+	usbdevices.set("EmulateDimensionsToypad", emulated_usb_devices.emulate_dimensions_toypad.GetValue());
 }
 
 GameEntry* CemuConfig::GetGameEntryByTitleId(uint64 titleId)

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -521,6 +521,7 @@ struct CemuConfig
 	{
 		ConfigValue<bool> emulate_skylander_portal{false};
 		ConfigValue<bool> emulate_infinity_base{false};
+		ConfigValue<bool> emulate_dimensions_toypad{false};
 	}emulated_usb_devices{};
 
 	private:

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
@@ -638,14 +638,14 @@ void EmulatedUSBDeviceFrame::LoadMinifigPath(wxString path_name, uint8 pad, uint
 
 	ClearMinifig(pad, index);
 
-	uint32 id = nsyshid::g_dimensionstoypad.LoadFigure(file_data, std::move(dim_file), pad, index, true);
+	uint32 id = nsyshid::g_dimensionstoypad.LoadFigure(file_data, std::move(dim_file), pad, index);
 	m_dimensionSlots[index]->ChangeValue(nsyshid::g_dimensionstoypad.FindFigure(id));
 	m_dimSlots[index] = id;
 }
 
 void EmulatedUSBDeviceFrame::ClearMinifig(uint8 pad, uint8 index)
 {
-	nsyshid::g_dimensionstoypad.RemoveFigure(pad, index, true, true);
+	nsyshid::g_dimensionstoypad.RemoveFigure(pad, index, true);
 	m_dimensionSlots[index]->ChangeValue("None");
 	m_dimSlots[index] = std::nullopt;
 }
@@ -662,7 +662,11 @@ void EmulatedUSBDeviceFrame::CreateMinifig(uint8 pad, uint8 index)
 
 void EmulatedUSBDeviceFrame::MoveMinifig(uint8 pad, uint8 index)
 {
+	if (!m_dimSlots[index])
+		return;
+
 	MoveDimensionFigureDialog move_dlg(this, index);
+	nsyshid::g_dimensionstoypad.TempRemove(index);
 	move_dlg.ShowModal();
 	if (move_dlg.GetReturnCode() == 1)
 	{
@@ -674,6 +678,10 @@ void EmulatedUSBDeviceFrame::MoveMinifig(uint8 pad, uint8 index)
 			m_dimSlots[index] = std::nullopt;
 			m_dimensionSlots[index]->ChangeValue("None");
 		}
+	}
+	else
+	{
+		nsyshid::g_dimensionstoypad.CancelRemove(index);
 	}
 }
 
@@ -778,8 +786,8 @@ MoveDimensionFigureDialog::MoveDimensionFigureDialog(EmulatedUSBDeviceFrame* par
 	sizer->Add(new wxStaticText(this, wxID_ANY, ""), 1, wxALL, 5);
 	sizer->Add(AddMinifigSlot(3, 2, currentIndex, ids[2]), 1, wxALL, 5);
 
-	sizer->Add(AddMinifigSlot(1, 3, currentIndex, ids[3]), 1, wxALL, 5);
-	sizer->Add(AddMinifigSlot(1, 4, currentIndex, ids[4]), 1, wxALL, 5);
+	sizer->Add(AddMinifigSlot(2, 3, currentIndex, ids[3]), 1, wxALL, 5);
+	sizer->Add(AddMinifigSlot(2, 4, currentIndex, ids[4]), 1, wxALL, 5);
 	sizer->Add(new wxStaticText(this, wxID_ANY, ""), 1, wxALL, 5);
 	sizer->Add(AddMinifigSlot(3, 5, currentIndex, ids[5]), 1, wxALL, 5);
 	sizer->Add(AddMinifigSlot(3, 6, currentIndex, ids[6]), 1, wxALL, 5);

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
@@ -132,16 +132,16 @@ wxPanel* EmulatedUSBDeviceFrame::AddDimensionsPage(wxNotebook* notebook)
 
 	auto* row = new wxBoxSizer(wxHORIZONTAL);
 
-	m_emulate_toypad =
+	m_emulateToypad =
 		new wxCheckBox(box, wxID_ANY, _("Emulate Dimensions Toypad"));
-	m_emulate_toypad->SetValue(
+	m_emulateToypad->SetValue(
 		GetConfig().emulated_usb_devices.emulate_dimensions_toypad);
-	m_emulate_toypad->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
+	m_emulateToypad->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
 		GetConfig().emulated_usb_devices.emulate_dimensions_toypad =
-			m_emulate_toypad->IsChecked();
+			m_emulateToypad->IsChecked();
 		g_config.Save();
 	});
-	row->Add(m_emulate_toypad, 1, wxEXPAND | wxALL, 2);
+	row->Add(m_emulateToypad, 1, wxEXPAND | wxALL, 2);
 	box_sizer->Add(row, 1, wxEXPAND | wxALL, 2);
 	auto* top_row = new wxBoxSizer(wxHORIZONTAL);
 	auto* bottom_row = new wxBoxSizer(wxHORIZONTAL);

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
@@ -1,4 +1,4 @@
-#include "gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h"
+#include "EmulatedUSBDeviceFrame.h"
 
 #include <algorithm>
 
@@ -8,14 +8,17 @@
 #include "util/helpers/helpers.h"
 
 #include "Cafe/OS/libs/nsyshid/nsyshid.h"
+#include "Cafe/OS/libs/nsyshid/Dimensions.h"
 
 #include "Common/FileStream.h"
 
 #include <wx/arrstr.h>
 #include <wx/button.h>
+#include <wx/combobox.h>
 #include <wx/checkbox.h>
 #include <wx/combobox.h>
 #include <wx/filedlg.h>
+#include <wx/log.h>
 #include <wx/msgdlg.h>
 #include <wx/notebook.h>
 #include <wx/panel.h>
@@ -29,7 +32,6 @@
 #include <wx/wfstream.h>
 
 #include "resource/embedded/resources.h"
-#include "EmulatedUSBDeviceFrame.h"
 
 EmulatedUSBDeviceFrame::EmulatedUSBDeviceFrame(wxWindow* parent)
 	: wxFrame(parent, wxID_ANY, _("Emulated USB Devices"), wxDefaultPosition,
@@ -44,6 +46,7 @@ EmulatedUSBDeviceFrame::EmulatedUSBDeviceFrame(wxWindow* parent)
 
 	notebook->AddPage(AddSkylanderPage(notebook), _("Skylanders Portal"));
 	notebook->AddPage(AddInfinityPage(notebook), _("Infinity Base"));
+	notebook->AddPage(AddDimensionsPage(notebook), _("Dimensions Toypad"));
 
 	sizer->Add(notebook, 1, wxEXPAND | wxALL, 2);
 
@@ -120,6 +123,51 @@ wxPanel* EmulatedUSBDeviceFrame::AddInfinityPage(wxNotebook* notebook)
 	return panel;
 }
 
+wxPanel* EmulatedUSBDeviceFrame::AddDimensionsPage(wxNotebook* notebook)
+{
+	auto* panel = new wxPanel(notebook);
+	auto* panel_sizer = new wxBoxSizer(wxVERTICAL);
+	auto* box = new wxStaticBox(panel, wxID_ANY, _("Dimensions Manager"));
+	auto* box_sizer = new wxStaticBoxSizer(box, wxVERTICAL);
+
+	auto* row = new wxBoxSizer(wxHORIZONTAL);
+
+	m_emulate_toypad =
+		new wxCheckBox(box, wxID_ANY, _("Emulate Dimensions Toypad"));
+	m_emulate_toypad->SetValue(
+		GetConfig().emulated_usb_devices.emulate_dimensions_toypad);
+	m_emulate_toypad->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
+		GetConfig().emulated_usb_devices.emulate_dimensions_toypad =
+			m_emulate_toypad->IsChecked();
+		g_config.Save();
+	});
+	row->Add(m_emulate_toypad, 1, wxEXPAND | wxALL, 2);
+	box_sizer->Add(row, 1, wxEXPAND | wxALL, 2);
+	auto* top_row = new wxBoxSizer(wxHORIZONTAL);
+	auto* bottom_row = new wxBoxSizer(wxHORIZONTAL);
+
+	auto* dummy = new wxStaticText(box, wxID_ANY, "");
+
+	top_row->Add(AddDimensionPanel(2, 0, box), 1, wxEXPAND | wxALL, 2);
+	top_row->Add(dummy, 1, wxEXPAND | wxLEFT | wxRIGHT, 2);
+	top_row->Add(AddDimensionPanel(1, 1, box), 1, wxEXPAND | wxALL, 2);
+	top_row->Add(dummy, 1, wxEXPAND | wxLEFT | wxRIGHT, 2);
+	top_row->Add(AddDimensionPanel(3, 2, box), 1, wxEXPAND | wxALL, 2);
+
+	bottom_row->Add(AddDimensionPanel(2, 3, box), 1, wxEXPAND | wxALL, 2);
+	bottom_row->Add(AddDimensionPanel(2, 4, box), 1, wxEXPAND | wxALL, 2);
+	bottom_row->Add(dummy, 1, wxEXPAND | wxLEFT | wxRIGHT, 0);
+	bottom_row->Add(AddDimensionPanel(3, 5, box), 1, wxEXPAND | wxALL, 2);
+	bottom_row->Add(AddDimensionPanel(3, 6, box), 1, wxEXPAND | wxALL, 2);
+
+	box_sizer->Add(top_row, 1, wxEXPAND | wxALL, 2);
+	box_sizer->Add(bottom_row, 1, wxEXPAND | wxALL, 2);
+	panel_sizer->Add(box_sizer, 1, wxEXPAND | wxALL, 2);
+	panel->SetSizerAndFit(panel_sizer);
+
+	return panel;
+}
+
 wxBoxSizer* EmulatedUSBDeviceFrame::AddSkylanderRow(uint8 rowNumber,
 													wxStaticBox* box)
 {
@@ -182,6 +230,41 @@ wxBoxSizer* EmulatedUSBDeviceFrame::AddInfinityRow(wxString name, uint8 rowNumbe
 	row->Add(clearButton, 1, wxEXPAND | wxALL, 2);
 
 	return row;
+}
+
+wxBoxSizer* EmulatedUSBDeviceFrame::AddDimensionPanel(uint8 pad, uint8 index, wxStaticBox* box)
+{
+	auto* panel = new wxBoxSizer(wxVERTICAL);
+
+	auto* combo_row = new wxBoxSizer(wxHORIZONTAL);
+	m_dimension_slots[index] = new wxTextCtrl(box, wxID_ANY, _("None"), wxDefaultPosition, wxDefaultSize,
+												  wxTE_READONLY);
+	combo_row->Add(m_dimension_slots[index], 1, wxEXPAND | wxALL, 2);
+	auto* move_button = new wxButton(box, wxID_ANY, _("Move"));
+
+	combo_row->Add(move_button, 1, wxEXPAND | wxALL, 2);
+
+	auto* button_row = new wxBoxSizer(wxHORIZONTAL);
+	auto* load_button = new wxButton(box, wxID_ANY, _("Load"));
+	load_button->Bind(wxEVT_BUTTON, [pad, index, this](wxCommandEvent&) {
+		LoadMinifig(pad, index);
+	});
+	auto* clear_button = new wxButton(box, wxID_ANY, _("Clear"));
+	clear_button->Bind(wxEVT_BUTTON, [pad, index, this](wxCommandEvent&) {
+		ClearMinifig(pad, index);
+	});
+	auto* create_button = new wxButton(box, wxID_ANY, _("Create"));
+	create_button->Bind(wxEVT_BUTTON, [pad, index, this](wxCommandEvent&) {
+		CreateMinifig(pad, index);
+	});
+	button_row->Add(clear_button, 1, wxEXPAND | wxALL, 2);
+	button_row->Add(create_button, 1, wxEXPAND | wxALL, 2);
+	button_row->Add(load_button, 1, wxEXPAND | wxALL, 2);
+
+	panel->Add(combo_row, 1, wxEXPAND | wxALL, 2);
+	panel->Add(button_row, 1, wxEXPAND | wxALL, 2);
+
+	return panel;
 }
 
 void EmulatedUSBDeviceFrame::LoadSkylander(uint8 slot)
@@ -307,8 +390,8 @@ CreateSkylanderDialog::CreateSkylanderDialog(wxWindow* parent, uint8 slot)
 			return;
 
 		m_filePath = saveFileDialog.GetPath();
-		
-		if(!nsyshid::g_skyportal.CreateSkylander(_utf8ToPath(m_filePath.utf8_string()), skyId, skyVar))
+
+		if (!nsyshid::g_skyportal.CreateSkylander(_utf8ToPath(m_filePath.utf8_string()), skyId, skyVar))
 		{
 			wxMessageDialog errorMessage(this, "Failed to create file");
 			errorMessage.ShowModal();
@@ -445,6 +528,143 @@ CreateInfinityFigureDialog::CreateInfinityFigureDialog(wxWindow* parent, uint8 s
 wxString CreateInfinityFigureDialog::GetFilePath() const
 {
 	return m_filePath;
+}
+
+CreateDimensionFigureDialog::CreateDimensionFigureDialog(wxWindow* parent)
+	: wxDialog(parent, wxID_ANY, _("Dimensions Figure Creator"), wxDefaultPosition, wxSize(500, 200))
+{
+	auto* sizer = new wxBoxSizer(wxVERTICAL);
+
+	auto* comboRow = new wxBoxSizer(wxHORIZONTAL);
+
+	auto* comboBox = new wxComboBox(this, wxID_ANY);
+	comboBox->Append("---Select---", reinterpret_cast<void*>(0xFFFFFFFF));
+	wxArrayString filterlist;
+	for (const auto& it : nsyshid::g_dimensionstoypad.GetListMinifigs())
+	{
+		const uint32 figure = it.first;
+		comboBox->Append(it.second, reinterpret_cast<void*>(figure));
+		filterlist.Add(it.second);
+	}
+	comboBox->SetSelection(0);
+	bool enabled = comboBox->AutoComplete(filterlist);
+	comboRow->Add(comboBox, 1, wxEXPAND | wxALL, 2);
+
+	auto* figNumRow = new wxBoxSizer(wxHORIZONTAL);
+
+	wxIntegerValidator<uint32> validator;
+
+	auto* labelFigNum = new wxStaticText(this, wxID_ANY, "Figure Number:");
+	auto* editFigNum = new wxTextCtrl(this, wxID_ANY, _("0"), wxDefaultPosition, wxDefaultSize, 0, validator);
+
+	figNumRow->Add(labelFigNum, 1, wxALL, 5);
+	figNumRow->Add(editFigNum, 1, wxALL, 5);
+
+	auto* buttonRow = new wxBoxSizer(wxHORIZONTAL);
+
+	auto* createButton = new wxButton(this, wxID_ANY, _("Create"));
+	createButton->Bind(wxEVT_BUTTON, [editFigNum, this](wxCommandEvent&) {
+		long longFigNum;
+		if (!editFigNum->GetValue().ToLong(&longFigNum) || longFigNum > 0xFFFF)
+		{
+			wxMessageDialog idError(this, "Error Converting Figure Number!", "Number Entered is Invalid");
+			idError.ShowModal();
+			this->EndModal(0);
+		}
+		uint16 figNum = longFigNum & 0xFFFF;
+		auto figure = nsyshid::g_dimensionstoypad.FindFigure(figNum);
+		wxString predefName = figure + ".bin";
+		wxFileDialog
+			saveFileDialog(this, _("Create Dimensions Figure file"), "", predefName,
+						   "BIN files (*.bin)|*.bin", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+		if (saveFileDialog.ShowModal() == wxID_CANCEL)
+			this->EndModal(0);
+
+		m_filePath = saveFileDialog.GetPath();
+
+		nsyshid::g_dimensionstoypad.CreateFigure(_utf8ToPath(m_filePath.utf8_string()), figNum);
+
+		this->EndModal(1);
+	});
+	auto* cancelButton = new wxButton(this, wxID_ANY, _("Cancel"));
+	cancelButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+		this->EndModal(0);
+	});
+
+	comboBox->Bind(wxEVT_COMBOBOX, [comboBox, editFigNum, this](wxCommandEvent&) {
+		const uint64 fig_info = reinterpret_cast<uint64>(comboBox->GetClientData(comboBox->GetSelection()));
+		if (fig_info != 0xFFFF)
+		{
+			const uint16 figNum = fig_info & 0xFFFF;
+
+			editFigNum->SetValue(wxString::Format(wxT("%i"), figNum));
+		}
+	});
+
+	buttonRow->Add(createButton, 1, wxALL, 5);
+	buttonRow->Add(cancelButton, 1, wxALL, 5);
+
+	sizer->Add(comboRow, 1, wxEXPAND | wxALL, 2);
+	sizer->Add(figNumRow, 1, wxEXPAND | wxALL, 2);
+	sizer->Add(buttonRow, 1, wxEXPAND | wxALL, 2);
+
+	this->SetSizer(sizer);
+	this->Centre(wxBOTH);
+}
+
+wxString CreateDimensionFigureDialog::GetFilePath() const
+{
+	return m_filePath;
+}
+
+void EmulatedUSBDeviceFrame::LoadMinifig(uint8 pad, uint8 index)
+{
+	wxFileDialog openFileDialog(this, _("Load Dimensions Figure"), "", "",
+								"Dimensions files (*.bin)|*.bin",
+								wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+	if (openFileDialog.ShowModal() != wxID_OK || openFileDialog.GetPath().empty())
+		return;
+
+	LoadMinifigPath(openFileDialog.GetPath(), pad, index);
+}
+void EmulatedUSBDeviceFrame::LoadMinifigPath(wxString path_name, uint8 pad, uint8 index)
+{
+	std::unique_ptr<FileStream> dim_file(FileStream::openFile2(_utf8ToPath(path_name.utf8_string()), true));
+	if (!dim_file)
+	{
+		wxMessageDialog errorMessage(this, "Failed to open minifig file");
+		errorMessage.ShowModal();
+		return;
+	}
+
+	std::array<uint8, 0x2D * 0x04> file_data;
+
+	if (dim_file->readData(file_data.data(), file_data.size()) != file_data.size())
+	{
+		wxMessageDialog errorMessage(this, "Failed to read minifig file data");
+		errorMessage.ShowModal();
+		return;
+	}
+
+	ClearMinifig(pad, index);
+
+	uint32 id = nsyshid::g_dimensionstoypad.LoadFigure(file_data, std::move(dim_file), pad, index);
+	m_dimension_slots[index]->ChangeValue(nsyshid::g_dimensionstoypad.FindFigure(id));
+}
+void EmulatedUSBDeviceFrame::ClearMinifig(uint8 pad, uint8 index)
+{
+	nsyshid::g_dimensionstoypad.RemoveFigure(pad, index);
+	m_dimension_slots[index]->ChangeValue("None");
+}
+void EmulatedUSBDeviceFrame::CreateMinifig(uint8 pad, uint8 index)
+{
+	CreateDimensionFigureDialog create_dlg(this);
+	create_dlg.ShowModal();
+	if (create_dlg.GetReturnCode() == 1)
+	{
+		LoadMinifigPath(create_dlg.GetFilePath(), pad, index);
+	}
 }
 
 void EmulatedUSBDeviceFrame::LoadFigure(uint8 slot)

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
@@ -25,18 +25,27 @@ class EmulatedUSBDeviceFrame : public wxFrame {
   private:
 	wxCheckBox* m_emulatePortal;
 	wxCheckBox* m_emulateBase;
+	wxCheckBox* m_emulate_toypad;
 	std::array<wxTextCtrl*, nsyshid::MAX_SKYLANDERS> m_skylanderSlots;
 	std::array<wxTextCtrl*, nsyshid::MAX_FIGURES> m_infinitySlots;
+	std::array<wxTextCtrl*, 7> m_dimension_slots;
 	std::array<std::optional<std::tuple<uint8, uint16, uint16>>, nsyshid::MAX_SKYLANDERS> m_skySlots;
+	std::array<std::optional<std::tuple<uint8, uint8, uint8>>, 7> dim_slots;
 
 	wxPanel* AddSkylanderPage(wxNotebook* notebook);
 	wxPanel* AddInfinityPage(wxNotebook* notebook);
+	wxPanel* AddDimensionsPage(wxNotebook* notebook);
 	wxBoxSizer* AddSkylanderRow(uint8 row_number, wxStaticBox* box);
 	wxBoxSizer* AddInfinityRow(wxString name, uint8 row_number, wxStaticBox* box);
+	wxBoxSizer* AddDimensionPanel(uint8 pad, uint8 index, wxStaticBox* box);
 	void LoadSkylander(uint8 slot);
 	void LoadSkylanderPath(uint8 slot, wxString path);
 	void CreateSkylander(uint8 slot);
 	void ClearSkylander(uint8 slot);
+	void LoadMinifigPath(wxString path_name, uint8 pad, uint8 index);
+	void LoadMinifig(uint8 pad, uint8 index);
+	void CreateMinifig(uint8 pad, uint8 index);
+	void ClearMinifig(uint8 pad, uint8 index);
 	void LoadFigure(uint8 slot);
 	void LoadFigurePath(uint8 slot, wxString path);
 	void CreateFigure(uint8 slot);
@@ -55,6 +64,15 @@ class CreateSkylanderDialog : public wxDialog {
 class CreateInfinityFigureDialog : public wxDialog {
   public:
 	explicit CreateInfinityFigureDialog(wxWindow* parent, uint8 slot);
+	wxString GetFilePath() const;
+
+  protected:
+	wxString m_filePath;
+};
+
+class CreateDimensionFigureDialog : public wxDialog {
+  public:
+	explicit CreateDimensionFigureDialog(wxWindow* parent);
 	wxString GetFilePath() const;
 
   protected:

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
@@ -27,7 +27,7 @@ class EmulatedUSBDeviceFrame : public wxFrame
   private:
 	wxCheckBox* m_emulatePortal;
 	wxCheckBox* m_emulateBase;
-	wxCheckBox* m_emulate_toypad;
+	wxCheckBox* m_emulateToypad;
 	std::array<wxTextCtrl*, nsyshid::MAX_SKYLANDERS> m_skylanderSlots;
 	std::array<wxTextCtrl*, nsyshid::MAX_FIGURES> m_infinitySlots;
 	std::array<wxTextCtrl*, 7> m_dimensionSlots;

--- a/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
+++ b/src/gui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
@@ -17,10 +17,12 @@ class wxStaticBox;
 class wxString;
 class wxTextCtrl;
 
-class EmulatedUSBDeviceFrame : public wxFrame {
+class EmulatedUSBDeviceFrame : public wxFrame
+{
   public:
 	EmulatedUSBDeviceFrame(wxWindow* parent);
 	~EmulatedUSBDeviceFrame();
+	std::array<std::optional<uint32>, 7> GetCurrentMinifigs();
 
   private:
 	wxCheckBox* m_emulatePortal;
@@ -28,9 +30,9 @@ class EmulatedUSBDeviceFrame : public wxFrame {
 	wxCheckBox* m_emulate_toypad;
 	std::array<wxTextCtrl*, nsyshid::MAX_SKYLANDERS> m_skylanderSlots;
 	std::array<wxTextCtrl*, nsyshid::MAX_FIGURES> m_infinitySlots;
-	std::array<wxTextCtrl*, 7> m_dimension_slots;
+	std::array<wxTextCtrl*, 7> m_dimensionSlots;
 	std::array<std::optional<std::tuple<uint8, uint16, uint16>>, nsyshid::MAX_SKYLANDERS> m_skySlots;
-	std::array<std::optional<std::tuple<uint8, uint8, uint8>>, 7> dim_slots;
+	std::array<std::optional<uint32>, 7> m_dimSlots;
 
 	wxPanel* AddSkylanderPage(wxNotebook* notebook);
 	wxPanel* AddInfinityPage(wxNotebook* notebook);
@@ -42,17 +44,20 @@ class EmulatedUSBDeviceFrame : public wxFrame {
 	void LoadSkylanderPath(uint8 slot, wxString path);
 	void CreateSkylander(uint8 slot);
 	void ClearSkylander(uint8 slot);
-	void LoadMinifigPath(wxString path_name, uint8 pad, uint8 index);
-	void LoadMinifig(uint8 pad, uint8 index);
-	void CreateMinifig(uint8 pad, uint8 index);
-	void ClearMinifig(uint8 pad, uint8 index);
+	void UpdateSkylanderEdits();
 	void LoadFigure(uint8 slot);
 	void LoadFigurePath(uint8 slot, wxString path);
 	void CreateFigure(uint8 slot);
 	void ClearFigure(uint8 slot);
-	void UpdateSkylanderEdits();
+	void LoadMinifig(uint8 pad, uint8 index);
+	void LoadMinifigPath(wxString path_name, uint8 pad, uint8 index);
+	void CreateMinifig(uint8 pad, uint8 index);
+	void ClearMinifig(uint8 pad, uint8 index);
+	void MoveMinifig(uint8 pad, uint8 index);
 };
-class CreateSkylanderDialog : public wxDialog {
+
+class CreateSkylanderDialog : public wxDialog
+{
   public:
 	explicit CreateSkylanderDialog(wxWindow* parent, uint8 slot);
 	wxString GetFilePath() const;
@@ -61,7 +66,8 @@ class CreateSkylanderDialog : public wxDialog {
 	wxString m_filePath;
 };
 
-class CreateInfinityFigureDialog : public wxDialog {
+class CreateInfinityFigureDialog : public wxDialog
+{
   public:
 	explicit CreateInfinityFigureDialog(wxWindow* parent, uint8 slot);
 	wxString GetFilePath() const;
@@ -70,11 +76,27 @@ class CreateInfinityFigureDialog : public wxDialog {
 	wxString m_filePath;
 };
 
-class CreateDimensionFigureDialog : public wxDialog {
+class CreateDimensionFigureDialog : public wxDialog
+{
   public:
 	explicit CreateDimensionFigureDialog(wxWindow* parent);
 	wxString GetFilePath() const;
 
   protected:
 	wxString m_filePath;
+};
+
+class MoveDimensionFigureDialog : public wxDialog
+{
+  public:
+	explicit MoveDimensionFigureDialog(EmulatedUSBDeviceFrame* parent, uint8 currentIndex);
+	uint8 GetNewPad() const;
+	uint8 GetNewIndex() const;
+
+  protected:
+	uint8 m_newIndex = 0;
+	uint8 m_newPad = 0;
+
+  private:
+	wxBoxSizer* AddMinifigSlot(uint8 pad, uint8 index, uint8 oldIndex, std::optional<uint32> currentId);
 };


### PR DESCRIPTION
This PR aims to emulate the last mainstream toys-to-life peripheral, the Lego Dimensions Toypad. The Toypad is functionally very similar to the Disney Infinity Base, it has 2 endpoints, one for reading and one for writing, and all requests and responses are padded to 32 bytes.

The UI I have created functions mostly the same as the Skylander Portal and Infinity Base, but the layout is slightly different, to try to match the positions of a physical portal:

![image](https://github.com/user-attachments/assets/e33065d8-329a-4d97-9334-6b64338f97da)

Users can Clear minifgures from the UI, Create either a new Character, or a 'Blank Tag' which can be used to store gadgets from the game, or Load an existing dump.

The game quite frequently requires figures to be moved to different positions on the Toypad, so I have added in a move button, which opens up a new UI window allowing users to quickly select a new position to move one of their loaded figures on to:

![image](https://github.com/user-attachments/assets/ef4b59c9-b821-41ac-a13c-8bbd456a118f)

Any testing would be much appreciated, I have the game but a lot of different sections of the game have different ways to interact with the Toypad, so there is potential for some areas of the game to require slight variations to adding/removing responses etc.

For anyone interested, [here is a video](https://youtu.be/v-htDhg1Pas) of the tool in action

This PR should close https://github.com/cemu-project/Cemu/issues/1268.