### PR TITLE
Add 2 new cli options for debugging

### DIFF
--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -74,7 +74,10 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 	po::options_description hidden{ "Hidden options" };
 	hidden.add_options()
 		("nsight", po::value<bool>()->implicit_value(true), "NSight debugging options")
-		("legacy", po::value<bool>()->implicit_value(true), "Intel legacy graphic mode");
+		("legacy", po::value<bool>()->implicit_value(true), "Intel legacy graphic mode")
+		("logs", po::value<bool>()->implicit_value(true), "Opens the log window on launch")
+		("debug", po::value<bool>()->implicit_value(true), "Opens the debugger window on launch");
+
 
 	po::options_description extractor{ "Extractor tool" };
 	extractor.add_options()
@@ -176,6 +179,12 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 		
 		if (vm.count("enable-gdbstub"))
 			s_enable_gdbstub = vm["enable-gdbstub"].as<bool>();
+
+		if (vm.count("logs"))
+			s_open_log_window_on_launch = vm["logs"].as<bool>();
+
+		if (vm.count("debug"))
+			s_open_debug_window_on_launch = vm["debug"].as<bool>();
 
 		std::wstring extract_path, log_path;
 		std::string output_path;

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -27,6 +27,9 @@ public:
 
 	static bool ForceInterpreter() { return s_force_interpreter; };
 
+	static bool OpenLogWindowOnLaunch() { return s_open_log_window_on_launch; };
+	static bool OpenDebugWindowOnLaunch() { return s_open_debug_window_on_launch; };
+
 	static std::optional<uint32> GetPersistentId() { return s_persistent_id; }
 
 private:
@@ -41,6 +44,9 @@ private:
 	inline static bool s_nsight_mode = false;
 
 	inline static bool s_force_interpreter = false;
+
+	inline static bool s_open_log_window_on_launch = false;
+	inline static bool s_open_debug_window_on_launch = false;
 	
 	inline static std::optional<uint32> s_persistent_id{};
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -157,6 +157,8 @@ wxDEFINE_EVENT(wxEVT_SET_WINDOW_TITLE, wxCommandEvent);
 wxDEFINE_EVENT(wxEVT_REQUEST_GAMELIST_REFRESH, wxCommandEvent);
 wxDEFINE_EVENT(wxEVT_LAUNCH_GAME, wxLaunchGameEvent);
 wxDEFINE_EVENT(wxEVT_REQUEST_RECREATE_CANVAS, wxCommandEvent);
+wxDEFINE_EVENT(wxEVT_OPEN_LOGGING_WINDOW, wxCommandEvent);
+wxDEFINE_EVENT(wxEVT_OPEN_DEBUG_WINDOWS, wxCommandEvent);
 
 wxBEGIN_EVENT_TABLE(MainWindow, wxFrame)
 EVT_TIMER(MAINFRAME_ID_TIMER1, MainWindow::OnTimer)
@@ -304,6 +306,8 @@ MainWindow::MainWindow()
 	auto* main_sizer = new wxBoxSizer(wxVERTICAL);
     auto load_file = LaunchSettings::GetLoadFile();
     auto load_title_id = LaunchSettings::GetLoadTitleID();
+	auto open_log_window = LaunchSettings::OpenLogWindowOnLaunch();
+	auto open_debug_window = LaunchSettings::OpenDebugWindowOnLaunch();
     bool quick_launch = false;
 
     if (load_file)
@@ -360,6 +364,19 @@ MainWindow::MainWindow()
     {
             g_gdbstub = std::make_unique<GDBServer>(config.gdb_port);
     }
+
+	if(open_log_window)
+	{
+		wxCommandEvent event(wxEVT_OPEN_LOGGING_WINDOW);
+		OnLoggingWindow(event);
+	}
+
+	if (open_debug_window)
+	{
+		wxCommandEvent event(wxEVT_OPEN_DEBUG_WINDOWS);
+		OnDebugViewPPCDebugger(event);
+	}
+
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Add 2 new CLI options for quick debugging.

These new options do the following:
- `--logs`: Starts the app with the logs window opened.
- `--debug`:  Starts the app with the debug window opened.