### PR TITLE
Vulkan: Match Vulkan Device Version and Shaders Targets

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -318,9 +318,25 @@ void RendererShaderVk::CompileInternal(bool isRenderThread)
 	const char* cstr = m_glslCode.c_str();
 	Shader.setStrings(&cstr, 1);
 	Shader.setEnvInput(glslang::EShSourceGlsl, state, glslang::EShClientVulkan, 100);
-	Shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_1);
 
+	uint32 apiVersion = VK_API_VERSION_1_1;
+	vkEnumerateInstanceVersion(&apiVersion);
+
+	if (VK_API_VERSION_MAJOR(apiVersion) == 1 || VK_API_VERSION_MINOR(apiVersion) == 1)
+	{
+	Shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_1);
 	Shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_3);
+	}
+	else if (VK_API_VERSION_MAJOR(apiVersion) == 1 || VK_API_VERSION_MINOR(apiVersion) == 2)
+	{
+	Shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_2);
+	Shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_5);
+	}
+	else if (VK_API_VERSION_MAJOR(apiVersion) == 1 || VK_API_VERSION_MINOR(apiVersion) >= 3)
+	{
+	Shader.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_3);
+	Shader.setEnvTarget(glslang::EShTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_6);
+	}
 
 	TBuiltInResource Resources = GetDefaultBuiltInResource();
 	std::string PreprocessedGLSL;


### PR DESCRIPTION
Instead of using Vulkan 1.1 and Spir-V 1.3 targets by default, It detect the Vulkan Version of the device and and matches them to the glslang targets.
To see which Spir-V version matches with which Vulkan version, I've used `glslang --help` command.

![glslang](https://github.com/user-attachments/assets/3f1539da-414f-485f-9351-fce55aff330f)

PS: Vulkan 1.4 devices uses Vulkan 1.3 and Spir-V 1.6 targets.

Tested on: Zelda Breath of the Wild, Mario Kart 8, Splatoon, Zelda Wind Waker HD, Zelda Twilight Princess HD, Super Mario 3D World and Wii U Menu
Tested with a Vulkan 1.4 device and no issues are visible.
Ready for modifications!