### PR TITLE
input/wiimote: Detect Classic Controller Pro as Classic Controller

### DIFF
--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -323,6 +323,7 @@ void WiimoteControllerProvider::reader_thread()
 							break;
 						case kExtensionClassicPro:
                             cemuLog_logDebug(LogType::Force,"Extension Type Received: Classic Pro");
+							new_state.m_extension = ClassicData{};
                             break;
 						case kExtensionGuitar:
                             cemuLog_logDebug(LogType::Force,"Extension Type Received: Guitar");


### PR DESCRIPTION
According to Wiibrew, they have the same packet format