### PR TITLE
Add FSTimeToCalendarTime function

### DIFF
--- a/src/Cafe/OS/libs/coreinit/coreinit_Time.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Time.h
@@ -50,6 +50,7 @@ namespace coreinit
 	};
 
 	void OSTicksToCalendarTime(uint64 ticks, OSCalendarTime_t* calenderStruct);
+	void FSTimeToCalendarTime(uint64 fsTime_microseconds, OSCalendarTime_t* outCalendarTime);
 
 	uint64 OSGetSystemTime();
 	uint64 OSGetTime();


### PR DESCRIPTION
This adds FSTimeToCalendarTime to coreinit_Time.cpp, which is commonly used in Lego games to convert a given timestamp.
![grafik](https://github.com/user-attachments/assets/965a2af1-30da-492d-8a81-d4f8fbea47d3)
![grafik](https://github.com/user-attachments/assets/98ef410f-755a-4b6c-b04d-723fe04abd20)