### PR TITLE
Fix opening of save directory on macOS

### DIFF
--- a/src/gui/TitleManager.cpp
+++ b/src/gui/TitleManager.cpp
@@ -491,7 +491,7 @@ void TitleManager::OnSaveOpenDirectory(wxCommandEvent& event)
 	if (!fs::exists(target) || !fs::is_directory(target))
 		return;
 
-	wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(target))));
+	wxLaunchDefaultApplication(wxHelper::FromPath(target));
 }
 
 void TitleManager::OnSaveDelete(wxCommandEvent& event)

--- a/src/gui/components/wxGameList.cpp
+++ b/src/gui/components/wxGameList.cpp
@@ -668,7 +668,7 @@ void wxGameList::OnContextMenuSelected(wxCommandEvent& event)
 				{
 				fs::path path(gameInfo.GetBase().GetPath());
 				_stripPathFilename(path);
-				wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(path))));
+				wxLaunchDefaultApplication(wxHelper::FromPath(path));
 				break;
 				}
 			case kWikiPage:
@@ -689,21 +689,21 @@ void wxGameList::OnContextMenuSelected(wxCommandEvent& event)
 
 			case kContextMenuSaveFolder:
 			{
-				wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(gameInfo.GetSaveFolder()))));
+				wxLaunchDefaultApplication(wxHelper::FromPath(gameInfo.GetSaveFolder()));
 				break;
 			}
 			case kContextMenuUpdateFolder:
 			{
 				fs::path path(gameInfo.GetUpdate().GetPath());
 				_stripPathFilename(path);
-				wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(path))));
+				wxLaunchDefaultApplication(wxHelper::FromPath(path));
 				break;
 			}
 			case kContextMenuDLCFolder:
 			{
 				fs::path path(gameInfo.GetAOC().front().GetPath());
 				_stripPathFilename(path);
-				wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(path))));
+				wxLaunchDefaultApplication(wxHelper::FromPath(path));
 				break;
 			}
 			case kContextMenuRemoveCache:

--- a/src/gui/components/wxTitleManagerList.cpp
+++ b/src/gui/components/wxTitleManagerList.cpp
@@ -869,7 +869,7 @@ void wxTitleManagerList::OnContextMenuSelected(wxCommandEvent& event)
 	case kContextMenuOpenDirectory:
 		{
 			const auto path = fs::is_directory(entry->path) ? entry->path : entry->path.parent_path();
-			wxLaunchDefaultBrowser(wxHelper::FromUtf8(fmt::format("file:{}", _pathToUtf8(path))));
+			wxLaunchDefaultApplication(wxHelper::FromPath(path));
 		}
 		break;
 	case kContextMenuDelete:


### PR DESCRIPTION
On macOS, trying to open save directory locations through the context menu usually results in errors like:
```
Failed to open URL "file:/Users/xxxxx/Library/Application Support/Cemu/mlc01/usr/save/00050000/xxxxxxxx" in default browser. (error 0: Undefined error: 0)
```
This is due to the default MLC path on macOS being located at `~/Library/Application\ Support/Cemu/mlc01`, which contains a space. I tried escaping with a `\` or surrounding the path with `""`, but it appears that since `wxLaunchDefaultBrowser` is being used then URI encoding is required. ~I couldn't find a URI encoding function in either `<wx/uri.h>` or `<wx/url.h>`, so I just did a manual string replacement of all spaces.~

~Alternatively,~ it's possible to just use `wxLaunchDefaultApplication` instead like this: 
https://github.com/cemu-project/Cemu/blob/b089ae5b32f5f2bc901b9ff2db2424cbf3c1186b/src/gui/MainWindow.cpp#L683-L684


I have not tested this on Linux or Windows, though this change doesn't seem like it would break anything in either