### PR TITLE
CI: Bump MoltenVK to v1.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
 
     - name: "Install molten-vk"
       run: |
-        curl -L -O https://github.com/KhronosGroup/MoltenVK/releases/download/v1.2.9/MoltenVK-macos.tar
+        curl -L -O https://github.com/KhronosGroup/MoltenVK/releases/download/v1.3.0/MoltenVK-macos.tar
         tar xf MoltenVK-macos.tar
         sudo mkdir -p /usr/local/lib
         sudo cp MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib /usr/local/lib


### PR DESCRIPTION
This bumps the MVK version to 1.3.0 in the CI. 

Not sure if this is the only place it needs to be changed, but I wasn't able to find another reference to it. 

MVK 1.3.0 adds full Vulkan 1.3 support and many bug fixes.

Full changelog is [here](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.3.0).