### PR TITLE
Add NSIS Windows installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,14 @@ jobs:
     - name: "cmake"
       run: |
         cmake -S . -B build ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} -DCMAKE_C_COMPILER=/usr/bin/clang-15 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-15 -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja
-        
+
     - name: "Build Cemu"
       run: |
         cmake --build build
-        
+
     - name: Prepare artifact
       run: mv bin/Cemu_release bin/Cemu
-              
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
@@ -138,7 +138,7 @@ jobs:
     - name: "Bootstrap vcpkg"
       run: |
         ./dependencies/vcpkg/bootstrap-vcpkg.bat
-        
+
     - name: 'Setup NuGet Credentials for vcpkg'
       shell: 'bash'
       run: |
@@ -152,7 +152,7 @@ jobs:
         `./dependencies/vcpkg/vcpkg.exe fetch nuget | tail -n 1` \
         setapikey "${{ secrets.GITHUB_TOKEN }}" \
         -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-        
+
     - name: "cmake"
       run: |
         mkdir -p build
@@ -160,7 +160,7 @@ jobs:
         echo "[INFO] BUILD_FLAGS: ${{ env.BUILD_FLAGS }}"
         echo "[INFO] BUILD_MODE: ${{ env.BUILD_MODE }}"
         cmake .. ${{ env.BUILD_FLAGS }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_MODE }} -DVCPKG_INSTALL_OPTIONS="--clean-after-build"
-        
+
     - name: "Build Cemu"
       run: |
         cd build
@@ -168,12 +168,24 @@ jobs:
 
     - name: Prepare artifact
       run: Rename-Item bin/Cemu_release.exe Cemu.exe
-      
+
+    - name: Build NSIS Installer
+      shell: cmd
+      run: |
+        cd src\resource
+        makensis /DPRODUCT_VERSION=${{ inputs.next_version_major }}.${{ inputs.next_version_minor }} installer.nsi
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: cemu-bin-windows-x64
         path: ./bin/Cemu.exe
+
+    - name: Upload NSIS Installer
+      uses: actions/upload-artifact@v4
+      with:
+        name: cemu-installer-windows-x64
+        path: ./src/resource/cemu-${{ inputs.next_version_major }}.${{ inputs.next_version_minor }}-windows-x64-installer.exe
 
   build-macos:
     runs-on: macos-14
@@ -185,7 +197,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: "recursive"
-        
+
     - name: Setup release mode parameters
       run: |
         echo "BUILD_MODE=release" >> $GITHUB_ENV
@@ -197,7 +209,7 @@ jobs:
       run: |
         echo "[INFO] Version ${{ inputs.next_version_major }}.${{ inputs.next_version_minor }}"
         echo "BUILD_FLAGS=${{ env.BUILD_FLAGS }} -DEMULATOR_VERSION_MAJOR=${{ inputs.next_version_major }} -DEMULATOR_VERSION_MINOR=${{ inputs.next_version_minor }}" >> $GITHUB_ENV
-        
+
     - name: "Install system dependencies"
       run: |
         brew update
@@ -218,7 +230,7 @@ jobs:
     - name: "Bootstrap vcpkg"
       run: |
         bash ./dependencies/vcpkg/bootstrap-vcpkg.sh
-        
+
     - name: 'Setup NuGet Credentials for vcpkg'
       shell: 'bash'
       run: |
@@ -232,7 +244,7 @@ jobs:
         mono `./dependencies/vcpkg/vcpkg fetch nuget | tail -n 1` \
         setapikey "${{ secrets.GITHUB_TOKEN }}" \
         -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-        
+
     - name: "cmake"
       run: |
         mkdir build
@@ -242,7 +254,7 @@ jobs:
         -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
         -DMACOS_BUNDLE=ON \
         -G Ninja
-        
+
     - name: "Build Cemu"
       run: |
         cmake --build build
@@ -258,7 +270,7 @@ jobs:
         hdiutil create ./bin/tmp.dmg -ov -volname "Cemu" -fs HFS+ -srcfolder "./bin/Cemu_app"
         hdiutil convert ./bin/tmp.dmg -format UDZO -o bin/Cemu.dmg
         rm bin/tmp.dmg
-              
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -95,6 +95,11 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: cemu-installer-windows-x64
+          path: cemu-installer-windows-x64
+
+      - uses: actions/download-artifact@v4
+        with:
           pattern: cemu-bin-macos*
           path: cemu-macos
 
@@ -102,7 +107,7 @@ jobs:
         run: |
           mkdir upload
           sudo apt install zip
-          
+
       - name: Set version dependent vars
         run: |
           echo "Version: ${{ needs.calculate-version.outputs.next_version }}"
@@ -119,6 +124,9 @@ jobs:
           mv cemu-bin-windows-x64/Cemu.exe ./${{ env.CEMU_FOLDER_NAME }}/Cemu.exe
           zip -9 -r upload/cemu-${{ env.CEMU_VERSION }}-windows-x64.zip ${{ env.CEMU_FOLDER_NAME }}
           rm -r ./${{ env.CEMU_FOLDER_NAME }}
+
+      - name: Create release from windows-installer
+        run: cp cemu-installer-windows-x64/cemu-${{ env.CEMU_VERSION }}-windows-x64-installer.exe upload/cemu-${{ env.CEMU_VERSION }}-windows-x64-installer.exe
 
       - name: Create appimage
         run: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Cemu is currently only available for 64-bit Windows, Linux & macOS devices.
 
 You can download the latest Cemu releases for Windows, Linux and Mac from the [GitHub Releases](https://github.com/cemu-project/Cemu/releases/). For Linux you can also find Cemu on [flathub](https://flathub.org/apps/info.cemu.Cemu).
 
-On Windows Cemu is currently only available in a portable format so no installation is required besides extracting it in a safe place.
+On Windows, Cemu is available both as an installer and in a portable format, where no installation is required besides extracting it in a safe place.
 
 The native macOS build is currently purely experimental and should not be considered stable or ready for issue-free gameplay. There are also known issues with degraded performance due to the use of MoltenVK and Rosetta for ARM Macs. We appreciate your patience while we improve Cemu for macOS.
 

--- a/src/resource/installer.nsi
+++ b/src/resource/installer.nsi
@@ -1,0 +1,172 @@
+; Copyright Dolphin Emulator Project / Azahar Emulator Project / Team Cemu
+; Licensed under MPL 2.0 with permission from authors
+
+; Usage:
+;   get the latest nsis: https://nsis.sourceforge.io/Download
+;   probably also want vscode extension: https://marketplace.visualstudio.com/items?itemName=idleberg.nsis
+
+; Require /DPRODUCT_VERSION for makensis.
+!ifndef PRODUCT_VERSION
+  !error "PRODUCT_VERSION must be defined"
+!endif
+
+ManifestDPIAware true
+
+!define PRODUCT_NAME "Cemu"
+!define PRODUCT_PUBLISHER "Team Cemu"
+!define PRODUCT_WEB_SITE "https://cemu.info/"
+!define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\${PRODUCT_NAME}.exe"
+!define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
+
+!define BINARY_SOURCE_DIR "..\..\bin"
+
+Name "${PRODUCT_NAME}"
+OutFile "cemu-${PRODUCT_VERSION}-windows-x64-installer.exe"
+SetCompressor /SOLID lzma
+InstallDir "$LOCALAPPDATA\Cemu" 
+ShowInstDetails show
+ShowUnInstDetails show
+
+!include "MUI2.nsh"
+; Custom page plugin
+!include "nsDialogs.nsh"
+
+; MUI Settings
+!define MUI_ICON "logo_icon.ico"
+!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
+
+; License page
+!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE.txt"
+; Desktop Shortcut page
+Page custom desktopShortcutPageCreate desktopShortcutPageLeave
+; Directory page
+!insertmacro MUI_PAGE_DIRECTORY
+; Instfiles page
+!insertmacro MUI_PAGE_INSTFILES
+; Finish page
+!define MUI_FINISHPAGE_RUN "$INSTDIR\Cemu.exe"
+!insertmacro MUI_PAGE_FINISH
+
+; Uninstaller pages
+!insertmacro MUI_UNPAGE_INSTFILES
+
+; Variables
+Var DesktopShortcutPageDialog
+Var DesktopShortcutCheckbox
+Var DesktopShortcut
+
+; Language files
+!insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE "SimpChinese"
+!insertmacro MUI_LANGUAGE "TradChinese"
+!insertmacro MUI_LANGUAGE "Danish"
+!insertmacro MUI_LANGUAGE "Dutch"
+!insertmacro MUI_LANGUAGE "French"
+!insertmacro MUI_LANGUAGE "German"
+!insertmacro MUI_LANGUAGE "Hungarian"
+!insertmacro MUI_LANGUAGE "Italian"
+!insertmacro MUI_LANGUAGE "Japanese"
+!insertmacro MUI_LANGUAGE "Korean"
+!insertmacro MUI_LANGUAGE "Lithuanian"
+!insertmacro MUI_LANGUAGE "Norwegian"
+!insertmacro MUI_LANGUAGE "Polish"
+!insertmacro MUI_LANGUAGE "PortugueseBR"
+!insertmacro MUI_LANGUAGE "Romanian"
+!insertmacro MUI_LANGUAGE "Russian"
+!insertmacro MUI_LANGUAGE "Spanish"
+!insertmacro MUI_LANGUAGE "Swedish"
+!insertmacro MUI_LANGUAGE "Turkish"
+!insertmacro MUI_LANGUAGE "Vietnamese"
+
+; MUI end ------
+
+Function .onInit
+  StrCpy $DesktopShortcut 1
+
+  !insertmacro MUI_LANGDLL_DISPLAY
+FunctionEnd
+
+Function desktopShortcutPageCreate
+  !insertmacro MUI_HEADER_TEXT "Create Desktop Shortcut" "Would you like to create a desktop shortcut?"
+  nsDialogs::Create 1018
+  Pop $DesktopShortcutPageDialog
+  ${If} $DesktopShortcutPageDialog == error
+    Abort
+  ${EndIf}
+
+  ${NSD_CreateCheckbox} 0u 0u 100% 12u "Create a desktop shortcut"
+  Pop $DesktopShortcutCheckbox
+  ${NSD_SetState} $DesktopShortcutCheckbox $DesktopShortcut
+
+  nsDialogs::Show
+FunctionEnd
+
+Function desktopShortcutPageLeave
+  ${NSD_GetState} $DesktopShortcutCheckbox $DesktopShortcut
+FunctionEnd
+
+Section "Base"
+  ExecWait '"$INSTDIR\uninst.exe" /S _?=$INSTDIR'
+
+  SectionIn RO
+
+  SetOutPath "$INSTDIR"
+
+  ; The binplaced build output will be included verbatim.
+  File /r "${BINARY_SOURCE_DIR}\*"
+
+  ; Create start menu and desktop shortcuts
+  CreateShortCut "$SMPROGRAMS\$(^Name).lnk" "$INSTDIR\Cemu.exe"
+  ${If} $DesktopShortcut == 1
+    CreateShortCut "$DESKTOP\$(^Name).lnk" "$INSTDIR\Cemu.exe"
+  ${EndIf}
+SectionEnd
+
+!include "FileFunc.nsh"
+
+Section -Post
+  WriteUninstaller "$INSTDIR\uninst.exe"
+
+  WriteRegStr HKCU "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\Cemu.exe"
+
+  ; Write metadata for add/remove programs applet
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninst.exe"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayIcon" "$INSTDIR\Cemu.exe"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "URLInfoAbout" "${PRODUCT_WEB_SITE}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "Publisher" "${PRODUCT_PUBLISHER}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "InstallLocation" "$INSTDIR"
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKCU "${PRODUCT_UNINST_KEY}" "EstimatedSize" "$0"
+
+  WriteRegStr HKCU "Software\Classes\.wud" "" "$(^Name)"
+  WriteRegStr HKCU "Software\Classes\.wux" "" "$(^Name)"
+  WriteRegStr HKCU "Software\Classes\.wua" "" "$(^Name)"
+  WriteRegStr HKCU "Software\Classes\$(^Name)\DefaultIcon" "" "$INSTDIR\Cemu.exe,0"
+  WriteRegStr HKCU "Software\Classes\$(^Name)\Shell\open\command" "" '"$INSTDIR\Cemu.exe" %1'
+SectionEnd
+
+Section Uninstall
+  Delete "$DESKTOP\$(^Name).lnk"
+  Delete "$SMPROGRAMS\$(^Name).lnk"
+
+; Be a bit careful to not delete files a user may have put into the install directory
+  Delete "$INSTDIR\Cemu.exe"
+  Delete "$INSTDIR\uninst.exe"
+  RMDir /r "$INSTDIR\gameProfiles"
+  RMDir /r "$INSTDIR\resources"
+  RMDir "$INSTDIR"
+
+  DeleteRegKey HKCU "Software\Classes\.wud"
+  DeleteRegKey HKCU "Software\Classes\.wux"
+  DeleteRegKey HKCU "Software\Classes\.wua"
+  DeleteRegKey HKCU "Software\Classes\$(^Name)"
+
+  DeleteRegKey HKCU "Software\Classes\discord-460807638964371468"
+
+  DeleteRegKey HKCU "${PRODUCT_UNINST_KEY}"
+  DeleteRegKey HKCU "${PRODUCT_DIR_REGKEY}"
+
+  SetAutoClose true
+SectionEnd


### PR DESCRIPTION
Addition of an [NSIS](https://nsis.sourceforge.io/Main_Page) Windows installer to Cemu's build and distribution. Addresses #1491


Installers are more familiar to many Windows users and have the following benefits:
- Automatically creates shortcuts on the Desktop and in the Start Menu
- Appearance in Apps and Programs, and uninstallation through it
  - Cleans registry leftovers
  - User files in `AppData\Roaming` remain untouched
- Gives the application a dedicated default path in `AppData\Local`, rather than just leaving it float in Downloads or Documents, which is true for most users
  - For inexperienced users, this can avoid problems caused by OneDrive syncing
- Automatically assigns Rom files (`.wud, .wux, .wua`) to be opened with Cemu
- Portable single-file installer for easy distribution and offline updates

The `.nsi` file is based upon the one from [Azahar](https://github.com/azahar-emu/azahar) (originally taken from Dolphin), which I have touched-up recently.

Tested and verified as working.

I have also adjusted spacing for consistency in the build files.