### PR TITLE
nsyshid: Play Emulated Portal Audio via Mono Audio

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShaderCache.cpp
@@ -209,7 +209,7 @@ class BootSoundPlayer
 
 		try
 		{
-			bootSndAudioDev = IAudioAPI::CreateDeviceFromConfig(true, sampleRate, nChannels, samplesPerBlock, bitsPerSample);
+			bootSndAudioDev = IAudioAPI::CreateDeviceFromConfig(IAudioAPI::AudioType::TV, sampleRate, nChannels, samplesPerBlock, bitsPerSample);
 			if(!bootSndAudioDev)
 				return;
 		}

--- a/src/Cafe/OS/libs/nsyshid/Skylander.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.cpp
@@ -6,6 +6,8 @@
 #include "Backend.h"
 
 #include "Common/FileStream.h"
+#include "audio/IAudioAPI.h"
+#include "config/CemuConfig.h"
 
 namespace nsyshid
 {
@@ -558,6 +560,45 @@ namespace nsyshid
 
 	Device::WriteResult SkylanderPortalDevice::Write(WriteMessage* message)
 	{
+		if (message->length != 64) {
+			cemu_assert_error();
+		}
+
+		if (!g_portalAudio)
+		{
+			auto& config = GetConfig();
+			auto& selectedDevice = L"default";
+
+			const auto audio_api = (IAudioAPI::AudioAPI)config.audio_api;
+			IAudioAPI::DeviceDescriptionPtr device_description;
+			if (IAudioAPI::IsAudioAPIAvailable(audio_api))
+			{
+				auto devices = IAudioAPI::GetDevices(audio_api);
+				const auto it = std::find_if(devices.begin(), devices.end(), [&selectedDevice](const auto& d) {
+					return d->GetIdentifier() == selectedDevice;
+				});
+				if (it != devices.end())
+				{
+					device_description = *it;
+				}
+			}
+			if (!device_description)
+				throw std::runtime_error("failed to find selected device while trying to create audio device");
+			
+			// Portal audio is mono channel, 16 bit audio.
+			// Audio is unsigned 16 bit, supplied as 64 bytes which is 32 samples per block
+			g_portalAudio = IAudioAPI::CreateDevice((IAudioAPI::AudioAPI)GetConfig().audio_api, device_description, 8000, 1, 32, 16);
+		}
+		std::array<sint16, 32> mono_samples;
+		for (unsigned int i = 0; i < mono_samples.size(); ++i)
+		{
+			sint16 sample = static_cast<uint16>(message->data[i * 2 + 1]) << 8 | static_cast<uint16>(message->data[i * 2]);
+			mono_samples[i] = sample;
+		}
+		if (g_portalAudio)
+		{
+			g_portalAudio->FeedBlock(mono_samples.data());
+		}
 		message->bytesWritten = message->length;
 		return Device::WriteResult::Success;
 	}
@@ -604,20 +645,20 @@ namespace nsyshid
 		*(uint16be*)(currentWritePtr + 7) = 0x001D; // wDescriptorLength
 		currentWritePtr = currentWritePtr + 9;
 		// endpoint descriptor 1
-		*(uint8*)(currentWritePtr + 0) = 7;		  // bLength
-		*(uint8*)(currentWritePtr + 1) = 0x05;	  // bDescriptorType
-		*(uint8*)(currentWritePtr + 2) = 0x81;	  // bEndpointAddress
-		*(uint8*)(currentWritePtr + 3) = 0x03;	  // bmAttributes
+		*(uint8*)(currentWritePtr + 0) = 7;			// bLength
+		*(uint8*)(currentWritePtr + 1) = 0x05;		// bDescriptorType
+		*(uint8*)(currentWritePtr + 2) = 0x81;		// bEndpointAddress
+		*(uint8*)(currentWritePtr + 3) = 0x03;		// bmAttributes
 		*(uint16be*)(currentWritePtr + 4) = 0x0040; // wMaxPacketSize
-		*(uint8*)(currentWritePtr + 6) = 0x01;	  // bInterval
+		*(uint8*)(currentWritePtr + 6) = 0x01;		// bInterval
 		currentWritePtr = currentWritePtr + 7;
 		// endpoint descriptor 2
-		*(uint8*)(currentWritePtr + 0) = 7;		  // bLength
-		*(uint8*)(currentWritePtr + 1) = 0x05;	  // bDescriptorType
-		*(uint8*)(currentWritePtr + 2) = 0x02;	  // bEndpointAddress
-		*(uint8*)(currentWritePtr + 3) = 0x03;	  // bmAttributes
+		*(uint8*)(currentWritePtr + 0) = 7;			// bLength
+		*(uint8*)(currentWritePtr + 1) = 0x05;		// bDescriptorType
+		*(uint8*)(currentWritePtr + 2) = 0x02;		// bEndpointAddress
+		*(uint8*)(currentWritePtr + 3) = 0x03;		// bmAttributes
 		*(uint16be*)(currentWritePtr + 4) = 0x0040; // wMaxPacketSize
-		*(uint8*)(currentWritePtr + 6) = 0x01;	  // bInterval
+		*(uint8*)(currentWritePtr + 6) = 0x01;		// bInterval
 		currentWritePtr = currentWritePtr + 7;
 
 		cemu_assert_debug((currentWritePtr - configurationDescriptor) == 0x29);
@@ -628,8 +669,8 @@ namespace nsyshid
 	}
 
 	bool SkylanderPortalDevice::SetIdle(uint8 ifIndex,
-									 uint8 reportId,
-									 uint8 duration)
+										uint8 reportId,
+										uint8 duration)
 	{
 		return true;
 	}

--- a/src/Cafe/OS/libs/nsyshid/Skylander.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.cpp
@@ -566,28 +566,9 @@ namespace nsyshid
 
 		if (!g_portalAudio)
 		{
-			auto& config = GetConfig();
-			auto& selectedDevice = L"default";
-
-			const auto audio_api = (IAudioAPI::AudioAPI)config.audio_api;
-			IAudioAPI::DeviceDescriptionPtr device_description;
-			if (IAudioAPI::IsAudioAPIAvailable(audio_api))
-			{
-				auto devices = IAudioAPI::GetDevices(audio_api);
-				const auto it = std::find_if(devices.begin(), devices.end(), [&selectedDevice](const auto& d) {
-					return d->GetIdentifier() == selectedDevice;
-				});
-				if (it != devices.end())
-				{
-					device_description = *it;
-				}
-			}
-			if (!device_description)
-				throw std::runtime_error("failed to find selected device while trying to create audio device");
-			
 			// Portal audio is mono channel, 16 bit audio.
 			// Audio is unsigned 16 bit, supplied as 64 bytes which is 32 samples per block
-			g_portalAudio = IAudioAPI::CreateDevice((IAudioAPI::AudioAPI)GetConfig().audio_api, device_description, 8000, 1, 32, 16);
+			g_portalAudio = IAudioAPI::CreateDeviceFromConfig(IAudioAPI::AudioType::Portal, 8000, 32, 16);
 		}
 		std::array<sint16, 32> mono_samples;
 		for (unsigned int i = 0; i < mono_samples.size(); ++i)

--- a/src/Cafe/OS/libs/snd_core/ax_out.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_out.cpp
@@ -462,6 +462,14 @@ namespace snd_core
 			else
 				g_padAudio->Stop();
 		}
+
+		if (g_portalAudio)
+		{
+			if (isPlaying)
+				g_portalAudio->Play();
+			else
+				g_portalAudio->Stop();
+		}
 	}
 
 	// called periodically to check for AX updates

--- a/src/Cafe/OS/libs/snd_core/ax_out.cpp
+++ b/src/Cafe/OS/libs/snd_core/ax_out.cpp
@@ -404,7 +404,7 @@ namespace snd_core
 		{
 			try
 			{
-				g_tvAudio = IAudioAPI::CreateDeviceFromConfig(true, 48000, snd_core::AX_SAMPLES_PER_3MS_48KHZ * AX_FRAMES_PER_GROUP, 16);
+				g_tvAudio = IAudioAPI::CreateDeviceFromConfig(IAudioAPI::AudioType::TV, 48000, snd_core::AX_SAMPLES_PER_3MS_48KHZ * AX_FRAMES_PER_GROUP, 16);
 			}
 			catch (std::runtime_error& ex)
 			{
@@ -417,7 +417,7 @@ namespace snd_core
 		{
 			try
 			{
-				g_padAudio = IAudioAPI::CreateDeviceFromConfig(false, 48000, snd_core::AX_SAMPLES_PER_3MS_48KHZ * AX_FRAMES_PER_GROUP, 16);
+				g_padAudio = IAudioAPI::CreateDeviceFromConfig(IAudioAPI::AudioType::Gamepad, 48000, snd_core::AX_SAMPLES_PER_3MS_48KHZ * AX_FRAMES_PER_GROUP, 16);
 				if(g_padAudio)
 					g_padVolume = g_padAudio->GetVolume();
 			}
@@ -441,6 +441,11 @@ namespace snd_core
 		{
 			g_padAudio->Stop();
 			g_padAudio.reset();
+		}
+		if (g_portalAudio)
+		{
+			g_portalAudio->Stop();
+			g_portalAudio.reset();
 		}
 	}
 

--- a/src/audio/IAudioAPI.cpp
+++ b/src/audio/IAudioAPI.cpp
@@ -13,6 +13,7 @@
 std::shared_mutex g_audioMutex;
 AudioAPIPtr g_tvAudio;
 AudioAPIPtr g_padAudio;
+AudioAPIPtr g_portalAudio;
 std::atomic_int32_t g_padVolume = 0;
 
 uint32 IAudioAPI::s_audioDelay = 2;

--- a/src/audio/IAudioAPI.cpp
+++ b/src/audio/IAudioAPI.cpp
@@ -129,6 +129,7 @@ AudioAPIPtr IAudioAPI::CreateDeviceFromConfig(AudioType type, sint32 rate, sint3
 
 	audioAPIDev = CreateDevice(audio_api, device_description, rate, channels, samples_per_block, bits_per_sample);
 	audioAPIDev->SetVolume(TV ? config.tv_volume : config.pad_volume);
+
 	return audioAPIDev;
 }
 
@@ -220,7 +221,7 @@ AudioChannels IAudioAPI::AudioTypeToChannels(AudioType type)
 	case Gamepad:
 		return config.pad_channels;
 	case Portal:
-		return config.portal_channels;
+		return kMono;
 	default:
 		return kMono;
 	}
@@ -239,5 +240,21 @@ std::wstring IAudioAPI::GetDeviceFromType(AudioType type)
 		return config.portal_device;
 	default:
 		return L"";
+	}
+}
+
+sint32 IAudioAPI::GetVolumeFromType(AudioType type)
+{
+	auto& config = GetConfig();
+	switch (type)
+	{
+	case TV:
+		return config.tv_volume;
+	case Gamepad:
+		return config.pad_volume;
+	case Portal:
+		return config.portal_volume;
+	default:
+		return 0;
 	}
 }

--- a/src/audio/IAudioAPI.cpp
+++ b/src/audio/IAudioAPI.cpp
@@ -101,7 +101,7 @@ bool IAudioAPI::IsAudioAPIAvailable(AudioAPI api)
 AudioAPIPtr IAudioAPI::CreateDeviceFromConfig(AudioType type, sint32 rate, sint32 samples_per_block, sint32 bits_per_sample)
 {
 	sint32 channels = CemuConfig::AudioChannelsToNChannels(AudioTypeToChannels(type));
-	return CreateDeviceFromConfig(TV, rate, channels, samples_per_block, bits_per_sample);
+	return CreateDeviceFromConfig(type, rate, channels, samples_per_block, bits_per_sample);
 }
 
 AudioAPIPtr IAudioAPI::CreateDeviceFromConfig(AudioType type, sint32 rate, sint32 channels, sint32 samples_per_block, sint32 bits_per_sample)
@@ -128,7 +128,7 @@ AudioAPIPtr IAudioAPI::CreateDeviceFromConfig(AudioType type, sint32 rate, sint3
 		throw std::runtime_error("failed to find selected device while trying to create audio device");
 
 	audioAPIDev = CreateDevice(audio_api, device_description, rate, channels, samples_per_block, bits_per_sample);
-	audioAPIDev->SetVolume(TV ? config.tv_volume : config.pad_volume);
+	audioAPIDev->SetVolume(GetVolumeFromType(type));
 
 	return audioAPIDev;
 }

--- a/src/audio/IAudioAPI.h
+++ b/src/audio/IAudioAPI.h
@@ -93,3 +93,5 @@ extern AudioAPIPtr g_tvAudio;
 
 extern AudioAPIPtr g_padAudio;
 extern std::atomic_int32_t g_padVolume;
+
+extern AudioAPIPtr g_portalAudio;

--- a/src/audio/IAudioAPI.h
+++ b/src/audio/IAudioAPI.h
@@ -4,6 +4,8 @@
 #include <mmreg.h>
 #endif
 
+#include "config/CemuConfig.h"
+
 class IAudioAPI
 {
 	friend class GeneralSettings2;
@@ -29,6 +31,13 @@ public:
 	};
 
 	using DeviceDescriptionPtr = std::shared_ptr<DeviceDescription>;
+
+	enum AudioType
+	{
+		TV = 0,
+		Gamepad,
+		Portal
+	};
 
 	enum AudioAPI
 	{
@@ -62,8 +71,8 @@ public:
 	static void InitializeStatic();
 	static bool IsAudioAPIAvailable(AudioAPI api);
 
-	static std::unique_ptr<IAudioAPI> CreateDeviceFromConfig(bool TV, sint32 rate, sint32 samples_per_block, sint32 bits_per_sample);
-	static std::unique_ptr<IAudioAPI> CreateDeviceFromConfig(bool TV, sint32 rate, sint32 channels, sint32 samples_per_block, sint32 bits_per_sample);
+	static std::unique_ptr<IAudioAPI> CreateDeviceFromConfig(AudioType type, sint32 rate, sint32 samples_per_block, sint32 bits_per_sample);
+	static std::unique_ptr<IAudioAPI> CreateDeviceFromConfig(AudioType type, sint32 rate, sint32 channels, sint32 samples_per_block, sint32 bits_per_sample);
 	static std::unique_ptr<IAudioAPI> CreateDevice(AudioAPI api, const DeviceDescriptionPtr& device, sint32 samplerate, sint32 channels, sint32 samples_per_block, sint32 bits_per_sample);
 	static std::vector<DeviceDescriptionPtr> GetDevices(AudioAPI api);
 
@@ -84,6 +93,8 @@ protected:
 private:
 	static uint32 s_audioDelay;
 	void InitWFX(sint32 samplerate, sint32 channels, sint32 bits_per_sample);
+	static AudioChannels AudioTypeToChannels(AudioType type);
+	static std::wstring GetDeviceFromType(AudioType type);
 	
 };
 

--- a/src/audio/IAudioAPI.h
+++ b/src/audio/IAudioAPI.h
@@ -95,6 +95,7 @@ private:
 	void InitWFX(sint32 samplerate, sint32 channels, sint32 bits_per_sample);
 	static AudioChannels AudioTypeToChannels(AudioType type);
 	static std::wstring GetDeviceFromType(AudioType type);
+	static sint32 GetVolumeFromType(AudioType type);
 	
 };
 

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -275,7 +275,6 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	tv_channels = audio.get("TVChannels", kStereo);
 	pad_channels = audio.get("PadChannels", kStereo);
 	input_channels = audio.get("InputChannels", kMono);
-	portal_channels = audio.get("PortalChannels", kMono);
 	tv_volume = audio.get("TVVolume", 20);
 	pad_volume = audio.get("PadVolume", 0);
 	input_volume = audio.get("InputVolume", 20);
@@ -520,7 +519,6 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	audio.set("TVChannels", tv_channels);
 	audio.set("PadChannels", pad_channels);
 	audio.set("InputChannels", input_channels);
-	audio.set("PortalChannels", portal_channels);
 	audio.set("TVVolume", tv_volume);
 	audio.set("PadVolume", pad_volume);
 	audio.set("InputVolume", input_volume);

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -275,9 +275,11 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	tv_channels = audio.get("TVChannels", kStereo);
 	pad_channels = audio.get("PadChannels", kStereo);
 	input_channels = audio.get("InputChannels", kMono);
+	portal_channels = audio.get("PortalChannels", kMono);
 	tv_volume = audio.get("TVVolume", 20);
 	pad_volume = audio.get("PadVolume", 0);
 	input_volume = audio.get("InputVolume", 20);
+	portal_volume = audio.get("PortalVolume", 20);
 
 	const auto tv = audio.get("TVDevice", "");
 	try
@@ -307,6 +309,16 @@ void CemuConfig::Load(XMLConfigParser& parser)
 	catch (const std::exception&)
 	{
 		cemuLog_log(LogType::Force, "config load error: can't load input device: {}", input_device_name);
+	}
+
+	const auto portal_device_name = audio.get("PortalDevice", "");
+	try
+	{
+		portal_device = boost::nowide::widen(portal_device_name);
+	}
+	catch (const std::exception&)
+	{
+		cemuLog_log(LogType::Force, "config load error: can't load input device: {}", portal_device_name);
 	}
 
 	// account
@@ -508,12 +520,15 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	audio.set("TVChannels", tv_channels);
 	audio.set("PadChannels", pad_channels);
 	audio.set("InputChannels", input_channels);
+	audio.set("InputChannels", portal_channels);
 	audio.set("TVVolume", tv_volume);
 	audio.set("PadVolume", pad_volume);
 	audio.set("InputVolume", input_volume);
+	audio.set("PortalVolume", portal_volume);
 	audio.set("TVDevice", boost::nowide::narrow(tv_device).c_str());
 	audio.set("PadDevice", boost::nowide::narrow(pad_device).c_str());
 	audio.set("InputDevice", boost::nowide::narrow(input_device).c_str());
+	audio.set("PortalDevice", boost::nowide::narrow(portal_device).c_str());
 
 	// account
 	auto acc = config.set("Account");

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -520,7 +520,7 @@ void CemuConfig::Save(XMLConfigParser& parser)
 	audio.set("TVChannels", tv_channels);
 	audio.set("PadChannels", pad_channels);
 	audio.set("InputChannels", input_channels);
-	audio.set("InputChannels", portal_channels);
+	audio.set("PortalChannels", portal_channels);
 	audio.set("TVVolume", tv_volume);
 	audio.set("PadVolume", pad_volume);
 	audio.set("InputVolume", input_volume);

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -479,9 +479,9 @@ struct CemuConfig
 	// audio
 	sint32 audio_api = 0;
 	sint32 audio_delay = 2;
-	AudioChannels tv_channels = kStereo, pad_channels = kStereo, input_channels = kMono;
-	sint32 tv_volume = 50, pad_volume = 0, input_volume = 50;
-	std::wstring tv_device{ L"default" }, pad_device, input_device;
+	AudioChannels tv_channels = kStereo, pad_channels = kStereo, input_channels = kMono, portal_channels = kMono;
+	sint32 tv_volume = 50, pad_volume = 0, input_volume = 50, portal_volume = 50;
+	std::wstring tv_device{ L"default" }, pad_device, input_device, portal_device;
 
 	// account
 	struct

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -479,7 +479,7 @@ struct CemuConfig
 	// audio
 	sint32 audio_api = 0;
 	sint32 audio_delay = 2;
-	AudioChannels tv_channels = kStereo, pad_channels = kStereo, input_channels = kMono, portal_channels = kMono;
+	AudioChannels tv_channels = kStereo, pad_channels = kStereo, input_channels = kMono;
 	sint32 tv_volume = 50, pad_volume = 0, input_volume = 50, portal_volume = 50;
 	std::wstring tv_device{ L"default" }, pad_device, input_device, portal_device;
 

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -1183,10 +1183,15 @@ void GeneralSettings2::OnVolumeChanged(wxCommandEvent& event)
 				g_padVolume = event.GetInt();
 			}
 		}
-		else
+		else if (event.GetEventObject() == m_tv_volume)
 		{
 			if (g_tvAudio)
 				g_tvAudio->SetVolume(event.GetInt());
+		}
+		else
+		{
+			if(g_portalAudio)
+				g_portalAudio->SetVolume(event.GetInt());
 		}
 	}
 	

--- a/src/gui/GeneralSettings2.cpp
+++ b/src/gui/GeneralSettings2.cpp
@@ -559,17 +559,6 @@ wxPanel* GeneralSettings2::AddAudioPage(wxNotebook* notebook)
 
 		m_portal_device->Bind(wxEVT_CHOICE, &GeneralSettings2::OnAudioDeviceSelected, this);
 
-		const wxString audio_channel_drc_choices[] = { _("Mono") }; // mono for now only
-
-		portal_audio_row->Add(new wxStaticText(box, wxID_ANY, _("Channels")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-		m_portal_channels = new wxChoice(box, wxID_ANY, wxDefaultPosition, wxDefaultSize, std::size(audio_channel_drc_choices), audio_channel_drc_choices);
-
-		m_portal_channels->SetSelection(0); // set default to mono
-
-		m_portal_channels->Bind(wxEVT_CHOICE, &GeneralSettings2::OnAudioChannelsSelected, this);
-		portal_audio_row->Add(m_portal_channels, 0, wxEXPAND | wxALL, 5);
-		portal_audio_row->AddSpacer(0);
-
 		portal_audio_row->Add(new wxStaticText(box, wxID_ANY, _("Volume")), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 		m_portal_volume = new wxSlider(box, wxID_ANY, 100, 0, 100);
 		portal_audio_row->Add(m_portal_volume, 0, wxEXPAND | wxALL, 5);
@@ -1030,7 +1019,6 @@ void GeneralSettings2::StoreConfig()
 	config.pad_channels = kStereo; // (AudioChannels)m_pad_channels->GetSelection();
 	//config.input_channels =  (AudioChannels)m_input_channels->GetSelection();
 	config.input_channels = kMono; // (AudioChannels)m_input_channels->GetSelection();
-	config.portal_channels = kMono; // (AudioChannels)m_portal_channels->GetSelection();
 	
 	config.tv_volume = m_tv_volume->GetValue();
 	config.pad_volume = m_pad_volume->GetValue();
@@ -1720,7 +1708,6 @@ void GeneralSettings2::ApplyConfig()
 	m_pad_channels->SetSelection(0);
 	//m_input_channels->SetSelection(config.pad_channels);
 	m_input_channels->SetSelection(0);
-	m_portal_channels->SetSelection(0);
 	
 	SendSliderEvent(m_tv_volume, config.tv_volume);
 
@@ -1975,7 +1962,7 @@ void GeneralSettings2::UpdateAudioDevice()
 				}
 				catch (std::runtime_error& ex)
 				{
-					cemuLog_log(LogType::Force, "can't initialize pad audio: {}", ex.what());
+					cemuLog_log(LogType::Force, "can't initialize portal audio: {}", ex.what());
 				}
 			}
 		}
@@ -2009,13 +1996,6 @@ void GeneralSettings2::OnAudioChannelsSelected(wxCommandEvent& event)
 			return;
 		
 		config.pad_channels = (AudioChannels)obj->GetSelection();
-	}
-	else if (obj == m_portal_channels)
-	{
-		if (config.portal_channels == (AudioChannels)obj->GetSelection())
-			return;
-		
-		config.portal_channels = (AudioChannels)obj->GetSelection();
 	}
 	else
 		cemu_assert_debug(false);

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -63,9 +63,9 @@ private:
 	// Audio
 	wxChoice* m_audio_api;
 	wxSlider *m_audio_latency;
-	wxSlider *m_tv_volume, *m_pad_volume, *m_input_volume;
-	wxChoice *m_tv_channels, *m_pad_channels, *m_input_channels;
-	wxChoice *m_tv_device, *m_pad_device, *m_input_device;
+	wxSlider *m_tv_volume, *m_pad_volume, *m_input_volume, *m_portal_volume;
+	wxChoice *m_tv_channels, *m_pad_channels, *m_input_channels, *m_portal_channels;
+	wxChoice *m_tv_device, *m_pad_device, *m_input_device, *m_portal_device;
 
 	// Account
 	wxButton* m_create_account, * m_delete_account;

--- a/src/gui/GeneralSettings2.h
+++ b/src/gui/GeneralSettings2.h
@@ -64,7 +64,7 @@ private:
 	wxChoice* m_audio_api;
 	wxSlider *m_audio_latency;
 	wxSlider *m_tv_volume, *m_pad_volume, *m_input_volume, *m_portal_volume;
-	wxChoice *m_tv_channels, *m_pad_channels, *m_input_channels, *m_portal_channels;
+	wxChoice *m_tv_channels, *m_pad_channels, *m_input_channels;
 	wxChoice *m_tv_device, *m_pad_device, *m_input_device, *m_portal_device;
 
 	// Account


### PR DESCRIPTION
In the Skylanders games, the portal that is currently emulated is the Trap Team portal. Normally it writes requests via the SetReport method, but the trap team portal also accepts audio requests via the Write method. The portal attached to the Trap Team portal is a Mono audio, 8000hz speaker, and audio requests are 64 bytes, which is 32 16 bit PCM audio samples.

I have also made the portal audio a setting similar to gamepad/tv audio, as well as changing some methods to allow for more than a binary choice when playing audio output.