### PR TITLE
Always use a single core while interpreter mode

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -9,6 +9,7 @@
 #include "audio/IAudioAPI.h"
 #include "audio/IAudioInputAPI.h"
 #include "config/ActiveSettings.h"
+#include "config/LaunchSettings.h"
 #include "Cafe/TitleList/GameInfo.h"
 #include "Cafe/GraphicPack/GraphicPack2.h"
 #include "util/helpers/SystemException.h"
@@ -843,7 +844,7 @@ namespace CafeSystem
 			module->TitleStart();
 		cemu_initForGame();
 		// enter scheduler
-		if (ActiveSettings::GetCPUMode() == CPUMode::MulticoreRecompiler)
+		if (ActiveSettings::GetCPUMode() == CPUMode::MulticoreRecompiler && !LaunchSettings::ForceInterpreter())
 			coreinit::OSSchedulerBegin(3);
 		else
 			coreinit::OSSchedulerBegin(1);

--- a/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
+++ b/src/Cafe/HW/Espresso/Debugger/Debugger.cpp
@@ -575,7 +575,7 @@ void debugger_enterTW(PPCInterpreter_t* hCPU)
 	debuggerState.debugSession.stepInto = false;
 	debuggerState.debugSession.stepOver = false;
 	debuggerState.debugSession.run = false;
-	while (true)
+	while (debuggerState.debugSession.isTrapped)
 	{
 		std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		// check for step commands


### PR DESCRIPTION
Cemu's CPU interpreter mode (as opposed to the default speedy recompiler mode) is expected to be primarily used for debugging, and thus should always be used with one core. However, unlike the game profile option, the `--force-interpreter` launch parameter didn't limit the amount of cores used to 1 which caused issues with multiple threads trying to be paused at the same time.

This commit fixes that issue, alongside an additional fix that might help situations where a debugger trap instruction gets hit by two threads simultaneously. Eventually this should be replaced with a more advanced approach that'd freeze other threads while stepping.
