### PR TITLE
replace basic_string<> with std::vector because of new Clang

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -132,7 +132,7 @@ namespace iosu
 
 		void convertMultiByteStringToBigEndianWidechar(const char* input, uint16be* output, sint32 maxOutputLength)
 		{
-			std::basic_string<uint16be> beStr = StringHelpers::FromUtf8(input);
+			std::vector<uint16be> beStr = StringHelpers::FromUtf8(input);
 			if (beStr.size() >= maxOutputLength - 1)
 				beStr.resize(maxOutputLength-1);
 			for (size_t i = 0; i < beStr.size(); i++)
@@ -723,7 +723,7 @@ namespace iosu
 			{
 				if(numVecIn != 0 || numVecOut != 1)
 					return FPResult_InvalidIPCParam;
-				std::basic_string<uint16be> myComment;
+				std::vector<uint16be> myComment;
 				if(g_fpd.nexFriendSession)
 				{
 					if(vecOut->size != MY_COMMENT_LENGTH * sizeof(uint16be))
@@ -735,8 +735,8 @@ namespace iosu
 					g_fpd.nexFriendSession->getMyComment(myNexComment);
 					myComment = StringHelpers::FromUtf8(myNexComment.commentString);
 				}
-				myComment.insert(0, 1, '\0');
-				memcpy(vecOut->basePhys.GetPtr(), myComment.c_str(), MY_COMMENT_LENGTH * sizeof(uint16be));
+				myComment.insert(myComment.begin(), '\0');
+				memcpy(vecOut->basePhys.GetPtr(), myComment.data(), MY_COMMENT_LENGTH * sizeof(uint16be));
 				return FPResult_Ok;
 			}
 

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.cpp
@@ -145,7 +145,8 @@ namespace nn
 
 				if (name.size() != 0)
 				{
-					auto name_utf16 = StringHelpers::FromUtf8(name).substr(0, 128);
+					auto name_utf16 = StringHelpers::FromUtf8(name);
+					name_utf16.resize(std::min<size_t>(name_utf16.size(), 128));
 					if (name_utf16.size() != 0)
 					{
 						for (int i = 0; i < name_utf16.size(); i++)
@@ -160,7 +161,8 @@ namespace nn
 
 				if (description.size() != 0)
 				{
-					auto description_utf16 = StringHelpers::FromUtf8(description).substr(0, 256);
+					auto description_utf16 = StringHelpers::FromUtf8(description);
+					description_utf16.resize(std::min<size_t>(description_utf16.size(), 256));
 					if (description_utf16.size() != 0)
 					{
 						for (int i = 0; i < description_utf16.size(); i++)
@@ -206,7 +208,8 @@ namespace nn
 
 				if (screen_name.size() != 0)
 				{
-					auto screen_name_utf16 = StringHelpers::FromUtf8(screen_name).substr(0, 32);
+					auto screen_name_utf16 = StringHelpers::FromUtf8(screen_name);
+					screen_name_utf16.resize(std::min<size_t>(screen_name_utf16.size(), 32));
 					if (screen_name_utf16.size() != 0)
 					{
 						for (int i = 0; i < screen_name_utf16.size(); i++)

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
@@ -250,7 +250,8 @@ namespace nn
 
 				if (name.size() != 0)
 				{
-					auto name_utf16 = StringHelpers::FromUtf8(name).substr(0, 128);
+					auto name_utf16 = StringHelpers::FromUtf8(name);
+					name_utf16.resize(std::min<size_t>(name_utf16.size(), 128));
 					if (name_utf16.size() != 0)
 					{
 						for (int i = 0; i < name_utf16.size(); i++)
@@ -265,7 +266,8 @@ namespace nn
 
 				if (description.size() != 0)
 				{
-					auto description_utf16 = StringHelpers::FromUtf8(description).substr(0, 256);
+					auto description_utf16 = StringHelpers::FromUtf8(description);
+					description_utf16.resize(std::min<size_t>(description_utf16.size(), 256));
 					if (description_utf16.size() != 0)
 					{
 						for (int i = 0; i < description_utf16.size(); i++)

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
@@ -1,5 +1,6 @@
 #include "nn_olv_UploadFavoriteTypes.h"
 #include <algorithm>
+#include <cstddef>
 
 namespace nn
 {
@@ -115,7 +116,8 @@ namespace nn
 
 				if (name.size() != 0)
 				{
-					auto name_utf16 = StringHelpers::FromUtf8(name).substr(0, 128);
+					auto name_utf16 = StringHelpers::FromUtf8(name);
+					name_utf16.resize(std::min<size_t>(name_utf16.size(), 128));
 					if (name_utf16.size() != 0)
 					{
 						for (int i = 0; i < name_utf16.size(); i++)
@@ -130,7 +132,8 @@ namespace nn
 
 				if (description.size() != 0)
 				{
-					auto description_utf16 = StringHelpers::FromUtf8(description).substr(0, 256);
+					auto description_utf16 = StringHelpers::FromUtf8(description);
+					description_utf16.resize(std::min<size_t>(description_utf16.size(), 256));
 					if (description_utf16.size() != 0)
 					{
 						for (int i = 0; i < description_utf16.size(); i++)

--- a/src/Common/CafeString.h
+++ b/src/Common/CafeString.h
@@ -51,15 +51,15 @@ class CafeWideString // fixed buffer size, null-terminated, PPC wchar_t (16bit b
 
 	bool assignFromUTF8(std::string_view sv)
 	{
-		std::basic_string<uint16be> beStr = StringHelpers::FromUtf8(sv);
-		if(beStr.length() > N-1)
+		std::vector<uint16be> beStr = StringHelpers::FromUtf8(sv);
+		if(beStr.size() > N-1)
 		{
 			memcpy(data, beStr.data(), (N-1)*sizeof(uint16be));
 			data[N-1] = 0;
 			return false;
 		}
-		memcpy(data, beStr.data(), beStr.length()*sizeof(uint16be));
-		data[beStr.length()] = '\0';
+		memcpy(data, beStr.data(), beStr.size()*sizeof(uint16be));
+		data[beStr.size()] = '\0';
 		return true;
 	}
 

--- a/src/util/helpers/StringHelpers.h
+++ b/src/util/helpers/StringHelpers.h
@@ -111,9 +111,9 @@ namespace StringHelpers
 	}
 
 	// convert utf8 string to Wii U big-endian wchar_t string
-	static std::basic_string<uint16be> FromUtf8(std::string_view str)
+	static std::vector<uint16be> FromUtf8(std::string_view str)
 	{
-		std::basic_string<uint16be> tmpStr;
+		std::vector<uint16be> tmpStr;
 		std::wstring w = boost::nowide::widen(str.data(), str.size());
 		for (auto& c : w)
 			tmpStr.push_back((uint16)c);


### PR DESCRIPTION
A recent version of Clang (actually libc++ 19 IIRC) has removed deprecated string templates. I replaced them with `std::vector`.