### PR TITLE
nsyshid: Initialise libusb index as 0

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/BackendLibusb.cpp
+++ b/src/Cafe/OS/libs/nsyshid/BackendLibusb.cpp
@@ -272,7 +272,7 @@ namespace nsyshid::backend::libusb
 		auto device = std::make_shared<DeviceLibusb>(m_ctx,
 													 desc.idVendor,
 													 desc.idProduct,
-													 1,
+													 0,
 													 2,
 													 0,
 													 libusb_get_bus_number(dev),


### PR DESCRIPTION
As the SetReport method now uses a reference to m_interfaceIndex when sending reports, this needs to be initialised as 0 as initialising as 1 causes errors if a device has only 1 interface (which is all USB portals that I know of). Should have been included as part of https://github.com/cemu-project/Cemu/pull/1471