### PR TITLE
Vulkan: Make scaling shaders compatible + fixes

### DIFF
--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -960,7 +960,7 @@ bool GraphicPack2::Activate()
 				auto option_upscale = rules.FindOption("upscaleMagFilter");
 				if(option_upscale && boost::iequals(*option_upscale, "NearestNeighbor"))
 					m_output_settings.upscale_filter = LatteTextureView::MagFilter::kNearestNeighbor;
-				auto option_downscale = rules.FindOption("NearestNeighbor");
+				auto option_downscale = rules.FindOption("downscaleMagFilter");
 				if (option_downscale && boost::iequals(*option_downscale, "NearestNeighbor"))
 					m_output_settings.downscale_filter = LatteTextureView::MagFilter::kNearestNeighbor;
 			}

--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -960,7 +960,7 @@ bool GraphicPack2::Activate()
 				auto option_upscale = rules.FindOption("upscaleMagFilter");
 				if(option_upscale && boost::iequals(*option_upscale, "NearestNeighbor"))
 					m_output_settings.upscale_filter = LatteTextureView::MagFilter::kNearestNeighbor;
-				auto option_downscale = rules.FindOption("downscaleMagFilter");
+				auto option_downscale = rules.FindOption("downscaleMinFilter");
 				if (option_downscale && boost::iequals(*option_downscale, "NearestNeighbor"))
 					m_output_settings.downscale_filter = LatteTextureView::MagFilter::kNearestNeighbor;
 			}

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -950,7 +950,7 @@ void LatteRenderTarget_copyToBackbuffer(LatteTextureView* textureView, bool isPa
 			else
 				shader = RendererOutputShader::s_bicubic_shader;
 
-			filter = LatteTextureView::MagFilter::kNearestNeighbor;
+			filter = LatteTextureView::MagFilter::kLinear;
 		}
 		else if (scaling_filter == kBicubicHermiteFilter)
 		{

--- a/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteRenderTarget.cpp
@@ -933,13 +933,6 @@ void LatteRenderTarget_copyToBackbuffer(LatteTextureView* textureView, bool isPa
 	if (shader == nullptr)
 	{
 		sint32 scaling_filter = downscaling ? GetConfig().downscale_filter : GetConfig().upscale_filter;
-		
-		if (g_renderer->GetType() == RendererAPI::Vulkan)
-		{
-			// force linear or nearest neighbor filter
-			if(scaling_filter != kLinearFilter && scaling_filter != kNearestNeighborFilter)
-				scaling_filter = kLinearFilter;
-		}
 
 		if (scaling_filter == kLinearFilter)
 		{

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -584,6 +584,12 @@ void OpenGLRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	LatteTextureViewGL* texViewGL = (LatteTextureViewGL*)texView;
 	texture_bindAndActivate(texView, 0);
 
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	texViewGL->samplerState.clampS = texViewGL->samplerState.clampT = 0xFF;
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, useLinearTexFilter ? GL_LINEAR : GL_NEAREST);
+	texViewGL->samplerState.filterMin = 0xFFFFFFFF;
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, useLinearTexFilter ? GL_LINEAR : GL_NEAREST);
 	texViewGL->samplerState.filterMag = 0xFFFFFFFF;
 

--- a/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/OpenGL/OpenGLRenderer.cpp
@@ -570,13 +570,10 @@ void OpenGLRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 		g_renderer->ClearColorbuffer(padView);
 	}
 
-	sint32 effectiveWidth, effectiveHeight;
-	texView->baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
-
 	shader_unbind(RendererShader::ShaderType::kGeometry);
 	shader_bind(shader->GetVertexShader());
 	shader_bind(shader->GetFragmentShader());
-	shader->SetUniformParameters(*texView, { effectiveWidth, effectiveHeight }, { imageWidth, imageHeight });
+	shader->SetUniformParameters(*texView, {imageWidth, imageHeight});
 
 	// set viewport
 	glViewportIndexedf(0, imageX, imageY, imageWidth, imageHeight);

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -48,24 +48,23 @@ vec4 cubic(float x)
 	return w / 6.0;
 }
 
-vec4 bcFilter(vec2 texcoord, vec2 texscale)
+vec4 bcFilter(vec2 uv, vec4 texelSize)
 {
-	float fx = fract(texcoord.x);
-	float fy = fract(texcoord.y);
-	texcoord.x -= fx;
-	texcoord.y -= fy;
+	vec2 pixel = uv*texelSize.zw - 0.5;
+	vec2 pixelFrac = fract(pixel);
+	vec2 pixelInt = pixel - pixelFrac;
 
-	vec4 xcubic = cubic(fx);
-	vec4 ycubic = cubic(fy);
+	vec4 xcubic = cubic(pixelFrac.x);
+	vec4 ycubic = cubic(pixelFrac.y);
 
-	vec4 c = vec4(texcoord.x - 0.5, texcoord.x + 1.5, texcoord.y - 0.5, texcoord.y + 1.5);
+	vec4 c = vec4(pixelInt.x - 0.5, pixelInt.x + 1.5, pixelInt.y - 0.5, pixelInt.y + 1.5);
 	vec4 s = vec4(xcubic.x + xcubic.y, xcubic.z + xcubic.w, ycubic.x + ycubic.y, ycubic.z + ycubic.w);
 	vec4 offset = c + vec4(xcubic.y, xcubic.w, ycubic.y, ycubic.w) / s;
 
-	vec4 sample0 = texture(textureSrc, vec2(offset.x, offset.z) * texscale);
-	vec4 sample1 = texture(textureSrc, vec2(offset.y, offset.z) * texscale);
-	vec4 sample2 = texture(textureSrc, vec2(offset.x, offset.w) * texscale);
-	vec4 sample3 = texture(textureSrc, vec2(offset.y, offset.w) * texscale);
+	vec4 sample0 = texture(textureSrc, vec2(offset.x, offset.z) * texelSize.xy);
+	vec4 sample1 = texture(textureSrc, vec2(offset.y, offset.z) * texelSize.xy);
+	vec4 sample2 = texture(textureSrc, vec2(offset.x, offset.w) * texelSize.xy);
+	vec4 sample3 = texture(textureSrc, vec2(offset.y, offset.w) * texelSize.xy);
 
 	float sx = s.x / (s.x + s.y);
 	float sy = s.z / (s.z + s.w);
@@ -76,7 +75,8 @@ vec4 bcFilter(vec2 texcoord, vec2 texscale)
 }
 
 void main(){
-	colorOut0 = vec4(bcFilter(passUV*inputResolution, vec2(1.0,1.0)/inputResolution).rgb,1.0);
+	vec4 texelSize = vec4( 1.0 / inputResolution.xy, inputResolution.xy);
+	colorOut0 = vec4(bcFilter(passUV, texelSize).rgb,1.0);
 }
 )";
 

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -31,7 +31,7 @@ layout(push_constant) uniform pc {
 };
 #else
 in vec2 passUV;
-uniform vec2 textureSrcResolution;
+uniform vec2 inputResolution;
 #endif
 layout(binding = 0)  uniform sampler2D textureSrc;
 layout(location = 0) out vec4 colorOut0;
@@ -76,7 +76,7 @@ vec4 bcFilter(vec2 texcoord, vec2 texscale)
 }
 
 void main(){
-	colorOut0 = vec4(bcFilter(passUV*textureSrcResolution, vec2(1.0,1.0)/textureSrcResolution).rgb,1.0);
+	colorOut0 = vec4(bcFilter(passUV*inputResolution, vec2(1.0,1.0)/inputResolution).rgb,1.0);
 }
 )";
 
@@ -94,8 +94,7 @@ layout(push_constant) uniform pc {
 };
 #else
 in vec2 passUV;
-uniform vec2 textureSrcResolution;
-uniform vec2 outputResolution;
+uniform vec2 inputResolution;
 #endif
 
 layout(location = 0) out vec4 colorOut0;
@@ -152,7 +151,7 @@ vec3 BicubicHermiteTexture(vec2 uv, vec4 texelSize)
 }
 
 void main(){
-	vec4 texelSize = vec4( 1.0 / outputResolution.xy, outputResolution.xy);
+	vec4 texelSize = vec4( 1.0 / inputResolution.xy, inputResolution.xy);
 	colorOut0 = vec4(BicubicHermiteTexture(passUV, texelSize), 1.0);
 }
 )";

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -120,7 +120,7 @@ vec3 BicubicHermiteTexture(vec2 uv, vec4 texelSize)
 	vec2 frac = fract(pixel);	
     pixel = floor(pixel) / texelSize.zw - vec2(texelSize.xy/2.0);
 	
-	vec4 doubleSize = texelSize*texelSize;
+	vec4 doubleSize = texelSize*2.0;
 
 	vec3 C00 = texture(textureSrc, pixel + vec2(-texelSize.x ,-texelSize.y)).rgb;
     vec3 C10 = texture(textureSrc, pixel + vec2( 0.0        ,-texelSize.y)).rgb;

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -142,14 +142,16 @@ RendererOutputShader::RendererOutputShader(const std::string& vertex_source, con
 	}
 }
 
-void RendererOutputShader::SetUniformParameters(const LatteTextureView& texture_view, const Vector2i& input_res, const Vector2i& output_res) const
+void RendererOutputShader::SetUniformParameters(const LatteTextureView& texture_view, const Vector2i& output_res) const
 {
+	sint32 effectiveWidth, effectiveHeight;
+	texture_view.baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
 	auto setUniforms = [&](RendererShader* shader, const UniformLocations& attributes){
 	  float res[2];
 	  if (attributes.m_loc_textureSrcResolution != -1)
 	  {
-		  res[0] = (float)input_res.x;
-		  res[1] = (float)input_res.y;
+		  res[0] = (float)effectiveWidth;
+		  res[1] = (float)effectiveHeight;
 		  shader->SetUniform2fv(attributes.m_loc_textureSrcResolution, res, 1);
 	  }
 

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -284,7 +284,7 @@ void main(){
 
 std::string RendererOutputShader::PrependFragmentPreamble(const std::string& shaderSrc)
 {
-	return R"(#version 420
+	return R"(#version 430
 #ifdef VULKAN
 layout(push_constant) uniform pc {
 	vec2 textureSrcResolution;
@@ -298,7 +298,7 @@ uniform vec2 outputResolution;
 #endif
 
 layout(location = 0) in vec2 passUV;
-layout(binding=0) uniform sampler2D textureSrc;
+layout(binding = 0) uniform sampler2D textureSrc;
 layout(location = 0) out vec4 colorOut0;
 )" + shaderSrc;
 }

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -4,11 +4,7 @@
 const std::string RendererOutputShader::s_copy_shader_source =
 R"(#version 420
 
-#ifdef VULKAN
 layout(location = 0) in vec2 passUV;
-#else
-in vec2 passUV;
-#endif
 layout(binding = 0) uniform sampler2D textureSrc;
 layout(location = 0) out vec4 colorOut0;
 
@@ -23,16 +19,16 @@ R"(
 #version 420
 
 #ifdef VULKAN
-layout(location = 0) in vec2 passUV;
 layout(push_constant) uniform pc {
 	vec2 textureSrcResolution;
 	vec2 inputResolution;
 	vec2 outputResolution;
 };
 #else
-in vec2 passUV;
 uniform vec2 inputResolution;
 #endif
+
+layout(location = 0) in vec2 passUV;
 layout(binding = 0)  uniform sampler2D textureSrc;
 layout(location = 0) out vec4 colorOut0;
 
@@ -83,20 +79,18 @@ void main(){
 const std::string RendererOutputShader::s_hermite_shader_source =
 R"(#version 420
 
-in vec4 gl_FragCoord;
-layout(binding=0) uniform sampler2D textureSrc;
 #ifdef VULKAN
-layout(location = 0) in vec2 passUV;
 layout(push_constant) uniform pc {
 	vec2 textureSrcResolution;
 	vec2 inputResolution;
 	vec2 outputResolution;
 };
 #else
-in vec2 passUV;
 uniform vec2 inputResolution;
 #endif
 
+layout(location = 0) in vec2 passUV;
+layout(binding=0) uniform sampler2D textureSrc;
 layout(location = 0) out vec4 colorOut0;
 
 // https://www.shadertoy.com/view/MllSzX

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp
@@ -146,27 +146,27 @@ void RendererOutputShader::SetUniformParameters(const LatteTextureView& texture_
 {
 	sint32 effectiveWidth, effectiveHeight;
 	texture_view.baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
-	auto setUniforms = [&](RendererShader* shader, const UniformLocations& attributes){
+	auto setUniforms = [&](RendererShader* shader, const UniformLocations& locations){
 	  float res[2];
-	  if (attributes.m_loc_textureSrcResolution != -1)
+	  if (locations.m_loc_textureSrcResolution != -1)
 	  {
 		  res[0] = (float)effectiveWidth;
 		  res[1] = (float)effectiveHeight;
-		  shader->SetUniform2fv(attributes.m_loc_textureSrcResolution, res, 1);
+		  shader->SetUniform2fv(locations.m_loc_textureSrcResolution, res, 1);
 	  }
 
-	  if (attributes.m_loc_nativeResolution != -1)
+	  if (locations.m_loc_nativeResolution != -1)
 	  {
 		  res[0] = (float)texture_view.baseTexture->width;
 		  res[1] = (float)texture_view.baseTexture->height;
-		  shader->SetUniform2fv(attributes.m_loc_nativeResolution, res, 1);
+		  shader->SetUniform2fv(locations.m_loc_nativeResolution, res, 1);
 	  }
 
-	  if (attributes.m_loc_outputResolution != -1)
+	  if (locations.m_loc_outputResolution != -1)
 	  {
 		  res[0] = (float)output_res.x;
 		  res[1] = (float)output_res.y;
-		  shader->SetUniform2fv(attributes.m_loc_outputResolution, res, 1);
+		  shader->SetUniform2fv(locations.m_loc_outputResolution, res, 1);
 	  }
 	};
 	setUniforms(m_vertex_shader, m_uniformLocations[0]);

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
@@ -49,12 +49,12 @@ protected:
 	RendererShader* m_vertex_shader;
 	RendererShader* m_fragment_shader;
 
-	struct
+	struct UniformLocations
 	{
-		sint32 m_loc_texture_src_resolution = -1;
-		sint32 m_loc_input_resolution = -1;
-		sint32 m_loc_output_resolution = -1;
-	} m_attributes[2]{};
+		sint32 m_loc_textureSrcResolution = -1;
+		sint32 m_loc_nativeResolution = -1;
+		sint32 m_loc_outputResolution = -1;
+	} m_uniformLocations[2]{};
 
 private:
 	static const std::string s_copy_shader_source;

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
@@ -43,6 +43,8 @@ public:
 	static std::string GetVulkanVertexSource(bool render_upside_down);
 	static std::string GetOpenGlVertexSource(bool render_upside_down);
 
+	static std::string PrependFragmentPreamble(const std::string& shaderSrc);
+
 protected:
 	RendererShader* m_vertex_shader;
 	RendererShader* m_fragment_shader;

--- a/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
+++ b/src/Cafe/HW/Latte/Renderer/RendererOuputShader.h
@@ -17,7 +17,7 @@ public:
 	RendererOutputShader(const std::string& vertex_source, const std::string& fragment_source);
 	virtual ~RendererOutputShader() = default;
 
-	void SetUniformParameters(const LatteTextureView& texture_view, const Vector2i& input_res, const Vector2i& output_res) const;
+	void SetUniformParameters(const LatteTextureView& texture_view, const Vector2i& output_res) const;
 
 	RendererShader* GetVertexShader() const
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureViewVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureViewVk.cpp
@@ -202,16 +202,24 @@ VkSampler LatteTextureViewVk::GetDefaultTextureSampler(bool useLinearTexFilter)
 	VkSamplerCreateInfo samplerInfo{};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
 
+	// emulate OpenGL linear minFilter
+	// see note under: https://docs.vulkan.org/spec/latest/chapters/samplers.html#VkSamplerCreateInfo
+	samplerInfo.minFilter = VK_FILTER_LINEAR;
+	samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+	samplerInfo.minLod = 0.0f;
+	samplerInfo.maxLod = 0.25f;
+
 	if (useLinearTexFilter)
 	{
 		samplerInfo.magFilter = VK_FILTER_LINEAR;
-		samplerInfo.minFilter = VK_FILTER_LINEAR;
 	}
 	else
 	{
 		samplerInfo.magFilter = VK_FILTER_NEAREST;
-		samplerInfo.minFilter = VK_FILTER_NEAREST;
 	}
+	samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
 
 	if (vkCreateSampler(m_device, &samplerInfo, nullptr, &sampler) != VK_SUCCESS)
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureViewVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureViewVk.cpp
@@ -202,9 +202,9 @@ VkSampler LatteTextureViewVk::GetDefaultTextureSampler(bool useLinearTexFilter)
 	VkSamplerCreateInfo samplerInfo{};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
 
-	// emulate OpenGL linear minFilter
+	// emulate OpenGL minFilters
 	// see note under: https://docs.vulkan.org/spec/latest/chapters/samplers.html#VkSamplerCreateInfo
-	samplerInfo.minFilter = VK_FILTER_LINEAR;
+	// if maxLod = 0 then magnification is always performed
 	samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
 	samplerInfo.minLod = 0.0f;
 	samplerInfo.maxLod = 0.25f;
@@ -212,10 +212,12 @@ VkSampler LatteTextureViewVk::GetDefaultTextureSampler(bool useLinearTexFilter)
 	if (useLinearTexFilter)
 	{
 		samplerInfo.magFilter = VK_FILTER_LINEAR;
+		samplerInfo.minFilter = VK_FILTER_LINEAR;
 	}
 	else
 	{
 		samplerInfo.magFilter = VK_FILTER_NEAREST;
+		samplerInfo.minFilter = VK_FILTER_NEAREST;
 	}
 	samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
 	samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2965,24 +2965,23 @@ void VulkanRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	vkCmdBindDescriptorSets(m_state.currentCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &descriptSet, 0, nullptr);
 
 	// update push constants
-	Vector2f pushData;
+	Vector2f pushData[3];
 
 	// textureSrcResolution
 	sint32 effectiveWidth, effectiveHeight;
 	texView->baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
-	pushData = {(float)effectiveWidth, (float)effectiveHeight};
-	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0*sizeof(float)*2, sizeof(float)*2, &pushData);
+	pushData[0] = {(float)effectiveWidth, (float)effectiveHeight};
 
 	// nativeResolution
-	pushData = {
+	pushData[1] = {
 		(float)texViewVk->baseTexture->width,
 		(float)texViewVk->baseTexture->height,
 	};
-	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 1*sizeof(float)*2, sizeof(float)*2, &pushData);
 
 	// outputResolution
-	pushData = {(float)imageWidth,(float)imageHeight};
-	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 2*sizeof(float)*2, sizeof(float)*2, &pushData);
+	pushData[2] = {(float)imageWidth,(float)imageHeight};
+
+	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(float) * 2 * 3, &pushData);
 
 	vkCmdDraw(m_state.currentCommandBuffer, 6, 1, 0, 0);
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2968,16 +2968,16 @@ void VulkanRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	Vector2f pushData;
 
 	// textureSrcResolution
+	sint32 effectiveWidth, effectiveHeight;
+	texView->baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
+	pushData = {(float)effectiveWidth, (float)effectiveHeight};
+	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0*sizeof(float)*2, sizeof(float)*2, &pushData);
+
+	// nativeResolution
 	pushData = {
 		(float)texViewVk->baseTexture->width,
 		(float)texViewVk->baseTexture->height,
 	};
-	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0*sizeof(float)*2, sizeof(float)*2, &pushData);
-
-	// inputResolution
-	sint32 effectiveWidth, effectiveHeight;
-	texView->baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
-	pushData = {(float)effectiveWidth, (float)effectiveHeight};
 	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 1*sizeof(float)*2, sizeof(float)*2, &pushData);
 
 	// outputResolution

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -2581,10 +2581,18 @@ VkPipeline VulkanRenderer::backbufferBlit_createGraphicsPipeline(VkDescriptorSet
 	colorBlending.blendConstants[2] = 0.0f;
 	colorBlending.blendConstants[3] = 0.0f;
 
+	VkPushConstantRange pushConstantRange{
+		.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+		.offset = 0,
+		.size = 3 * sizeof(float) * 2 // 3 vec2's
+	};
+
 	VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
 	pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
 	pipelineLayoutInfo.setLayoutCount = 1;
 	pipelineLayoutInfo.pSetLayouts = &descriptorLayout;
+	pipelineLayoutInfo.pushConstantRangeCount = 1;
+	pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
 
 	VkResult result = vkCreatePipelineLayout(m_logicalDevice, &pipelineLayoutInfo, nullptr, &m_pipelineLayout);
 	if (result != VK_SUCCESS)
@@ -2955,6 +2963,26 @@ void VulkanRenderer::DrawBackbufferQuad(LatteTextureView* texView, RendererOutpu
 	m_state.currentPipeline = pipeline;
 
 	vkCmdBindDescriptorSets(m_state.currentCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipelineLayout, 0, 1, &descriptSet, 0, nullptr);
+
+	// update push constants
+	Vector2f pushData;
+
+	// textureSrcResolution
+	pushData = {
+		(float)texViewVk->baseTexture->width,
+		(float)texViewVk->baseTexture->height,
+	};
+	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0*sizeof(float)*2, sizeof(float)*2, &pushData);
+
+	// inputResolution
+	sint32 effectiveWidth, effectiveHeight;
+	texView->baseTexture->GetEffectiveSize(effectiveWidth, effectiveHeight, 0);
+	pushData = {(float)effectiveWidth, (float)effectiveHeight};
+	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 1*sizeof(float)*2, sizeof(float)*2, &pushData);
+
+	// outputResolution
+	pushData = {(float)imageWidth,(float)imageHeight};
+	vkCmdPushConstants(m_state.currentCommandBuffer, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 2*sizeof(float)*2, sizeof(float)*2, &pushData);
 
 	vkCmdDraw(m_state.currentCommandBuffer, 6, 1, 0, 0);
 


### PR DESCRIPTION
Make built-in scaling shaders compatible with vulkan and incorporate the fixes from #879

### Changes for graphic pack developers
- Cemu now prepends a preamble containing all the uniforms so you can just write the shader parts :smile: 
- preamble uses GLSL version 430
- ``textureSrcResolution`` is now the actual resolution of the textureSrc sampler.
- ``inputResolution`` has been replaced by ``nativeResolution`` and gives the resolution that the game would render at without graphic pack overrides.

#### Full preamble (as of writing) for reference
https://github.com/cemu-project/Cemu/blob/e2e9e81c3eaa626b401a9a61f10daf7335f95d7f/src/Cafe/HW/Latte/Renderer/RendererOuputShader.cpp#L287-L302