### PR TITLE
debug: add CLI option to have multithreaded interpreter

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -844,7 +844,7 @@ namespace CafeSystem
 			module->TitleStart();
 		cemu_initForGame();
 		// enter scheduler
-		if (ActiveSettings::GetCPUMode() == CPUMode::MulticoreRecompiler && !LaunchSettings::ForceInterpreter())
+		if ((ActiveSettings::GetCPUMode() == CPUMode::MulticoreRecompiler || LaunchSettings::ForceMultiCoreInterpreter()) && !LaunchSettings::ForceInterpreter())
 			coreinit::OSSchedulerBegin(3);
 		else
 			coreinit::OSSchedulerBegin(1);

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompiler.cpp
@@ -669,9 +669,9 @@ void PPCRecompiler_init()
 		ppcRecompilerEnabled = false;
 		return;
 	}
-	if (LaunchSettings::ForceInterpreter())
+	if (LaunchSettings::ForceInterpreter() || LaunchSettings::ForceMultiCoreInterpreter())
 	{
-		cemuLog_log(LogType::Force, "Recompiler disabled. Command line --force-interpreter was passed");
+		cemuLog_log(LogType::Force, "Recompiler disabled. Command line --force-interpreter or force-multicore-interpreter was passed");
 		return;
 	}
 	if (ppcRecompilerInstanceData)

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -69,7 +69,8 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 
 		("account,a", po::value<std::string>(), "Persistent id of account")
 
-		("force-interpreter", po::value<bool>()->implicit_value(true), "Force interpreter CPU emulation, disables recompiler")
+		("force-interpreter", po::value<bool>()->implicit_value(true), "Force interpreter CPU emulation, disables recompiler. Useful for debugging purposes where you want to get accurate memory accesses and stack traces.")
+		("force-multicore-interpreter", po::value<bool>()->implicit_value(true), "Force multi-core interpreter CPU emulation, disables recompiler. Only useful for getting stack traces, but slightly faster than the single-core interpreter mode.")
 		("enable-gdbstub", po::value<bool>()->implicit_value(true), "Enable GDB stub to debug executables inside Cemu using an external debugger");
 
 	po::options_description hidden{ "Hidden options" };
@@ -176,6 +177,9 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 
 		if(vm.count("force-interpreter"))
 			s_force_interpreter = vm["force-interpreter"].as<bool>();
+
+		if(vm.count("force-multicore-interpreter"))
+			s_force_multicore_interpreter = vm["force-multicore-interpreter"].as<bool>();
 		
 		if (vm.count("enable-gdbstub"))
 			s_enable_gdbstub = vm["enable-gdbstub"].as<bool>();

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -26,6 +26,7 @@ public:
 	static bool NSightModeEnabled() { return s_nsight_mode; }
 
 	static bool ForceInterpreter() { return s_force_interpreter; };
+	static bool ForceMultiCoreInterpreter() { return s_force_multicore_interpreter; }
 
 	static std::optional<uint32> GetPersistentId() { return s_persistent_id; }
 
@@ -44,6 +45,7 @@ private:
 	inline static bool s_nsight_mode = false;
 
 	inline static bool s_force_interpreter = false;
+	inline static bool s_force_multicore_interpreter = false;
 	
 	inline static std::optional<uint32> s_persistent_id{};
 


### PR DESCRIPTION
This option still allows you to have proper stack traces for crashes or for the PPC debugger, but is a lot faster then the really slow interpreter (especially when loading into large games like BotW where there has to be a lot of asset decompressing). It makes memory access breakpoints much more brittle though, so it's not a perfect option.

Normal users should of course stick with using the recompiler.