### PR TITLE
Fix glslang build on Fedora 42

### DIFF
--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -552,7 +552,7 @@ target_include_directories(CemuCafe PUBLIC "../")
 if (glslang_VERSION VERSION_LESS "15.0.0")
 	set(glslang_target "glslang::SPIRV")
 else()
-	set(glslang_target "glslang")
+	set(glslang_target "glslang::glslang")
 endif()
 
 target_link_libraries(CemuCafe PRIVATE

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -58,6 +58,10 @@
   ],
   "overrides": [
     {
+      "name": "glslang",
+      "version": "15.1.0"
+    },
+    {
       "name": "sdl2",
       "version": "2.30.3"
     }


### PR DESCRIPTION
Fixes building glslang on Fedora 42 by adding the updated Spirv headers.
fixed in https://github.com/KhronosGroup/glslang/commit/e40c14a3e007fac0e4f2e4164fdf14d1712355bd
Uses glslang imported target instead of library as suggested by @abouvier https://github.com/cemu-project/Cemu/pull/1436#issuecomment-2538261325

fixes: https://github.com/cemu-project/Cemu/issues/1544

