### PR TITLE
fix for cmake 4

### DIFF
--- a/dependencies/discord-rpc/CMakeLists.txt
+++ b/dependencies/discord-rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.2.0)
+cmake_minimum_required (VERSION 3.2.0...3.5)
 project (DiscordRPC)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Compatibility with versions of CMake older than 3.5 has been removed.