### PR TITLE
Minor macOS UI improvements

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -288,6 +288,11 @@ private:
 MainWindow::MainWindow()
 	: wxFrame(nullptr, -1, GetInitialWindowTitle(), wxDefaultPosition, wxSize(1280, 720), wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxSYSTEM_MENU | wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN | wxRESIZE_BORDER)
 {
+#ifdef __WXMAC__
+	// Not necessary to set wxApp::s_macExitMenuItemId as automatically handled
+	wxApp::s_macAboutMenuItemId = MAINFRAME_MENU_ID_HELP_ABOUT;
+	wxApp::s_macPreferencesMenuItemId = MAINFRAME_MENU_ID_OPTIONS_GENERAL2;
+#endif
 	gui_initHandleContextFromWxWidgetsWindow(g_window_info.window_main, this);
 	g_mainFrame = this;
 	CafeSystem::SetImplementation(this);
@@ -1940,6 +1945,16 @@ public:
 			lineSizer->Add(new wxStaticText(parent, -1, ")"), 0);
 			sizer->Add(lineSizer);
 		}
+#if BOOST_OS_MACOS
+		// MoltenVK
+		{
+			wxSizer* lineSizer = new wxBoxSizer(wxHORIZONTAL);
+			lineSizer->Add(new wxStaticText(parent, -1, "MoltenVK ("), 0);
+			lineSizer->Add(new wxHyperlinkCtrl(parent, -1, "https://github.com/KhronosGroup/MoltenVK", "https://github.com/KhronosGroup/MoltenVK"), 0);
+			lineSizer->Add(new wxStaticText(parent, -1, ")"), 0);
+			sizer->Add(lineSizer);
+		}
+#endif
 		// icons
 		{
 			wxSizer* lineSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -2165,7 +2180,11 @@ void MainWindow::RecreateMenu()
 	m_padViewMenuItem = optionsMenu->AppendCheckItem(MAINFRAME_MENU_ID_OPTIONS_SECOND_WINDOW_PADVIEW, _("&Separate GamePad view"), wxEmptyString);
 	m_padViewMenuItem->Check(GetConfig().pad_open);
 	optionsMenu->AppendSeparator();
+	#if BOOST_OS_MACOS
+	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, _("&Settings..." "\tCtrl-,"));
+	#else
 	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, _("&General settings"));
+	#endif
 	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_INPUT, _("&Input settings"));
 
 	optionsMenu->AppendSeparator();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -91,6 +91,7 @@ enum
 	MAINFRAME_MENU_ID_OPTIONS_GENERAL2,
 	MAINFRAME_MENU_ID_OPTIONS_AUDIO,
 	MAINFRAME_MENU_ID_OPTIONS_INPUT,
+	MAINFRAME_MENU_ID_OPTIONS_MAC_SETTINGS,
 	// options -> account
 	MAINFRAME_MENU_ID_OPTIONS_ACCOUNT_1 = 20350,
 	MAINFRAME_MENU_ID_OPTIONS_ACCOUNT_12 = 20350 + 11,
@@ -187,6 +188,7 @@ EVT_MENU(MAINFRAME_MENU_ID_OPTIONS_GENERAL, MainWindow::OnOptionsInput)
 EVT_MENU(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, MainWindow::OnOptionsInput)
 EVT_MENU(MAINFRAME_MENU_ID_OPTIONS_AUDIO, MainWindow::OnOptionsInput)
 EVT_MENU(MAINFRAME_MENU_ID_OPTIONS_INPUT, MainWindow::OnOptionsInput)
+EVT_MENU(MAINFRAME_MENU_ID_OPTIONS_MAC_SETTINGS, MainWindow::OnOptionsInput)
 // tools menu
 EVT_MENU(MAINFRAME_MENU_ID_TOOLS_MEMORY_SEARCHER, MainWindow::OnToolsInput)
 EVT_MENU(MAINFRAME_MENU_ID_TOOLS_TITLE_MANAGER, MainWindow::OnToolsInput)
@@ -291,7 +293,7 @@ MainWindow::MainWindow()
 #ifdef __WXMAC__
 	// Not necessary to set wxApp::s_macExitMenuItemId as automatically handled
 	wxApp::s_macAboutMenuItemId = MAINFRAME_MENU_ID_HELP_ABOUT;
-	wxApp::s_macPreferencesMenuItemId = MAINFRAME_MENU_ID_OPTIONS_GENERAL2;
+	wxApp::s_macPreferencesMenuItemId = MAINFRAME_MENU_ID_OPTIONS_MAC_SETTINGS;
 #endif
 	gui_initHandleContextFromWxWidgetsWindow(g_window_info.window_main, this);
 	g_mainFrame = this;
@@ -916,6 +918,7 @@ void MainWindow::OnOptionsInput(wxCommandEvent& event)
 		break;
 	}
 
+	case MAINFRAME_MENU_ID_OPTIONS_MAC_SETTINGS:
 	case MAINFRAME_MENU_ID_OPTIONS_GENERAL2:
 	{
 		OpenSettings();
@@ -2181,10 +2184,9 @@ void MainWindow::RecreateMenu()
 	m_padViewMenuItem->Check(GetConfig().pad_open);
 	optionsMenu->AppendSeparator();
 	#if BOOST_OS_MACOS
-	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, _("&Settings..." "\tCtrl-,"));
-	#else
-	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, _("&General settings"));
+	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_MAC_SETTINGS, _("&Settings..." "\tCtrl-,"));
 	#endif
+	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_GENERAL2, _("&General settings"));
 	optionsMenu->Append(MAINFRAME_MENU_ID_OPTIONS_INPUT, _("&Input settings"));
 
 	optionsMenu->AppendSeparator();

--- a/src/gui/components/wxGameList.h
+++ b/src/gui/components/wxGameList.h
@@ -53,9 +53,7 @@ public:
 	void ReloadGameEntries(bool cached = false);
 	void DeleteCachedStrings();
 
-#if BOOST_OS_LINUX || BOOST_OS_WINDOWS
     void CreateShortcut(GameInfo2& gameInfo);
-#endif
 
 	long FindListItemByTitleId(uint64 title_id) const;
 	void OnClose(wxCloseEvent& event);


### PR DESCRIPTION
Various minor improvements to the macOS UI:
* Allow creating app shortcuts on Mac, similar to Linux and Windows
* Move the 'About' and 'General settings' menu items to where they would typically be found on Mac
* * Another copy of the existing 'General settings' menu item is still there in its original location
* Add `⌘,` keybinding for Settings, same as for other macOS apps
* Add MoltenVK to list of used libraries

Cemu menu:
<img width="210" alt="Screenshot 2025-05-24 at 1 18 47 AM" src="https://github.com/user-attachments/assets/33f438fc-4eef-4886-b918-202a70a446a6" />
App appearance in Launchpad:
<img width="656" alt="Screenshot 2025-05-24 at 1 36 36 AM" src="https://github.com/user-attachments/assets/d3cd84c6-e983-4eeb-85c5-114123fcfc69" />
