### PR TITLE
UI: wxCAPTION flag on input API dialog to fix kwin

### DIFF
--- a/src/gui/input/InputAPIAddWindow.cpp
+++ b/src/gui/input/InputAPIAddWindow.cpp
@@ -23,7 +23,7 @@ using wxControllerData = wxCustomData<ControllerPtr>;
 
 InputAPIAddWindow::InputAPIAddWindow(wxWindow* parent, const wxPoint& position,
                                      const std::vector<ControllerPtr>& controllers)
-	: wxDialog(parent, wxID_ANY, "Add input API", position, wxDefaultSize, 0), m_controllers(controllers)
+	: wxDialog(parent, wxID_ANY, "Add input API", position, wxDefaultSize, wxCAPTION), m_controllers(controllers)
 {
 	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
 


### PR DESCRIPTION
The IP and port input boxes are not shown when the DSUController API is first selected when using wayland with kwin.

Setting the dialog as wxCAPTION causes kwin to add decorations to the window which for whatever reason causes the toplevel to resize correctly.

This may be a bug in wxWidgets or kwin.

With dialog style set to 0:

https://github.com/user-attachments/assets/42d15f24-f402-4217-bf85-594db658e063

With dialog style set to wxCAPTION:

https://github.com/user-attachments/assets/a05d0860-308d-4f31-9501-4df4f7f3bd77

Fixes #867