### PR TITLE
GraphicPack: Allow overlay for code folder

### DIFF
--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -821,7 +821,7 @@ void GraphicPack2::AddConstantsForCurrentPreset(ExpressionParser& ep)
 	}
 }
 
-void GraphicPack2::_iterateReplacedFiles(const fs::path& currentPath, bool isAOC)
+void GraphicPack2::_iterateReplacedFiles(const fs::path& currentPath, bool isAOC, const char* virtualMountBase)
 {
 	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
 	uint64 aocTitleId = (currentTitleId & 0xFFFFFFFFull) | 0x0005000c00000000ull;
@@ -836,7 +836,7 @@ void GraphicPack2::_iterateReplacedFiles(const fs::path& currentPath, bool isAOC
 			}
 			else
 			{
-				virtualMountPath = fs::path("vol/content/") / virtualMountPath;
+				virtualMountPath = fs::path(virtualMountBase) / virtualMountPath;
 			}
 			fscDeviceRedirect_add(virtualMountPath.generic_string(), it.file_size(), it.path().generic_string(), m_fs_priority);
 		}		
@@ -861,7 +861,7 @@ void GraphicPack2::LoadReplacedFiles()
 	{
 		// setup redirections	
 		fscDeviceRedirect_map();
-		_iterateReplacedFiles(contentPath, false);
+		_iterateReplacedFiles(contentPath, false, "vol/content/");
 	}
 	// /aoc/
 	fs::path aocPath(gfxPackPath);
@@ -874,7 +874,18 @@ void GraphicPack2::LoadReplacedFiles()
 		aocTitleId |= 0x0005000c00000000ULL;
 		// setup redirections	
 		fscDeviceRedirect_map();
-		_iterateReplacedFiles(aocPath, true);
+		_iterateReplacedFiles(aocPath, true, nullptr);
+	}
+	
+	// /code/
+	fs::path codePath(gfxPackPath);
+	codePath.append("code");
+	
+	if (fs::exists(codePath, ec))
+	{
+	    // setup redirections
+		fscDeviceRedirect_map();
+		_iterateReplacedFiles(codePath, false, CafeSystem::GetInternalVirtualCodeFolder().c_str());
 	}
 }
 

--- a/src/Cafe/GraphicPack/GraphicPack2.h
+++ b/src/Cafe/GraphicPack/GraphicPack2.h
@@ -260,7 +260,7 @@ private:
 	CustomShader LoadShader(const fs::path& path, uint64 shader_base_hash, uint64 shader_aux_hash, GP_SHADER_TYPE shader_type) const;
 	void ApplyShaderPresets(std::string& shader_source) const;
 	void LoadReplacedFiles();
-	void _iterateReplacedFiles(const fs::path& currentPath, bool isAOC);
+	void _iterateReplacedFiles(const fs::path& currentPath, bool isAOC, const char* virtualMountBase);
 
 	// ram mappings
 	std::vector<std::pair<MPTR, MPTR>> m_ramMappings;


### PR DESCRIPTION
Allow graphic packs to overlay/redirect files into the code directory, using the `InternalVirtualCodeFolder` base path.