### PR TITLE
Override C preprocessor directives in aarch64

### DIFF
--- a/dependencies/ih264d/CMakeLists.txt
+++ b/dependencies/ih264d/CMakeLists.txt
@@ -182,7 +182,10 @@ target_sources(ih264d PRIVATE
 "decoder/arm/ih264d_function_selector_av8.c"
 "decoder/arm/ih264d_function_selector.c"
 )
-target_compile_options(ih264d PRIVATE -DARMV8)
+target_compile_options(ih264d PRIVATE -DARMV8 $<$<COMPILE_LANGUAGE:ASM,Clang>:-Wno-unused-command-line-argument>)
+if(NOT MSVC)
+    set(CMAKE_ASM_FLAGS "${CFLAGS} -x assembler-with-cpp")
+endif()
 if(APPLE)
     target_sources(ih264d PRIVATE "common/armv8/macos_arm_symbol_aliases.s")
 endif()


### PR DESCRIPTION
Fixes: https://github.com/cemu-project/Cemu/issues/1618