### PR TITLE
Add toggle button to VPAD show screen input

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -396,7 +396,7 @@ void cemu_initForGame()
 		// replace any known function signatures with our HLE implementations and patch bugs in the games
 		GamePatch_scan();
 	}
-	LatteGPUState.alwaysDisplayDRC = ActiveSettings::DisplayDRCEnabled();
+	LatteGPUState.isDRCPrimary = ActiveSettings::DisplayDRCEnabled();
 	InfoLog_PrintActiveSettings();
 	Latte_Start();
 	// check for debugger entrypoint bp

--- a/src/Cafe/HW/Latte/Core/Latte.h
+++ b/src/Cafe/HW/Latte/Core/Latte.h
@@ -52,7 +52,7 @@ struct LatteGPUState_t
 	uint32 gx2InitCalled; // incremented every time GX2Init() is called
 	// OpenGL control
 	uint32 glVendor; // GLVENDOR_*
-	bool alwaysDisplayDRC = false;
+	bool isDRCPrimary = false;
 	// temporary (replace with proper solution later)
 	bool tvBufferUsesSRGB;
 	bool drcBufferUsesSRGB;

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -989,8 +989,6 @@ void LatteRenderTarget_copyToBackbuffer(LatteTextureView* textureView, bool isPa
 	g_renderer->ImguiEnd();
 }
 
-bool ctrlTabHotkeyPressed = false;
-
 void LatteRenderTarget_itHLECopyColorBufferToScanBuffer(MPTR colorBufferPtr, uint32 colorBufferWidth, uint32 colorBufferHeight, uint32 colorBufferSliceIndex, uint32 colorBufferFormat, uint32 colorBufferPitch, Latte::E_HWTILEMODE colorBufferTilemode, uint32 colorBufferSwizzle, uint32 renderTarget)
 {
 	cemu_assert_debug(colorBufferSliceIndex == 0); // todo - support for non-zero slice
@@ -1000,38 +998,31 @@ void LatteRenderTarget_itHLECopyColorBufferToScanBuffer(MPTR colorBufferPtr, uin
 		return;
 	}
 
+	auto getVPADScreenActive = [](size_t n) -> std::pair<bool, bool> {
+		auto controller = InputManager::instance().get_vpad_controller(n);
+		if (!controller)
+			return {false,false};
+		auto pressed = controller->is_screen_active();
+		auto toggle = controller->is_screen_active_toggle();
+		return {pressed && !toggle, pressed && toggle};
+	};
+
 	const bool tabPressed = gui_isKeyDown(PlatformKeyCodes::TAB);
 	const bool ctrlPressed = gui_isKeyDown(PlatformKeyCodes::LCONTROL);
+	const auto [vpad0Active, vpad0Toggle] = getVPADScreenActive(0);
+	const auto [vpad1Active, vpad1Toggle] = getVPADScreenActive(1);
 
-	bool showDRC = swkbd_hasKeyboardInputHook() == false && tabPressed;
-	bool& alwaysDisplayDRC = LatteGPUState.alwaysDisplayDRC;
+	const bool altScreenRequested = (!ctrlPressed && tabPressed) || vpad0Active || vpad1Active;
+	const bool togglePressed = (ctrlPressed && tabPressed) || vpad0Toggle || vpad1Toggle;
+	static bool togglePressedLast = false;
 
-	if (ctrlPressed && tabPressed)
-	{
-		if (ctrlTabHotkeyPressed == false)
-		{
-			alwaysDisplayDRC = !alwaysDisplayDRC;
-			ctrlTabHotkeyPressed = true;
-		}
-	}
-	else
-		ctrlTabHotkeyPressed = false;
+	bool& isDRCPrimary = LatteGPUState.isDRCPrimary;
 
-	if (alwaysDisplayDRC)
-		showDRC = !tabPressed;
+	if(togglePressed && !togglePressedLast)
+		isDRCPrimary = !isDRCPrimary;
+	togglePressedLast = togglePressed;
 
-	if (!showDRC)
-	{
-		auto controller = InputManager::instance().get_vpad_controller(0);
-		if (controller && controller->is_screen_active())
-			showDRC = true;
-		if (!showDRC)
-		{
-			controller = InputManager::instance().get_vpad_controller(1);
-			if (controller && controller->is_screen_active())
-				showDRC = true;	
-		}
-	}
+	bool showDRC = swkbd_hasKeyboardInputHook() == false && (isDRCPrimary ^ altScreenRequested);
 
 	if ((renderTarget & RENDER_TARGET_DRC) && g_renderer->IsPadWindowActive())
 		LatteRenderTarget_copyToBackbuffer(texView, true);

--- a/src/gui/input/panels/VPADInputPanel.cpp
+++ b/src/gui/input/panels/VPADInputPanel.cpp
@@ -103,7 +103,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	text = new wxStaticText(this, wxID_ANY, _("Volume"));
 	text->Disable();
-	main_sizer->Add(text, wxGBPosition(row, column), wxDefaultSpan, wxALL, 5);
+	main_sizer->Add(text, wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
 	auto*m_volume = new wxSlider(this, wxID_ANY, 0, 0, 100);
 	m_volume->Disable();
@@ -111,7 +111,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	const auto volume_text = new wxStaticText(this, wxID_ANY, wxString::Format("%d%%", 0));
 	volume_text->Disable();
-	main_sizer->Add(volume_text, wxGBPosition(row, column + 2), wxDefaultSpan, wxALL, 5);
+	main_sizer->Add(volume_text, wxGBPosition(row, column + 2), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 	m_volume->Bind(wxEVT_SLIDER, &VPADInputPanel::OnVolumeChange, this, wxID_ANY, wxID_ANY, new wxControlObject(volume_text));
 
 	main_sizer->Add(new wxStaticLine(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVERTICAL), wxGBPosition(0, column + 3), wxGBSpan(11, 1), wxALL | wxEXPAND, 5);

--- a/src/gui/input/panels/VPADInputPanel.cpp
+++ b/src/gui/input/panels/VPADInputPanel.cpp
@@ -103,7 +103,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	text = new wxStaticText(this, wxID_ANY, _("Volume"));
 	text->Disable();
-	main_sizer->Add(text, wxGBPosition(row, column), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+	main_sizer->Add(text, wxGBPosition(row, column), wxDefaultSpan, wxALL, 5);
 
 	auto*m_volume = new wxSlider(this, wxID_ANY, 0, 0, 100);
 	m_volume->Disable();
@@ -111,7 +111,7 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	const auto volume_text = new wxStaticText(this, wxID_ANY, wxString::Format("%d%%", 0));
 	volume_text->Disable();
-	main_sizer->Add(volume_text, wxGBPosition(row, column + 2), wxDefaultSpan, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+	main_sizer->Add(volume_text, wxGBPosition(row, column + 2), wxDefaultSpan, wxALL, 5);
 	m_volume->Bind(wxEVT_SLIDER, &VPADInputPanel::OnVolumeChange, this, wxID_ANY, wxID_ANY, new wxControlObject(volume_text));
 
 	main_sizer->Add(new wxStaticLine(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVERTICAL), wxGBPosition(0, column + 3), wxGBSpan(11, 1), wxALL | wxEXPAND, 5);
@@ -138,8 +138,17 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 
 	add_button_row(main_sizer, row, column, VPADController::kButtonId_Screen, _("show screen"));
 	row++;
-	m_togglePadViewCheckBox = new wxCheckBox(this, wxID_ANY, _("toggle screen"), wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-	main_sizer->Add(m_togglePadViewCheckBox, wxGBPosition(row,column), wxDefaultSpan, wxALL | wxEXPAND, 5);
+
+	auto toggleScreenText = new wxStaticText(this, wxID_ANY, _("toggle screen"));
+	main_sizer->Add(toggleScreenText,
+		wxGBPosition(row, column),
+		wxDefaultSpan,
+		wxALL | wxALIGN_CENTER_VERTICAL, 5);
+	m_togglePadViewCheckBox = new wxCheckBox(this, wxID_ANY, {}, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+	wxString toggleScreenTT = _("Makes the \"show screen\" button toggle between the TV and gamepad screens");
+	m_togglePadViewCheckBox->SetToolTip(toggleScreenTT);
+	toggleScreenText->SetToolTip(toggleScreenTT);
+	main_sizer->Add(m_togglePadViewCheckBox, wxGBPosition(row,column+1), wxDefaultSpan, wxALL | wxEXPAND, 5);
 
 	//////////////////////////////////////////////////////////////////
 

--- a/src/gui/input/panels/VPADInputPanel.cpp
+++ b/src/gui/input/panels/VPADInputPanel.cpp
@@ -5,6 +5,7 @@
 #include <wx/statline.h>
 #include <wx/textctrl.h>
 #include <wx/slider.h>
+#include <wx/checkbox.h>
 
 
 #include "gui/helpers/wxControlObject.h"
@@ -131,11 +132,14 @@ VPADInputPanel::VPADInputPanel(wxWindow* parent)
 	}
 
 	// Blow Mic
-	row = 9;
+	row = 8;
 	add_button_row(main_sizer, row, column, VPADController::kButtonId_Mic, _("blow mic"));
 	row++;
 
 	add_button_row(main_sizer, row, column, VPADController::kButtonId_Screen, _("show screen"));
+	row++;
+	m_togglePadViewCheckBox = new wxCheckBox(this, wxID_ANY, _("toggle screen"), wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+	main_sizer->Add(m_togglePadViewCheckBox, wxGBPosition(row,column), wxDefaultSpan, wxALL | wxEXPAND, 5);
 
 	//////////////////////////////////////////////////////////////////
 
@@ -168,6 +172,8 @@ void VPADInputPanel::on_timer(const EmulatedControllerPtr& emulated_controller, 
 {
 	InputPanel::on_timer(emulated_controller, controller_base);
 
+	static_cast<VPADController*>(emulated_controller.get())->set_screen_toggle(m_togglePadViewCheckBox->GetValue());
+
 	if(emulated_controller)
 	{
 		const auto axis = emulated_controller->get_axis();
@@ -181,4 +187,11 @@ void VPADInputPanel::on_timer(const EmulatedControllerPtr& emulated_controller, 
 void VPADInputPanel::OnVolumeChange(wxCommandEvent& event)
 {
 
+}
+void VPADInputPanel::load_controller(const EmulatedControllerPtr& controller)
+{
+	InputPanel::load_controller(controller);
+
+	const bool isToggle = static_cast<VPADController*>(controller.get())->is_screen_active_toggle();
+	m_togglePadViewCheckBox->SetValue(isToggle);
 }

--- a/src/gui/input/panels/VPADInputPanel.h
+++ b/src/gui/input/panels/VPADInputPanel.h
@@ -4,6 +4,7 @@
 #include "gui/input/panels/InputPanel.h"
 
 class wxInputDraw;
+class wxCheckBox;
 
 class VPADInputPanel : public InputPanel
 {
@@ -11,11 +12,13 @@ public:
 	VPADInputPanel(wxWindow* parent);
 
 	void on_timer(const EmulatedControllerPtr& emulated_controller, const ControllerPtr& controller) override;
+	virtual void load_controller(const EmulatedControllerPtr& controller) override;
 
 private:
 	void OnVolumeChange(wxCommandEvent& event);
 
 	wxInputDraw* m_left_draw, * m_right_draw;
+	wxCheckBox* m_togglePadViewCheckBox;
 
 	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id);
 	void add_button_row(wxGridBagSizer *sizer, sint32 row, sint32 column, const VPADController::ButtonId &button_id, const wxString &label);

--- a/src/input/emulated/VPADController.cpp
+++ b/src/input/emulated/VPADController.cpp
@@ -686,3 +686,14 @@ bool VPADController::set_default_mapping(const std::shared_ptr<ControllerBase>& 
 
 	return mapping_updated;
 }
+
+void VPADController::load(const pugi::xml_node& node)
+{
+	if (const auto value = node.child("toggle_display"))
+		m_screen_active_toggle = ConvertString<bool>(value.child_value());
+}
+
+void VPADController::save(pugi::xml_node& node)
+{
+	node.append_child("toggle_display").append_child(pugi::node_pcdata).set_value(fmt::format("{}", (int)m_screen_active_toggle).c_str());
+}

--- a/src/input/emulated/VPADController.h
+++ b/src/input/emulated/VPADController.h
@@ -66,6 +66,8 @@ public:
 
 	bool is_mic_active() { return m_mic_active; }
 	bool is_screen_active() { return m_screen_active; }
+	bool is_screen_active_toggle() { return m_screen_active_toggle; }
+	void set_screen_toggle(bool toggle) {m_screen_active_toggle = toggle;}
 
 	static std::string_view get_button_name(ButtonId id);
 
@@ -86,9 +88,13 @@ public:
 
 	bool set_default_mapping(const std::shared_ptr<ControllerBase>& controller) override;
 
+	void load(const pugi::xml_node& node) override;
+	void save(pugi::xml_node& node) override;
+
 private:
 	bool m_mic_active = false;
 	bool m_screen_active = false;
+	bool m_screen_active_toggle = false;
 	uint32be m_last_holdvalue = 0;
 
 	std::chrono::high_resolution_clock::time_point m_last_hold_change{}, m_last_pulse{};


### PR DESCRIPTION
In addition to adding a checkbox this also alters the behaviour of pressing the "show screen" button. Currently if you enable the "Launch with gamepad view" option in the game profile, pressing the button does nothing. I've changed it so it acts like the TAB key and shows the TV screen.
![image](https://github.com/user-attachments/assets/a3109ff1-36d4-40c5-bc6b-0cfb8242dc46)
![image](https://github.com/user-attachments/assets/633cdafc-9133-4f98-a75f-d330a59d6bfb)

I'm not happy with the alignment of the volume slider and the checkbox. That's the main reason why this is marked as draft. I think it needs to look a little more polished.
EDIT: I've added a windows screenshot since writing this and I think it doesn't look as bad on windows.
Closes: #1373
Closes: #916