### PR TITLE
boss: Use HTTP/1.1 instead of default

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_boss.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_boss.cpp
@@ -502,6 +502,7 @@ namespace iosu
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, task_header_callback);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &(*it));
 		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0x3C);
+		curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 		if (IsNetworkServiceSSLDisabled(ActiveSettings::GetNetworkService()))
 		{ 
 			curl_easy_setopt(curl,CURLOPT_SSL_VERIFYPEER,0L);


### PR DESCRIPTION
The Pretendo BOSS server does not accept HTTP/2 connections, even when the request is correctly formed (it assumes you're using a web browser). This, from what I've seen online, is not a problem because libcurl defaults to HTTP/1.1. Except on the Flatpak build for some reason. This fixes Splatoon for me.