### PR TITLE
ALLOW_PORTABLE build flag and directory check 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.21.1)
 
 option(ENABLE_VCPKG "Enable the vcpkg package manager" ON)
 option(MACOS_BUNDLE "The executable when built on macOS will be created as an application bundle" OFF)
+option(ALLOW_PORTABLE "Allow Cemu to be run in portable mode" ON)
 
 # used by CI script to set version:
 set(EMULATOR_VERSION_MAJOR "0" CACHE STRING "")

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -178,3 +178,7 @@ endif()
 if(WIN32)
 	target_link_libraries(CemuGui PRIVATE bthprops)
 endif()
+
+if(ALLOW_PORTABLE)
+	target_compile_definitions(CemuGui PRIVATE CEMU_ALLOW_PORTABLE)
+endif ()

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -89,7 +89,7 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Windo
 	fs::path portablePath = exePath.parent_path() / "portable";
 	data_path = exePath.parent_path(); // the data path is always the same as the exe path
 #ifdef CEMU_ALLOW_PORTABLE
-	if (fs::exists(portablePath, ec))
+	if (fs::is_directory(portablePath, ec))
 	{
 		isPortable = true;
 		user_data_path = config_path = cache_path = portablePath;
@@ -132,7 +132,7 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Linux
 		portablePath = exePath.parent_path() / "portable";
 	}
 #ifdef CEMU_ALLOW_PORTABLE
-	if (fs::exists(portablePath, ec))
+	if (fs::is_directory(portablePath, ec))
 	{
 		isPortable = true;
 		user_data_path = config_path = cache_path = portablePath;
@@ -174,8 +174,8 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for MacOS
     // If run from an app bundle, use its parent directory
 	fs::path appPath = exePath.parent_path().parent_path().parent_path();
 	fs::path portablePath = appPath.extension() == ".app" ? appPath.parent_path() / "portable" : exePath.parent_path() / "portable";
-	#ifdef CEMU_ALLOW_PORTABLE
-	if (fs::exists(portablePath, ec))
+#ifdef CEMU_ALLOW_PORTABLE
+	if (fs::is_directory(portablePath, ec))
 	{
 		isPortable = true;
 		user_data_path = config_path = cache_path = portablePath;

--- a/src/gui/CemuApp.cpp
+++ b/src/gui/CemuApp.cpp
@@ -88,12 +88,14 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Windo
 	fs::path exePath(wxHelper::MakeFSPath(standardPaths.GetExecutablePath()));
 	fs::path portablePath = exePath.parent_path() / "portable";
 	data_path = exePath.parent_path(); // the data path is always the same as the exe path
+#ifdef CEMU_ALLOW_PORTABLE
 	if (fs::exists(portablePath, ec))
 	{
 		isPortable = true;
 		user_data_path = config_path = cache_path = portablePath;
 	}
 	else
+#endif
 	{
 		fs::path roamingPath = GetAppDataRoamingPath() / "Cemu";
 		user_data_path = config_path = cache_path = roamingPath;
@@ -124,11 +126,12 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Linux
 	fs::path portablePath = exePath.parent_path() / "portable";
 	// GetExecutablePath returns the AppImage's temporary mount location
 	wxString appImagePath;
-	if (wxGetEnv(("APPIMAGE"), &appImagePath))
+	if (wxGetEnv("APPIMAGE", &appImagePath))
 	{
 		exePath = wxHelper::MakeFSPath(appImagePath);
 		portablePath = exePath.parent_path() / "portable";
 	}
+#ifdef CEMU_ALLOW_PORTABLE
 	if (fs::exists(portablePath, ec))
 	{
 		isPortable = true;
@@ -137,6 +140,7 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for Linux
 		data_path = exePath.parent_path();
 	}
 	else
+#endif
 	{
 		SetAppName("Cemu");
 		wxString appName = GetAppName();
@@ -167,9 +171,10 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for MacOS
 	fs::path user_data_path, config_path, cache_path, data_path;
 	auto standardPaths = wxStandardPaths::Get();
 	fs::path exePath(wxHelper::MakeFSPath(standardPaths.GetExecutablePath()));
-        // If run from an app bundle, use its parent directory
-        fs::path appPath = exePath.parent_path().parent_path().parent_path();
-        fs::path portablePath = appPath.extension() == ".app" ? appPath.parent_path() / "portable" : exePath.parent_path() / "portable";
+    // If run from an app bundle, use its parent directory
+	fs::path appPath = exePath.parent_path().parent_path().parent_path();
+	fs::path portablePath = appPath.extension() == ".app" ? appPath.parent_path() / "portable" : exePath.parent_path() / "portable";
+	#ifdef CEMU_ALLOW_PORTABLE
 	if (fs::exists(portablePath, ec))
 	{
 		isPortable = true;
@@ -177,6 +182,7 @@ void CemuApp::DeterminePaths(std::set<fs::path>& failedWriteAccess) // for MacOS
 		data_path = exePath.parent_path();
 	}
 	else
+#endif
 	{
 		SetAppName("Cemu");
 		wxString appName = GetAppName();


### PR DESCRIPTION
`ALLOW_PORTABLE` cmake flag to determine whether portable mode *can* be used. Defaulted to `ON`.

Also check that the portable path is indeed a directory, as in https://github.com/cemu-project/Cemu/pull/1445

Fixes https://github.com/cemu-project/Cemu/issues/1444
