### PR TITLE
Fix building against fmt 11.1.0

### DIFF
--- a/src/Cafe/GameProfile/GameProfile.cpp
+++ b/src/Cafe/GameProfile/GameProfile.cpp
@@ -147,7 +147,7 @@ bool gameProfile_loadEnumOption(IniParser& iniParser, const char* optionName, T&
 		}
 
 		// test enum name
-		if(boost::iequals(fmt::format("{}", v), *option_value))
+		if(boost::iequals(fmt::format("{}", fmt::underlying(v)), *option_value))
 		{
 			option = v;
 			return true;


### PR DESCRIPTION
I don't know why this particular enum is not deal with [this code](https://github.com/cemu-project/Cemu/blob/eab1b24320454ef60d6172dd41dfa8379b3015ac/src/Common/precompiled.h#L566-L577), but it solve this error since [fmt 11.1.0](https://github.com/fmtlib/fmt/releases/tag/11.1.0):
```
[505/518] Building CXX object src/Cafe/CMakeFiles/CemuCafe.dir/Account/Account.cpp.o
samu: job failed: /usr/lib/ccache/bin/c++ -DBOOST_NOWIDE_DYN_LINK -DBOOST_NOWIDE_NO_LIB -DEMULATOR_HASH=eab1b243 -DEMULATOR_VERSION_MAJOR=0 -DEMULATOR_VERSION_MINOR=0 -DEMULATOR_VERSION_PATCH=0 -DENABLE_DISCORD_RPC -DENABLE_FERAL_GAMEMODE -DFMT_SHARED -DHAS_BLUEZ -DHAS_CUBEB=1 -DHAS_HIDAPI -DHAS_WAYLAND -DSUPPORTS_WIIMOTE -DVK_NO_PROTOTYPES -DVK_USE_PLATFORM_WAYLAND_KHR -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XLIB_KHR -DWXUSINGDLL -D_FILE_OFFSET_BITS=64 -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -I/build/cemu-git/src/build/src/Cafe -I/build/cemu-git/src/cemu/src/Cafe -I/build/cemu-git/src/cemu/dependencies/Vulkan-Headers/include -I/build/cemu-git/src/cemu/src/Cafe/.. -I/build/cemu-git/src/cemu/src/audio/.. -I/build/cemu-git/src/cemu/src/Common/.. -I/build/cemu-git/src/cemu/src/Cemu/.. -I/build/cemu-git/src/cemu/src/config/.. -I/build/cemu-git/src/cemu/src/gui/.. -I/build/cemu-git/src/cemu/src/input/.. -I/build/cemu-git/src/cemu/src/resource/.. -I/build/cemu-git/src/cemu/src/util/.. -I/build/cemu-git/src/cemu/src/imgui/.. -I/build/cemu-git/src/cemu/src/imgui/../../dependencies/imgui -isystem /usr/lib/wx/include/gtk3-unicode-3.2 -isystem /usr/include/wx-3.2 -isystem /usr/include/gtk-3.0 -isystem /usr/include/pango-1.0 -isystem /usr/include/cloudproviders -isystem /usr/include/cairo -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/at-spi2-atk/2.0 -isystem /usr/include/at-spi-2.0 -isystem /usr/include/atk-1.0 -isystem /usr/include/dbus-1.0 -isystem /usr/lib/dbus-1.0/include -isystem /usr/include/fribidi -isystem /usr/include/pixman-1 -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/libpng16 -isystem /usr/include/gio-unix-2.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/sysprof-6 -isystem /usr/include/libusb-1.0 -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto -DNDEBUG -std=gnu++20 -Wno-multichar -Wno-invalid-offsetof -Wno-switch -Wno-ignored-attributes -Wno-deprecated-enum-enum-conversion -pthread -Winvalid-pch -include /build/cemu-git/src/build/src/Cafe/CMakeFiles/CemuCafe.dir/cmake_pch.hxx -MD -MT src/Cafe/CMakeFiles/CemuCafe.dir/GameProfile/GameProfile.cpp.o -MF src/Cafe/CMakeFiles/CemuCafe.dir/GameProfile/GameProfile.cpp.o.d -o src/Cafe/CMakeFiles/CemuCafe.dir/GameProfile/GameProfile.cpp.o -c /build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp
In file included from /usr/include/fmt/format.h:41,
                 from /usr/include/fmt/core.h:5,
                 from /build/cemu-git/src/cemu/src/Common/precompiled.h:9,
                 from /build/cemu-git/src/build/src/Cafe/CMakeFiles/CemuCafe.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/fmt/base.h: In substitution of ‘template<class T> struct fmt::v11::detail::use_format_as_member<T, std::integral_constant<bool, std::is_arithmetic<typename std::remove_cv<typename std::remove_reference<decltype (fmt::v11::formatter<T>::format_as(declval<const T&>()))>::type>::type>::value> > [with T = const AccurateShaderMulOption]’:
/usr/include/fmt/base.h:1116:73:   required by substitution of ‘template<class T, class U> using fmt::v11::detail::use_formatter = fmt::v11::bool_constant<((bool)(((((((std::is_class<_Tp>::value || std::is_enum<_Tp>::value) || std::is_union<_Tp>::value) || std::is_array<_Tp>::value) && (! fmt::v11::detail::has_to_string_view<T>::value)) && (! fmt::v11::detail::is_named_arg<T>::value)) && (! fmt::v11::detail::use_format_as<T>::value)) && (! fmt::v11::detail::use_format_as_member<T>::value)))> [with T = const AccurateShaderMulOption; U = AccurateShaderMulOption]’
 1116 |                   !use_format_as<T>::value && !use_format_as_member<T>::value>;
      |                                                                         ^~~~~
/usr/include/fmt/base.h:1180:25:   required by substitution of ‘template<class T, typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> > static fmt::v11::conditional_t<((bool)has_formatter<T, char>()), T&, void> fmt::v11::detail::type_mapper<char>::map(T&) [with T = const AccurateShaderMulOption; typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> = <missing>]’
 1180 |   template <typename T, FMT_ENABLE_IF(use_formatter<T>::value)>
      |                         ^~~~~~~~~~~~~
/usr/include/fmt/base.h:1189:57:   required by substitution of ‘template<class T, class Char> using fmt::v11::detail::mapped_type_constant = fmt::v11::detail::type_constant<decltype (fmt::v11::detail::type_mapper<Char>::map(declval<T&>())), Char> [with T = const AccurateShaderMulOption&; Char = char]’
 1189 | using mapped_t = decltype(detail::type_mapper<Char>::map(std::declval<T&>()));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1668:47:   required from ‘constexpr fmt::v11::detail::format_string_checker<Char, NUM_ARGS, NUM_NAMED_ARGS, DYNAMIC_NAMES>::format_string_checker(fmt::v11::basic_string_view<Char>, fmt::v11::detail::arg_pack<T ...>) [with T = {const AccurateShaderMulOption&}; Char = char; int NUM_ARGS = 1; int NUM_NAMED_ARGS = 0; bool DYNAMIC_NAMES = false]’
 1668 |       : types_{mapped_type_constant<T, Char>::value...},
      |                                               ^~~~~
/usr/include/fmt/base.h:2701:57:   required from ‘bool gameProfile_loadEnumOption(IniParser&, const char*, T&) [with T = AccurateShaderMulOption]’
 2701 |     if (FMT_USE_CONSTEVAL) parse_format_string<char>(s, checker(s, arg_pack()));
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:228:30:   required from here
  228 |                         gameProfile_loadEnumOption(iniParser, "accurateShaderMul", m_accurateShaderMul);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:150:32:   in ‘constexpr’ expansion of ‘fmt::v11::fstring<const AccurateShaderMulOption&>("{}")’
/usr/include/fmt/base.h:1093:52: error: ambiguous template instantiation for ‘struct fmt::v11::formatter<const AccurateShaderMulOption, char, void>’
 1093 |     remove_cvref_t<decltype(formatter<T>::format_as(std::declval<const T&>()))>;
      |                             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/cemu-git/src/cemu/src/Common/precompiled.h:11:
/usr/include/fmt/ranges.h:491:8: note: candidates are: ‘template<class R, class Char> struct fmt::v11::formatter<R, Char, typename std::enable_if<fmt::v11::conjunction<std::integral_constant<bool, ((((fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::disabled) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::map)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::string)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::debug_string))>, fmt::v11::detail::is_formattable_delayed<R, Char> >::value, void>::type> [with R = const AccurateShaderMulOption; Char = char]’
  491 | struct formatter<
      |        ^~~~~~~~~~
  492 |     R, Char,
      |     ~~~~~~~~
  493 |     enable_if_t<conjunction<
      |     ~~~~~~~~~~~~~~~~~~~~~~~~
  494 |         bool_constant<
      |         ~~~~~~~~~~~~~~
  495 |             range_format_kind<R, Char>::value != range_format::disabled &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  496 |             range_format_kind<R, Char>::value != range_format::map &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  497 |             range_format_kind<R, Char>::value != range_format::string &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  498 |             range_format_kind<R, Char>::value != range_format::debug_string>,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  499 |         detail::is_formattable_delayed<R, Char>>::value>> {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Common/precompiled.h:568:13: note:                 ‘template<class Enum>  requires  is_enum_v<Enum> struct fmt::v11::formatter<T> [with Enum = const AccurateShaderMulOption]’
  568 | struct fmt::formatter<Enum> : fmt::formatter<underlying_t<Enum>>
      |             ^~~~~~~~~~~~~~~
/usr/include/fmt/base.h: In substitution of ‘template<class T> struct fmt::v11::detail::use_format_as_member<T, std::integral_constant<bool, std::is_arithmetic<typename std::remove_cv<typename std::remove_reference<decltype (fmt::v11::formatter<T>::format_as(declval<const T&>()))>::type>::type>::value> > [with T = const CPUMode]’:
/usr/include/fmt/base.h:1116:73:   required by substitution of ‘template<class T, class U> using fmt::v11::detail::use_formatter = fmt::v11::bool_constant<((bool)(((((((std::is_class<_Tp>::value || std::is_enum<_Tp>::value) || std::is_union<_Tp>::value) || std::is_array<_Tp>::value) && (! fmt::v11::detail::has_to_string_view<T>::value)) && (! fmt::v11::detail::is_named_arg<T>::value)) && (! fmt::v11::detail::use_format_as<T>::value)) && (! fmt::v11::detail::use_format_as_member<T>::value)))> [with T = const CPUMode; U = CPUMode]’
 1116 |                   !use_format_as<T>::value && !use_format_as_member<T>::value>;
      |                                                                         ^~~~~
/usr/include/fmt/base.h:1180:25:   required by substitution of ‘template<class T, typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> > static fmt::v11::conditional_t<((bool)has_formatter<T, char>()), T&, void> fmt::v11::detail::type_mapper<char>::map(T&) [with T = const CPUMode; typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> = <missing>]’
 1180 |   template <typename T, FMT_ENABLE_IF(use_formatter<T>::value)>
      |                         ^~~~~~~~~~~~~
/usr/include/fmt/base.h:1189:57:   required by substitution of ‘template<class T, class Char> using fmt::v11::detail::mapped_type_constant = fmt::v11::detail::type_constant<decltype (fmt::v11::detail::type_mapper<Char>::map(declval<T&>())), Char> [with T = const CPUMode&; Char = char]’
 1189 | using mapped_t = decltype(detail::type_mapper<Char>::map(std::declval<T&>()));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1668:47:   required from ‘constexpr fmt::v11::detail::format_string_checker<Char, NUM_ARGS, NUM_NAMED_ARGS, DYNAMIC_NAMES>::format_string_checker(fmt::v11::basic_string_view<Char>, fmt::v11::detail::arg_pack<T ...>) [with T = {const CPUMode&}; Char = char; int NUM_ARGS = 1; int NUM_NAMED_ARGS = 0; bool DYNAMIC_NAMES = false]’
 1668 |       : types_{mapped_type_constant<T, Char>::value...},
      |                                               ^~~~~
/usr/include/fmt/base.h:2701:57:   required from ‘bool gameProfile_loadEnumOption(IniParser&, const char*, T&) [with T = CPUMode]’
 2701 |     if (FMT_USE_CONSTEVAL) parse_format_string<char>(s, checker(s, arg_pack()));
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:163:48:   required from ‘bool gameProfile_loadEnumOption(IniParser&, const char*, std::optional<_Tp>&) [with T = CPUMode]’
  163 |         const auto result = gameProfile_loadEnumOption(iniParser, optionName, tmp);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:251:35:   required from here
  251 |                         if (!gameProfile_loadEnumOption(iniParser, "cpuMode", m_cpuMode))
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:150:32:   in ‘constexpr’ expansion of ‘fmt::v11::fstring<const CPUMode&>("{}")’
/usr/include/fmt/base.h:1093:52: error: ambiguous template instantiation for ‘struct fmt::v11::formatter<const CPUMode, char, void>’
 1093 |     remove_cvref_t<decltype(formatter<T>::format_as(std::declval<const T&>()))>;
      |                             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/ranges.h:491:8: note: candidates are: ‘template<class R, class Char> struct fmt::v11::formatter<R, Char, typename std::enable_if<fmt::v11::conjunction<std::integral_constant<bool, ((((fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::disabled) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::map)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::string)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::debug_string))>, fmt::v11::detail::is_formattable_delayed<R, Char> >::value, void>::type> [with R = const CPUMode; Char = char]’
  491 | struct formatter<
      |        ^~~~~~~~~~
  492 |     R, Char,
      |     ~~~~~~~~
  493 |     enable_if_t<conjunction<
      |     ~~~~~~~~~~~~~~~~~~~~~~~~
  494 |         bool_constant<
      |         ~~~~~~~~~~~~~~
  495 |             range_format_kind<R, Char>::value != range_format::disabled &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  496 |             range_format_kind<R, Char>::value != range_format::map &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  497 |             range_format_kind<R, Char>::value != range_format::string &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  498 |             range_format_kind<R, Char>::value != range_format::debug_string>,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  499 |         detail::is_formattable_delayed<R, Char>>::value>> {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Common/precompiled.h:568:13: note:                 ‘template<class Enum>  requires  is_enum_v<Enum> struct fmt::v11::formatter<T> [with Enum = const CPUMode]’
  568 | struct fmt::formatter<Enum> : fmt::formatter<underlying_t<Enum>>
      |             ^~~~~~~~~~~~~~~
/usr/include/fmt/base.h: In substitution of ‘template<class T> struct fmt::v11::detail::use_format_as_member<T, std::integral_constant<bool, std::is_arithmetic<typename std::remove_cv<typename std::remove_reference<decltype (fmt::v11::formatter<T>::format_as(declval<const T&>()))>::type>::type>::value> > [with T = const CPUModeLegacy]’:
/usr/include/fmt/base.h:1116:73:   required by substitution of ‘template<class T, class U> using fmt::v11::detail::use_formatter = fmt::v11::bool_constant<((bool)(((((((std::is_class<_Tp>::value || std::is_enum<_Tp>::value) || std::is_union<_Tp>::value) || std::is_array<_Tp>::value) && (! fmt::v11::detail::has_to_string_view<T>::value)) && (! fmt::v11::detail::is_named_arg<T>::value)) && (! fmt::v11::detail::use_format_as<T>::value)) && (! fmt::v11::detail::use_format_as_member<T>::value)))> [with T = const CPUModeLegacy; U = CPUModeLegacy]’
 1116 |                   !use_format_as<T>::value && !use_format_as_member<T>::value>;
      |                                                                         ^~~~~
/usr/include/fmt/base.h:1180:25:   required by substitution of ‘template<class T, typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> > static fmt::v11::conditional_t<((bool)has_formatter<T, char>()), T&, void> fmt::v11::detail::type_mapper<char>::map(T&) [with T = const CPUModeLegacy; typename std::enable_if<fmt::v11::detail::use_formatter<T, typename std::remove_const<_Tp>::type>::value, int>::type <anonymous> = <missing>]’
 1180 |   template <typename T, FMT_ENABLE_IF(use_formatter<T>::value)>
      |                         ^~~~~~~~~~~~~
/usr/include/fmt/base.h:1189:57:   required by substitution of ‘template<class T, class Char> using fmt::v11::detail::mapped_type_constant = fmt::v11::detail::type_constant<decltype (fmt::v11::detail::type_mapper<Char>::map(declval<T&>())), Char> [with T = const CPUModeLegacy&; Char = char]’
 1189 | using mapped_t = decltype(detail::type_mapper<Char>::map(std::declval<T&>()));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1668:47:   required from ‘constexpr fmt::v11::detail::format_string_checker<Char, NUM_ARGS, NUM_NAMED_ARGS, DYNAMIC_NAMES>::format_string_checker(fmt::v11::basic_string_view<Char>, fmt::v11::detail::arg_pack<T ...>) [with T = {const CPUModeLegacy&}; Char = char; int NUM_ARGS = 1; int NUM_NAMED_ARGS = 0; bool DYNAMIC_NAMES = false]’
 1668 |       : types_{mapped_type_constant<T, Char>::value...},
      |                                               ^~~~~
/usr/include/fmt/base.h:2701:57:   required from ‘bool gameProfile_loadEnumOption(IniParser&, const char*, T&) [with T = CPUModeLegacy]’
 2701 |     if (FMT_USE_CONSTEVAL) parse_format_string<char>(s, checker(s, arg_pack()));
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:163:48:   required from ‘bool gameProfile_loadEnumOption(IniParser&, const char*, std::optional<_Tp>&) [with T = CPUModeLegacy]’
  163 |         const auto result = gameProfile_loadEnumOption(iniParser, optionName, tmp);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:255:35:   required from here
  255 |                                 if (gameProfile_loadEnumOption(iniParser, "cpuMode", cpu_mode_legacy) && cpu_mode_legacy.has_value())
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Cafe/GameProfile/GameProfile.cpp:150:32:   in ‘constexpr’ expansion of ‘fmt::v11::fstring<const CPUModeLegacy&>("{}")’
/usr/include/fmt/base.h:1093:52: error: ambiguous template instantiation for ‘struct fmt::v11::formatter<const CPUModeLegacy, char, void>’
 1093 |     remove_cvref_t<decltype(formatter<T>::format_as(std::declval<const T&>()))>;
      |                             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/ranges.h:491:8: note: candidates are: ‘template<class R, class Char> struct fmt::v11::formatter<R, Char, typename std::enable_if<fmt::v11::conjunction<std::integral_constant<bool, ((((fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::disabled) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::map)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::string)) && (fmt::v11::range_format_kind<R, Char, void>::value != fmt::v11::range_format::debug_string))>, fmt::v11::detail::is_formattable_delayed<R, Char> >::value, void>::type> [with R = const CPUModeLegacy; Char = char]’
  491 | struct formatter<
      |        ^~~~~~~~~~
  492 |     R, Char,
      |     ~~~~~~~~
  493 |     enable_if_t<conjunction<
      |     ~~~~~~~~~~~~~~~~~~~~~~~~
  494 |         bool_constant<
      |         ~~~~~~~~~~~~~~
  495 |             range_format_kind<R, Char>::value != range_format::disabled &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  496 |             range_format_kind<R, Char>::value != range_format::map &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  497 |             range_format_kind<R, Char>::value != range_format::string &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  498 |             range_format_kind<R, Char>::value != range_format::debug_string>,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  499 |         detail::is_formattable_delayed<R, Char>>::value>> {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/cemu-git/src/cemu/src/Common/precompiled.h:568:13: note:                 ‘template<class Enum>  requires  is_enum_v<Enum> struct fmt::v11::formatter<T> [with Enum = const CPUModeLegacy]’
  568 | struct fmt::formatter<Enum> : fmt::formatter<underlying_t<Enum>>
      |             ^~~~~~~~~~~~~~~
In file included from /build/cemu-git/src/cemu/src/Cafe/../Cafe/OS/RPL/rpl_structs.h:3,
                 from /build/cemu-git/src/cemu/src/Cafe/GraphicPack/GraphicPack2PatchesApply.cpp:4:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h: In member function ‘void ChunkedHeap<TMinimumAlignment>::verifyHeap()’:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h:286:49: warning: expected ‘template’ keyword before dependent template name [-Wmissing-template-keyword]
  286 |                                         if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
      |                                                 ^~~~~~
      |                                                 template
In file included from /build/cemu-git/src/cemu/src/Cafe/../Cafe/OS/RPL/rpl_structs.h:3,
                 from /build/cemu-git/src/cemu/src/Cafe/HW/Espresso/Debugger/GDBStub.cpp:8:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h: In member function ‘void ChunkedHeap<TMinimumAlignment>::verifyHeap()’:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h:286:49: warning: expected ‘template’ keyword before dependent template name [-Wmissing-template-keyword]
  286 |                                         if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
      |                                                 ^~~~~~
      |                                                 template
/build/cemu-git/src/cemu/src/Cafe/Filesystem/FST/FST.cpp: In member function ‘void FSTVolume::DetermineUnhashedBlockIV(uint32, uint32, uint8*)’:
/build/cemu-git/src/cemu/src/Cafe/Filesystem/FST/FST.cpp:924:33: warning: ‘sizeof’ on array function parameter ‘ivOut’ will return size of ‘uint8*’ {aka ‘unsigned char*’} [-Wsizeof-array-argument]
  924 |         memset(ivOut, 0, sizeof(ivOut));
      |                                ~^~~~~~
/build/cemu-git/src/cemu/src/Cafe/Filesystem/FST/FST.cpp:922:88: note: declared here
  922 | void FSTVolume::DetermineUnhashedBlockIV(uint32 clusterIndex, uint32 blockIndex, uint8 ivOut[16])
      |                                                                                  ~~~~~~^~~~~~~~~
In file included from /build/cemu-git/src/cemu/src/Cafe/../Cafe/OS/RPL/rpl_structs.h:3,
                 from /build/cemu-git/src/cemu/src/Cafe/HW/Espresso/Debugger/Debugger.cpp:3:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h: In member function ‘void ChunkedHeap<TMinimumAlignment>::verifyHeap()’:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h:286:49: warning: expected ‘template’ keyword before dependent template name [-Wmissing-template-keyword]
  286 |                                         if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
      |                                                 ^~~~~~
      |                                                 template
In file included from /build/cemu-git/src/cemu/src/Cafe/../Cafe/OS/RPL/rpl_structs.h:3,
                 from /build/cemu-git/src/cemu/src/Cafe/GraphicPack/GraphicPack2Patches.cpp:5:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h: In member function ‘void ChunkedHeap<TMinimumAlignment>::verifyHeap()’:
/build/cemu-git/src/cemu/src/Cafe/../util/ChunkedHeap/ChunkedHeap.h:286:49: warning: expected ‘template’ keyword before dependent template name [-Wmissing-template-keyword]
  286 |                                         if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
      |                                                 ^~~~~~
      |                                                 template
```