### PR TITLE
"verbose" command line argument to log to stdout

### DIFF
--- a/src/Cemu/Logging/CemuLogging.cpp
+++ b/src/Cemu/Logging/CemuLogging.cpp
@@ -3,6 +3,7 @@
 #include "util/helpers/helpers.h"
 #include "config/CemuConfig.h"
 #include "config/ActiveSettings.h"
+#include "config/LaunchSettings.h"
 
 #include <mutex>
 #include <condition_variable>
@@ -143,6 +144,9 @@ bool cemuLog_log(LogType type, std::string_view text)
 {
 	if (!cemuLog_isLoggingEnabled(type))
 		return false;
+
+	if (LaunchSettings::Verbose())
+		std::cout << text << std::endl;
 
 	cemuLog_writeLineToLog(text);
 

--- a/src/config/LaunchSettings.cpp
+++ b/src/config/LaunchSettings.cpp
@@ -59,6 +59,9 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 	desc.add_options()
 		("help,h", "This help screen")
 		("version,v", "Displays the version of Cemu")
+#if !BOOST_OS_WINDOWS
+		("verbose", "Log to stdout")
+#endif
 
 		("game,g", po::wvalue<std::wstring>(), "Path of game to launch")
         ("title-id,t", po::value<std::string>(), "Title ID of the title to be launched (overridden by --game)")
@@ -124,6 +127,9 @@ bool LaunchSettings::HandleCommandline(const std::vector<std::wstring>& args)
 			std::cout << versionStr << std::endl;
 			return false; // exit in main
 		}
+
+		if (vm.count("verbose"))
+			s_verbose = true;
 
 		if (vm.count("game"))
 		{

--- a/src/config/LaunchSettings.h
+++ b/src/config/LaunchSettings.h
@@ -22,6 +22,8 @@ public:
 	static std::optional<bool> RenderUpsideDownEnabled() { return s_render_upside_down; }
 	static std::optional<bool> FullscreenEnabled() { return s_fullscreen; }
 
+	static bool Verbose() { return s_verbose; }
+
 	static bool GDBStubEnabled() { return s_enable_gdbstub; }
 	static bool NSightModeEnabled() { return s_nsight_mode; }
 
@@ -40,6 +42,8 @@ private:
 
 	inline static std::optional<bool> s_render_upside_down{};
 	inline static std::optional<bool> s_fullscreen{};
+
+	inline static bool s_verbose = false;
 	
 	inline static bool s_enable_gdbstub = false;
 	inline static bool s_nsight_mode = false;


### PR DESCRIPTION
I find the way Cemu logs intuitive.

When I try to track down an issue too much of my time is spent trying to figure out where my log lines are going.

What I want is to type `Cemu --help`, see that there's an option to print to stdout and use that.