### PR TITLE
Fix Mac build for Xcode 16.3

### DIFF
--- a/src/util/helpers/StringHelpers.h
+++ b/src/util/helpers/StringHelpers.h
@@ -2,6 +2,92 @@
 #include "boost/nowide/convert.hpp"
 #include <charconv>
 
+// Definition for removed templates in Apple Clang 17
+#if defined(__apple_build_version__) && (__apple_build_version__ >= 17000000)
+namespace std {
+	template<>
+	struct char_traits<uint16be> {
+		using char_type = uint16be;
+		using int_type = int;
+		using off_type = streamoff;
+		using pos_type = streampos;
+		using state_type = mbstate_t;
+
+		static inline void constexpr assign(char_type& c1, const char_type& c2) noexcept {
+			c1 = c2;
+		}
+
+		static inline constexpr bool eq(char_type c1, char_type c2) noexcept {
+			return c1 == c2;
+		}
+
+		static inline constexpr bool lt(char_type c1, char_type c2) noexcept {
+			return c1 < c2;
+		}
+
+		static constexpr int compare(const char_type* s1, const char_type* s2, size_t n) {
+			for (; n; --n, ++s1, ++s2) {
+				if (lt(*s1, *s2)) return -1;
+				if (lt(*s2, *s1)) return 1;
+			}
+			return 0;
+		}
+
+		static constexpr size_t length(const char_type* s) {
+			size_t len = 0;
+			for (; !eq(*s, char_type(0)); ++s) ++len;
+			return len;
+		}
+
+		static constexpr const char_type* find(const char_type* s, size_t n, const char_type& a) {
+			for (; n; --n) {
+				if (eq(*s, a))
+					return s;
+				++s;
+			}
+			return nullptr;
+		}
+
+		static constexpr char_type* move(char_type* s1, const char_type* s2, size_t n) {
+			if (n == 0) return s1;
+			return static_cast<char_type*>(memmove(s1, s2, n * sizeof(char_type)));
+		}
+
+		static constexpr char_type* copy(char_type* s1, const char_type* s2, size_t n) {
+			if (n == 0) return s1;
+			return static_cast<char_type*>(memcpy(s1, s2, n * sizeof(char_type)));
+		}
+
+		static constexpr char_type* assign(char_type* s, size_t n, char_type a) {
+			char_type* r = s;
+			for (; n; --n, ++s)
+				assign(*s, a);
+			return r;
+		}
+
+		static inline constexpr char_type to_char_type(int_type c) noexcept {
+			return char_type(c);
+		}
+
+		static inline constexpr int_type to_int_type(char_type c) noexcept {
+			return int_type(c);
+		}
+
+		static inline constexpr bool eq_int_type(int_type c1, int_type c2) noexcept {
+			return c1 == c2;
+		}
+
+		static inline constexpr int_type eof() noexcept {
+			return static_cast<int_type>(EOF);
+		}
+
+		static inline constexpr int_type not_eof(int_type c) noexcept {
+			return eq_int_type(c, eof()) ? ~eof() : c;
+		}
+	};
+}
+#endif
+
 // todo - move the Cafe/PPC specific parts to CafeString.h eventually
 namespace StringHelpers
 {


### PR DESCRIPTION
Fix for the build issue reported in #1547 

Xcode 16.3 removed the base template for `std::char_traits`: https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes. As a result, the `basic_string<uint16be>` type in this code gives compiler errors, as the `basic_string` template relies on `char_traits`:
https://github.com/cemu-project/Cemu/blob/e6a64aadda4d99ebe16f33f55b0a813444827a06/src/util/helpers/StringHelpers.h#L28-L35
I implemented the removed template for the `uint16be` type based on the documentation found in `Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__string/char_traits.h`

With this, I was able to build the macOS app bundle and launch games successfully. However, the standalone `Cemu_release` executable (without the app bundle) crashes when launching a game; I hadn't tested launching games with the standalone executable on an earlier compiler version, so I'm not sure it actually works without the app bundle to begin with (or may be due to a permissions issue with the external drive).

For reference, here's the implementation of the base template from Apple Clang 16:
<details>
<summary> <code>std::char_traits</code> base template</summary>

```
/*
The Standard does not define the base template for char_traits because it is impossible to provide
a correct definition for arbitrary character types. Instead, it requires implementations to provide
specializations for predefined character types like `char`, `wchar_t` and others. We provide this as
exposition-only to document what members a char_traits specialization should provide:
{
    using char_type  = _CharT;
    using int_type   = ...;
    using off_type   = ...;
    using pos_type   = ...;
    using state_type = ...;

    static void assign(char_type&, const char_type&);
    static bool eq(char_type, char_type);
    static bool lt(char_type, char_type);

    static int              compare(const char_type*, const char_type*, size_t);
    static size_t           length(const char_type*);
    static const char_type* find(const char_type*, size_t, const char_type&);
    static char_type*       move(char_type*, const char_type*, size_t);
    static char_type*       copy(char_type*, const char_type*, size_t);
    static char_type*       assign(char_type*, size_t, char_type);

    static int_type  not_eof(int_type);
    static char_type to_char_type(int_type);
    static int_type  to_int_type(char_type);
    static bool      eq_int_type(int_type, int_type);
    static int_type  eof();
};
*/

//
// Temporary extension to provide a base template for std::char_traits.
// TODO(LLVM-19): Remove this class.
//
#if !defined(_LIBCPP_CHAR_TRAITS_REMOVE_BASE_SPECIALIZATION)
template <class _CharT>
struct _LIBCPP_DEPRECATED_(
    "char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided "
    "for a temporary period. It will be removed in LLVM 19, so please migrate off of it.") char_traits {
  using char_type  = _CharT;
  using int_type   = int;
  using off_type   = streamoff;
  using pos_type   = streampos;
  using state_type = mbstate_t;

  static inline void _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI
  assign(char_type& __c1, const char_type& __c2) _NOEXCEPT {
    __c1 = __c2;
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool eq(char_type __c1, char_type __c2) _NOEXCEPT {
    return __c1 == __c2;
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool lt(char_type __c1, char_type __c2) _NOEXCEPT {
    return __c1 < __c2;
  }

  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 int
  compare(const char_type* __s1, const char_type* __s2, size_t __n) {
    for (; __n; --__n, ++__s1, ++__s2) {
      if (lt(*__s1, *__s2))
        return -1;
      if (lt(*__s2, *__s1))
        return 1;
    }
    return 0;
  }
  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) {
    size_t __len = 0;
    for (; !eq(*__s, char_type(0)); ++__s)
      ++__len;
    return __len;
  }
  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 const char_type*
  find(const char_type* __s, size_t __n, const char_type& __a) {
    for (; __n; --__n) {
      if (eq(*__s, __a))
        return __s;
      ++__s;
    }
    return nullptr;
  }
  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 char_type*
  move(char_type* __s1, const char_type* __s2, size_t __n) {
    if (__n == 0)
      return __s1;
    char_type* __r = __s1;
    if (__s1 < __s2) {
      for (; __n; --__n, ++__s1, ++__s2)
        assign(*__s1, *__s2);
    } else if (__s2 < __s1) {
      __s1 += __n;
      __s2 += __n;
      for (; __n; --__n)
        assign(*--__s1, *--__s2);
    }
    return __r;
  }
  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX20 char_type*
  copy(char_type* __s1, const char_type* __s2, size_t __n) {
    _LIBCPP_ASSERT_NON_OVERLAPPING_RANGES(!std::__is_pointer_in_range(__s1, __s1 + __n, __s2),
                                          "char_traits::copy: source and destination ranges overlap");
    char_type* __r = __s1;
    for (; __n; --__n, ++__s1, ++__s2)
      assign(*__s1, *__s2);
    return __r;
  }
  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX20 char_type*
  assign(char_type* __s, size_t __n, char_type __a) {
    char_type* __r = __s;
    for (; __n; --__n, ++__s)
      assign(*__s, __a);
    return __r;
  }

  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int_type not_eof(int_type __c) _NOEXCEPT {
    return eq_int_type(__c, eof()) ? ~eof() : __c;
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR char_type to_char_type(int_type __c) _NOEXCEPT {
    return char_type(__c);
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int_type to_int_type(char_type __c) _NOEXCEPT {
    return int_type(__c);
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool eq_int_type(int_type __c1, int_type __c2) _NOEXCEPT {
    return __c1 == __c2;
  }
  static inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int_type eof() _NOEXCEPT { return int_type(EOF); }
};
#endif // !defined(_LIBCPP_CHAR_TRAITS_REMOVE_BASE_SPECIALIZATION)
```
</details>