### PR TITLE
Disable Ctrl+Q shortcut on non-macOS platforms to prevent accidental exits during gameplay

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1448,15 +1448,23 @@ void MainWindow::OnKeyUp(wxKeyEvent& event)
 
 void MainWindow::OnKeyDown(wxKeyEvent& event)
 {
-	if ((event.AltDown() && event.GetKeyCode() == WXK_F4) || 
-		(event.CmdDown() && event.GetKeyCode() == 'Q'))
-	{
-		Close(true);
-	}
-	else
-	{
-		event.Skip();
-	}
+#if defined(__APPLE__)
+       // On macOS, allow Cmd+Q to quit the application
+    if (event.CmdDown() && event.GetKeyCode() == 'Q')
+    {
+        Close(true);
+    }
+#else
+     // On Windows/Linux, only Alt+F4 is allowed for quittinger
+    if (event.AltDown() && event.GetKeyCode() == WXK_F4)
+    {
+        Close(true);
+    }
+#endif
+    else
+    {
+        event.Skip(); 
+    }
 }
 
 void MainWindow::OnChar(wxKeyEvent& event)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1455,7 +1455,7 @@ void MainWindow::OnKeyDown(wxKeyEvent& event)
         Close(true);
     }
 #else
-     // On Windows/Linux, only Alt+F4 is allowed for quittinger
+     // On Windows/Linux, only Alt+F4 is allowed for quitting
     if (event.AltDown() && event.GetKeyCode() == WXK_F4)
     {
         Close(true);


### PR DESCRIPTION
This PR updates the `MainWindow::OnKeyDown` logic to prevent `Ctrl+Q` from closing the application on Windows and Linux.

### Why this change?

On non-macOS platforms, `Ctrl+Q` is not a standard quit shortcut. However, it was previously hardcoded in Cemu to close the window, using `event.CmdDown() && event.GetKeyCode() == 'Q'`, which maps to `Ctrl+Q` on Windows/Linux and `Cmd+Q` on macOS.

For users who map `Ctrl+Q` (or press it accidentally) during gameplay—especially those playing with keyboard controls—this could result in an unexpected app exit and potential progress loss.

### What this PR changes

- The quit shortcut `Cmd+Q` now works **only** on macOS.
- On Windows/Linux, only `Alt+F4` triggers a clean shutdown.
- `Ctrl+Q` is ignored on non-macOS systems to avoid unintended closures.

### Tested:
✅ Windows 11, built with MSVC  
✅ Cemu launches and closes as expected using `Alt+F4`
