### PR TITLE
nsyshid: Add Kamen Rider USB Device to Whitelist

### DIFF
--- a/src/Cafe/OS/libs/nsyshid/Whitelist.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Whitelist.cpp
@@ -20,6 +20,8 @@ namespace nsyshid
 			m_devices.emplace_back(0x1430, 0x1F17);
 			// disney infinity base
 			m_devices.emplace_back(0x0e6f, 0x0129);
+			// kamen rider ride gate
+			m_devices.emplace_back(0x0e6f, 0x200A);
 		}
 	}
 


### PR DESCRIPTION
Allows users to play Kamen Rider: Summon Ride on Cemu with their USB Portal from the PS3 or Wii U version of the game