### PR TITLE
Check whether portable is directory to avoid conflict with portable sandboxing framework

### DIFF
--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -88,7 +88,7 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Windo
 	fs::path exePath(wxHelper::MakeFSPath(standardPaths.GetExecutablePath()));
 	fs::path portablePath = exePath.parent_path() / "portable";
 	data_path = exePath.parent_path(); // the data path is always the same as the exe path
-	if (fs::exists(portablePath, ec))
+	if (fs::is_directory(portablePath, ec))
 	{
 		isPortable = true;
 		user_data_path = config_path = cache_path = portablePath;


### PR DESCRIPTION
Portable sandboxing framework adds an executable called "portable" which may confuse the portable configuration check of cemu. Fix #1444 