### PR TITLE
cubeb: Allow to select the default device even if cubeb_enumerate_devices fails

### DIFF
--- a/src/audio/CubebAPI.cpp
+++ b/src/audio/CubebAPI.cpp
@@ -183,16 +183,16 @@ void CubebAPI::Destroy()
 
 std::vector<IAudioAPI::DeviceDescriptionPtr> CubebAPI::GetDevices()
 {
-	cubeb_device_collection devices;
-	if (cubeb_enumerate_devices(s_context, CUBEB_DEVICE_TYPE_OUTPUT, &devices) != CUBEB_OK)
-		return {};
-
 	std::vector<DeviceDescriptionPtr> result;
-	result.reserve(devices.count + 1); // Reserve space for the default device
-
 	// Add the default device to the list
 	auto defaultDevice = std::make_shared<CubebDeviceDescription>(nullptr, "default", L"Default Device");
 	result.emplace_back(defaultDevice);
+
+	cubeb_device_collection devices;
+	if (cubeb_enumerate_devices(s_context, CUBEB_DEVICE_TYPE_OUTPUT, &devices) != CUBEB_OK)
+		return result;
+
+	result.reserve(devices.count + 1); // The default device already occupies one element
 
 	for (size_t i = 0; i < devices.count; ++i)
 	{

--- a/src/audio/CubebInputAPI.cpp
+++ b/src/audio/CubebInputAPI.cpp
@@ -175,16 +175,16 @@ void CubebInputAPI::Destroy()
 
 std::vector<IAudioInputAPI::DeviceDescriptionPtr> CubebInputAPI::GetDevices()
 {
-	cubeb_device_collection devices;
-	if (cubeb_enumerate_devices(s_context, CUBEB_DEVICE_TYPE_INPUT, &devices) != CUBEB_OK)
-		return {};
-
 	std::vector<DeviceDescriptionPtr> result;
-	result.reserve(devices.count + 1); // Reserve space for the default device
-
 	// Add the default device to the list
 	auto defaultDevice = std::make_shared<CubebDeviceDescription>(nullptr, "default", L"Default Device");
 	result.emplace_back(defaultDevice);
+
+	cubeb_device_collection devices;
+	if (cubeb_enumerate_devices(s_context, CUBEB_DEVICE_TYPE_INPUT, &devices) != CUBEB_OK)
+		return result;
+
+	result.reserve(devices.count + 1); // The default device already occupies one element
 
 	for (size_t i = 0; i < devices.count; ++i)
 	{


### PR DESCRIPTION
Cemu would not let you select even cubeb's default device if cubeb_enumerate_devices failed,
however, there are cases where it will fail but you can still get sound if you use cubeb's default device.
(For example, if you use ALSA. )