### PR TITLE
refactor: use concepts instead of SFINAE

### DIFF
--- a/src/Cafe/GameProfile/GameProfile.cpp
+++ b/src/Cafe/GameProfile/GameProfile.cpp
@@ -106,7 +106,7 @@ bool gameProfile_loadIntegerOption(IniParser* iniParser, const char* optionName,
 template <typename T>
 bool gameProfile_loadIntegerOption(IniParser& iniParser, const char* optionName, T& option, T minVal, T maxVal)
 {
-	static_assert(std::is_integral<T>::value);
+	static_assert(std::is_integral_v<T>);
 	auto option_value = iniParser.FindOption(optionName);
 	if (!option_value)
 		return false;
@@ -133,7 +133,7 @@ bool gameProfile_loadIntegerOption(IniParser& iniParser, const char* optionName,
 template<typename T>
 bool gameProfile_loadEnumOption(IniParser& iniParser, const char* optionName, T& option)
 {
-	static_assert(std::is_enum<T>::value);
+	static_assert(std::is_enum_v<T>);
 	auto option_value = iniParser.FindOption(optionName);
 	if (!option_value)
 		return false;

--- a/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteBufferCache.cpp
@@ -25,7 +25,7 @@ class IntervalTree2
 	// static TNodeObject* Split(TNodeObject* nodeObject, TRangeData firstRangeBegin, TRangeData firstRangeEnd, TRangeData secondRangeBegin, TRangeData secondRangeEnd)
 	// Cut a hole into an existing range and split it in two. Should return the newly created node object after the hole
 
-	static_assert(std::is_pointer<TNodeObject>::value == false, "TNodeObject must be a non-pointer type");
+	static_assert(!std::is_pointer_v<TNodeObject>, "TNodeObject must be a non-pointer type");
 
 	struct InternalRange
 	{

--- a/src/Cafe/OS/common/OSUtil.h
+++ b/src/Cafe/OS/common/OSUtil.h
@@ -176,14 +176,14 @@ void cafeExportCallWrapper(PPCInterpreter_t* hCPU)
 		if(cemuLog_advancedPPCLoggingEnabled())
 		{
 			MPTR threadMPTR = memory_getVirtualOffsetFromPointer(coreinit::OSGetCurrentThread());
-			if constexpr (std::tuple_size<decltype(format_tup)>::value > 0)
+			if constexpr (std::tuple_size_v<decltype(format_tup)> > 0)
 				shouldLog = cemuLog_log(TLogType, "{}.{}{} # LR: {:#x} | Thread: {:#x}", TNames::GetLib(), TNames::GetFunc(), format_tup, hCPU->spr.LR, threadMPTR);
 			else
 				shouldLog = cemuLog_log(TLogType, "{}.{}() # LR: {:#x} | Thread: {:#x}", TNames::GetLib(), TNames::GetFunc(), hCPU->spr.LR, threadMPTR);
 		}
 		else
 		{
-			if constexpr (std::tuple_size<decltype(format_tup)>::value > 0)
+			if constexpr (std::tuple_size_v<decltype(format_tup)> > 0)
 			{
 				shouldLog = cemuLog_log(TLogType, "{}.{}{}", TNames::GetLib(), TNames::GetFunc(), format_tup);
 			}
@@ -192,7 +192,7 @@ void cafeExportCallWrapper(PPCInterpreter_t* hCPU)
 		}
 	}
 
-	if constexpr (!std::is_void<decltype(std::apply(fn, tup))>::value)
+	if constexpr (!std::is_void_v<decltype(std::apply(fn, tup))>)
 	{
 		// has non-void return type
 		decltype(auto) result = std::apply(fn, tup);

--- a/src/Cafe/OS/libs/gx2/GX2_Command.h
+++ b/src/Cafe/OS/libs/gx2/GX2_Command.h
@@ -39,9 +39,9 @@ inline void gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const b
 }
 
 template <typename T, typename ...Targs>
+	requires std::is_floating_point_v<T>
 inline
-typename std::enable_if< std::is_floating_point<T>::value, void>::type
-gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
+void gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
 {
 	static_assert(sizeof(T) == sizeof(uint32));
 	*writePtr = *(uint32*)&arg;
@@ -50,9 +50,9 @@ gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs
 }
 
 template <typename T, typename ...Targs>
+	requires std::is_base_of_v<Latte::LATTEREG, T>
 inline
-typename std::enable_if< std::is_base_of<Latte::LATTEREG, T>::value, void>::type
-gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
+void gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
 {
 	static_assert(sizeof(Latte::LATTEREG) == sizeof(uint32be));
 	*writePtr = arg.getRawValue();
@@ -61,9 +61,9 @@ gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs
 }
 
 template <typename T, typename ...Targs>
+	requires (!std::is_base_of_v<Latte::LATTEREG, T>) && (!std::is_floating_point_v<T>)
 inline
-typename std::enable_if< !std::is_base_of<Latte::LATTEREG, T>::value && !std::is_floating_point<T>::value, void>::type
-gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
+void gx2WriteGather_submit_(uint32 coreIndex, uint32be* writePtr, const T& arg, Targs... args)
 {
 	*writePtr = arg;
 	writePtr++;

--- a/src/Cemu/ExpressionParser/ExpressionParser.h
+++ b/src/Cemu/ExpressionParser/ExpressionParser.h
@@ -37,7 +37,7 @@ public:
 	template<typename T>
 	T Evaluate(std::string_view expression) const
 	{
-		static_assert(std::is_arithmetic<T>::value, "type T must be an arithmetic type");
+		static_assert(std::is_arithmetic_v<T>, "type T must be an arithmetic type");
 		return (T)Evaluate(expression);
 	}
 

--- a/src/Common/SysAllocator.h
+++ b/src/Common/SysAllocator.h
@@ -113,9 +113,8 @@ public:
 	operator void*() { return m_sysMem->GetPtr(); }
 
 	// for all arrays except bool
-	template<class Q = T>
-	typename std::enable_if< count != 1 && !std::is_same<Q, bool>::value, Q >::type&
-		operator[](int index)
+	T& operator[](int index)
+		requires(count != 1) && (!std::is_same_v<T, bool>)
 	{
 		// return tmp data until we allocated in sys mem
 		if (m_sysMem.GetMPTR() == 0)
@@ -125,7 +124,7 @@ public:
 
 		return m_sysMem[index];
 	}
-private:
+  private:
 	SysAllocator(uint32 memptr)
 		: m_sysMem(memptr)
 	{}

--- a/src/Common/betype.h
+++ b/src/Common/betype.h
@@ -22,7 +22,7 @@ constexpr T bswap(T i)
 template <typename T>
 constexpr T SwapEndian(T value)
 {
-	if constexpr (std::is_integral<T>::value)
+	if constexpr (std::is_integral_v<T>)
 	{
 #ifdef _MSC_VER
 		if constexpr (sizeof(T) == sizeof(uint32_t))
@@ -33,7 +33,7 @@ constexpr T SwapEndian(T value)
 
 		return (T)bswap((std::make_unsigned_t<T>)value);
 	}
-	else if constexpr (std::is_floating_point<T>::value)
+	else if constexpr (std::is_floating_point_v<T>)
 	{
 		if constexpr (sizeof(T) == sizeof(uint32_t))
 		{
@@ -46,18 +46,18 @@ constexpr T SwapEndian(T value)
 			return *(T*)&tmp;
 		}
 	}
-	else if constexpr (std::is_enum<T>::value)
+	else if constexpr (std::is_enum_v<T>)
 	{
 		return (T)SwapEndian((std::underlying_type_t<T>)value);
 	}
-	else if constexpr (std::is_base_of<Latte::LATTEREG, T>::value)
+	else if constexpr (std::is_base_of_v<Latte::LATTEREG, T>)
 	{
 		const auto tmp = bswap<uint32_t>(*(uint32_t*)&value);
 		return *(T*)&tmp;
 	}
     else
     {
-        static_assert(std::is_integral<T>::value, "unsupported betype specialization!");
+        static_assert(std::is_integral_v<T>, "unsupported betype specialization!");
     }
 
 	return value;

--- a/src/Common/enumFlags.h
+++ b/src/Common/enumFlags.h
@@ -10,63 +10,65 @@ struct EnableBitMaskOperators
 };
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type
-operator &(TEnum lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum operator &(TEnum lhs, TEnum rhs)
 {
 	return static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) & static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type
-operator |(TEnum lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum operator |(TEnum lhs, TEnum rhs)
 {
 	return static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) | static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type
-operator ^(TEnum lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum operator ^(TEnum lhs, TEnum rhs)
 {
 	return static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) ^ static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type
-operator ~(TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum operator ~(TEnum rhs)
 {
 	return static_cast<TEnum> (~static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type&
-operator &=(TEnum& lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum& operator &=(TEnum& lhs, TEnum rhs)
 {
 	lhs = static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) & static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 	return lhs;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type&
-operator |=(TEnum& lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum& operator |=(TEnum& lhs, TEnum rhs)
 {
 	lhs = static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) | static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 	return lhs;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableBitMaskOperators<TEnum>::enable, TEnum>::type&
-operator ^=(TEnum& lhs, TEnum rhs)
+	requires EnableBitMaskOperators<TEnum>::enable
+TEnum& operator ^=(TEnum& lhs, TEnum rhs)
 {
 	lhs = static_cast<TEnum> (static_cast<typename std::underlying_type<TEnum>::type>(lhs) ^ static_cast<typename std::underlying_type<TEnum>::type>(rhs));
 	return lhs;
 }
 
-template<typename TEnum, typename = std::enable_if_t<EnableBitMaskOperators<TEnum>::enable>>
+template<typename TEnum>
+	requires EnableBitMaskOperators<TEnum>::enable
 constexpr bool operator==(TEnum lhs, std::underlying_type_t<TEnum> rhs)
 {
 	return static_cast<std::underlying_type_t<TEnum>>(lhs) == rhs;
 }
-template<typename TEnum, typename = std::enable_if_t<EnableBitMaskOperators<TEnum>::enable>>
+template<typename TEnum>
+	requires EnableBitMaskOperators<TEnum>::enable
 constexpr bool operator!=(TEnum lhs, std::underlying_type_t<TEnum> rhs)
 {
 	return static_cast<std::underlying_type_t<TEnum>>(lhs) != rhs;
@@ -82,43 +84,43 @@ struct EnableEnumIterators
 };
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type&
-operator++(TEnum& lhs) 
+	requires EnableEnumIterators<TEnum>::enable
+TEnum& operator++(TEnum& lhs) 
 {
 	lhs = static_cast<TEnum>(static_cast<typename std::underlying_type<TEnum>::type>(lhs) + 1);
 	return lhs;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type
-operator*(TEnum rhs) 
+	requires EnableEnumIterators<TEnum>::enable
+TEnum operator*(TEnum rhs) 
 {
 	return rhs;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type
-begin(TEnum value) 
+	requires EnableEnumIterators<TEnum>::enable
+TEnum begin(TEnum value) 
 {
 	return EnableEnumIterators<TEnum>::begin;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type
-rbegin(TEnum value) 
+	requires EnableEnumIterators<TEnum>::enable
+TEnum rbegin(TEnum value) 
 {
 	return EnableEnumIterators<TEnum>::rbegin;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type
-end(TEnum r) {
+	requires EnableEnumIterators<TEnum>::enable
+TEnum end(TEnum r) {
 	return EnableEnumIterators<TEnum>::end;
 }
 
 template<typename TEnum>
-typename std::enable_if<EnableEnumIterators<TEnum>::enable, TEnum>::type
-rend(TEnum r) {
+	requires EnableEnumIterators<TEnum>::enable
+TEnum rend(TEnum r) {
 	return EnableEnumIterators<TEnum>::rend;
 }
 

--- a/src/Common/precompiled.h
+++ b/src/Common/precompiled.h
@@ -653,7 +653,8 @@ struct fmt::formatter<betype<T>> : fmt::formatter<T>
 namespace stdx
 {
 	// std::to_underlying
-    template <typename EnumT, typename = std::enable_if_t < std::is_enum<EnumT>{} >>
+    template <typename EnumT>
+		requires (std::is_enum_v<EnumT>)
         constexpr std::underlying_type_t<EnumT> to_underlying(EnumT e) noexcept {
         return static_cast<std::underlying_type_t<EnumT>>(e);
     };
@@ -689,7 +690,7 @@ namespace stdx
 	template<typename T>
 	class atomic_ref
 	{
-		static_assert(std::is_trivially_copyable<T>::value, "atomic_ref requires trivially copyable types");
+		static_assert(std::is_trivially_copyable_v<T>, "atomic_ref requires trivially copyable types");
 	public:
 		using value_type = T;
 

--- a/src/config/ConfigValue.h
+++ b/src/config/ConfigValue.h
@@ -96,15 +96,15 @@ public:
 		m_value = v;
 	}
 
-	template <typename = typename std::enable_if<std::is_same_v<TType, std::string>>>
 	void SetValue(std::string_view v)
+		requires std::is_same_v<TType, std::string>
 	{
 		std::lock_guard lock(m_mutex);
 		m_value = v;
 	}
 
-    template <typename = typename std::enable_if<std::is_same_v<TType, std::wstring>>>
 	void SetValue(std::wstring_view v)
+		requires std::is_same_v<TType, std::string>
 	{
 		std::lock_guard lock(m_mutex);
 		m_value = v;
@@ -171,22 +171,22 @@ public:
 	}
 
 	// init from enum with iterators
-	template<typename TEnum = typename std::enable_if<std::is_enum<TType>::value && EnableEnumIterators<TType>::enable, TType>>
 	constexpr ConfigValueBounds()
-		: base_type(), m_min_value(begin(TEnum{})), m_max_value(rbegin(TEnum{}))
+		requires std::is_enum_v<TType> && EnableEnumIterators<TType>::enable
+		: base_type(), m_min_value(begin(TType{})), m_max_value(rbegin(TType{}))
 	{
 		assert(m_min_value <= this->GetInitValue() && this->GetInitValue() <= m_max_value);
 	}
 
-    template<typename TEnum = typename std::enable_if<std::is_enum<TType>::value && EnableEnumIterators<TType>::enable, TType>>
 	constexpr ConfigValueBounds(const TType& init_value)
+		requires std::is_enum_v<TType> && EnableEnumIterators<TType>::enable
 		: base_type(std::forward<TType>(init_value)), m_min_value(begin(init_value)), m_max_value(rbegin(init_value))
 	{
 		assert(m_min_value <= init_value && init_value <= m_max_value);
 	}
 
-    template<typename TEnum = typename std::enable_if<std::is_enum<TType>::value && EnableEnumIterators<TType>::enable, TType>>
 	constexpr ConfigValueBounds(TType&& init_value)
+		requires std::is_enum_v<TType> && EnableEnumIterators<TType>::enable
 		: base_type(std::forward<TType>(init_value)), m_min_value(begin(init_value)), m_max_value(rbegin(init_value))
 	{
 		assert(m_min_value <= init_value && init_value <= m_max_value);

--- a/src/config/XMLConfig.h
+++ b/src/config/XMLConfig.h
@@ -221,7 +221,7 @@ public:
 	{
 		auto* element = m_document->NewElement(name);
 
-		if constexpr (std::is_enum<T>::value)
+		if constexpr (std::is_enum_v<T>)
 			element->SetText(fmt::format("{}", static_cast<typename std::underlying_type<T>::type>(value)).c_str());
 		else
 			element->SetText(fmt::format("{}", value).c_str());

--- a/src/gui/wxgui/helpers/wxControlObject.h
+++ b/src/gui/wxgui/helpers/wxControlObject.h
@@ -11,7 +11,7 @@ public:
 	template<typename T>
 	T* GetControl() const
 	{
-		static_assert(std::is_base_of<wxControl, T>::value, "T must inherit from wxControl");
+		static_assert(std::is_base_of_v<wxControl, T>, "T must inherit from wxControl");
 		return dynamic_cast<T*>(m_control);
 	}
 
@@ -30,7 +30,7 @@ public:
 	template<typename T = wxControl>
 	T* GetControl(int index) const
 	{
-		static_assert(std::is_base_of<wxControl, T>::value, "T must inherit from wxControl");
+		static_assert(std::is_base_of_v<wxControl, T>, "T must inherit from wxControl");
 		if (index < 0 || index >= m_controls.size())
 			return nullptr;
 		

--- a/src/util/helpers/ringbuffer.h
+++ b/src/util/helpers/ringbuffer.h
@@ -10,9 +10,8 @@ public:
 
 	bool Push(const T& v);
 
-	template<class Q = T>
-	typename std::enable_if< !std::is_array<T>::value, Q >::type
-	Pop()
+	T Pop()
+		requires (!std::is_array_v<T>)
 	{
 		std::unique_lock<std::mutex> lock(m_mutex);
 		if (m_readPointer == m_writePointer)


### PR DESCRIPTION
Since Cemu uses C++ 20 this PR replaces the use `std::enable_if` and the like with concepts.