### PR TITLE
UI: Fix minor dark mode issues

### DIFF
--- a/src/gui/wxgui/AudioDebuggerWindow.cpp
+++ b/src/gui/wxgui/AudioDebuggerWindow.cpp
@@ -24,7 +24,6 @@ wxEND_EVENT_TABLE()
 AudioDebuggerWindow::AudioDebuggerWindow(wxFrame& parent)
 	: wxFrame(&parent, wxID_ANY, _("AX voice viewer"), wxDefaultPosition, wxSize(1126, 580), wxCLOSE_BOX | wxCLIP_CHILDREN | wxCAPTION | wxRESIZE_BORDER)
 {
-	
 	wxPanel* mainPane = new wxPanel(this);
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 	
@@ -140,8 +139,6 @@ AudioDebuggerWindow::AudioDebuggerWindow(wxFrame& parent)
 		voiceListbox->InsertItem(item);
 	}
 	RefreshVoiceList();
-
-	wxFrame::SetBackgroundColour(*wxWHITE);
 
 	// start refresh timer
 	static const int INTERVAL = 100; // milliseconds

--- a/src/gui/wxgui/GraphicPacksWindow2.cpp
+++ b/src/gui/wxgui/GraphicPacksWindow2.cpp
@@ -131,11 +131,11 @@ void GraphicPacksWindow2::FillGraphicPackList() const
 			{
 				auto tmp_text = m_graphic_pack_tree->GetItemText(node);
 				m_graphic_pack_tree->SetItemText(node, tmp_text + " (Unsupported version)");
-				m_graphic_pack_tree->SetItemTextColour(node, 0x0000CC);
+				m_graphic_pack_tree->SetItemTextColour(node, m_incompatible_colour);
 				canEnable = false;
 			}
 			else if (p->IsActivated())
-				m_graphic_pack_tree->SetItemTextColour(node, 0x009900);
+				m_graphic_pack_tree->SetItemTextColour(node, m_activated_colour);
 
 			m_graphic_pack_tree->MakeCheckable(node, p->IsEnabled());
 			if (!canEnable)
@@ -509,7 +509,7 @@ void GraphicPacksWindow2::OnTreeChoiceChanged(wxTreeEvent& event)
 			if (!requiresRestart)
 			{
 				ReloadPack(graphic_pack);
-				m_graphic_pack_tree->SetItemTextColour(item, 0x009900);
+				m_graphic_pack_tree->SetItemTextColour(item, m_activated_colour);
 			}
 		}
 		else
@@ -517,7 +517,7 @@ void GraphicPacksWindow2::OnTreeChoiceChanged(wxTreeEvent& event)
 			if (!requiresRestart)
 			{
 				DeleteShadersFromRuntimeCache(graphic_pack);
-				m_graphic_pack_tree->SetItemTextColour(item, *wxBLACK);
+				m_graphic_pack_tree->SetItemTextColour(item, m_default_colour);
 			}
 			GraphicPack2::DeactivateGraphicPack(graphic_pack);
 		}

--- a/src/gui/wxgui/GraphicPacksWindow2.h
+++ b/src/gui/wxgui/GraphicPacksWindow2.h
@@ -53,6 +53,9 @@ private:
 	std::string m_gp_name, m_gp_description;
 
 	float m_ratio = 0.55f;
+	wxColour m_default_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+	wxColour m_activated_colour = wxSystemSettings::SelectLightDark(wxColour(0x00, 0xCC, 0x00), wxColour(0x42, 0xB3, 0x42));
+	wxColour m_incompatible_colour = wxSystemSettings::SelectLightDark(wxColour(0xCC, 0x00, 0x00), wxColour(0xDE, 0x49, 0x49));
 
 	wxTreeItemId FindTreeItem(const wxTreeItemId& root, const wxString& text) const;
 	void LoadPresetSelections(const GraphicPackPtr& gp);

--- a/src/gui/wxgui/components/wxGameList.cpp
+++ b/src/gui/wxgui/components/wxGameList.cpp
@@ -140,8 +140,8 @@ wxGameList::wxGameList(wxWindow* parent, wxWindowID id)
 {
 	const auto& config = GetWxGUIConfig();
 
-	char transparent_bitmap[kIconWidth * kIconWidth * 4] = {wxIMAGE_ALPHA_TRANSPARENT};
-	memset((void*)transparent_bitmap, wxIMAGE_ALPHA_TRANSPARENT, sizeof(transparent_bitmap));
+	char transparent_bitmap[kIconWidth * kIconWidth * 4] = {};
+	memset((void*)transparent_bitmap, wxSystemSettings::GetAppearance().IsDark() ? 0xFF : 0x00, sizeof(transparent_bitmap));
 	wxBitmap blank(transparent_bitmap, kIconWidth, kIconWidth);
 	blank.UseAlpha(true);
 

--- a/src/gui/wxgui/debugger/ModuleWindow.cpp
+++ b/src/gui/wxgui/debugger/ModuleWindow.cpp
@@ -23,8 +23,6 @@ ModuleWindow::ModuleWindow(DebuggerWindow2& parent, const wxPoint& main_position
 {
 	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
 
-	// this->wxWindowBase::SetBackgroundColour(*wxWHITE);
-
 	wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
 
 	m_modules = new wxListView(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT);

--- a/src/gui/wxgui/input/HotkeySettings.cpp
+++ b/src/gui/wxgui/input/HotkeySettings.cpp
@@ -89,11 +89,11 @@ std::optional<std::string> SaveScreenshot(std::vector<uint8> data, int width, in
 		if (SaveScreenshotToClipboard(image))
 		{
 			if (!save_screenshot)
-				return "Screenshot saved to clipboard";
+				return _tr("Screenshot saved to clipboard");
 		}
 		else
 		{
-			return "Failed to open clipboard";
+			return _tr("Failed to open clipboard");
 		}
 	}
 	if (save_screenshot)
@@ -102,11 +102,11 @@ std::optional<std::string> SaveScreenshot(std::vector<uint8> data, int width, in
 		if (imagePath.has_value() && SaveScreenshotToFile(imagePath.value(), image))
 		{
 			if (mainWindow)
-				return "Screenshot saved";
+				return _tr("Screenshot saved");
 		}
 		else
 		{
-			return "Failed to save screenshot to file";
+			return _tr("Failed to save screenshot to file");
 		}
 	}
 	return std::nullopt;
@@ -140,7 +140,7 @@ HotkeySettings::HotkeySettings(wxWindow* parent)
 	m_sizer->AddGrowableCol(1);
 	m_sizer->AddGrowableCol(2);
 
-	m_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_SIMPLE);
+	m_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_THEME);
 	m_panel->SetSizer(m_sizer);
 
 	Center();
@@ -150,13 +150,13 @@ HotkeySettings::HotkeySettings(wxWindow* parent)
 	CreateColumnHeaders();
 
 	/* global modifier */
-	CreateHotkeyRow("Hotkey modifier", s_cfgHotkeys.modifiers);
+	CreateHotkeyRow(_tr("Hotkey modifier"), s_cfgHotkeys.modifiers);
 	m_hotkeys.at(0).keyInput->Hide();
 
 	/* hotkeys */
-	CreateHotkeyRow("Toggle fullscreen", s_cfgHotkeys.toggleFullscreen);
-	CreateHotkeyRow("Take screenshot", s_cfgHotkeys.takeScreenshot);
-	CreateHotkeyRow("Toggle fast-forward", s_cfgHotkeys.toggleFastForward);
+	CreateHotkeyRow(_tr("Toggle fullscreen"), s_cfgHotkeys.toggleFullscreen);
+	CreateHotkeyRow(_tr("Take screenshot"), s_cfgHotkeys.takeScreenshot);
+	CreateHotkeyRow(_tr("Toggle fast-forward"), s_cfgHotkeys.toggleFastForward);
 
 	m_controllerTimer = new wxTimer(this);
 	Bind(wxEVT_TIMER, &HotkeySettings::OnControllerTimer, this);
@@ -214,13 +214,15 @@ void HotkeySettings::Init(MainWindow* mainWindowFrame)
 void HotkeySettings::CreateColumnHeaders(void)
 {
 	auto* emptySpace = new wxStaticText(m_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
-	auto* keyboard = new wxStaticText(m_panel, wxID_ANY, "Keyboard", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
-	auto* controller = new wxStaticText(m_panel, wxID_ANY, "Controller", wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
+	auto* keyboard = new wxStaticText(m_panel, wxID_ANY, _tr("Keyboard"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
+	auto* controller = new wxStaticText(m_panel, wxID_ANY, _tr("Controller"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER_HORIZONTAL);
+	keyboard->SetFont(keyboard->GetFont().Bold().Larger());
+	controller->SetFont(controller->GetFont().Bold().Larger());
 
 	keyboard->SetMinSize(m_minButtonSize);
 	controller->SetMinSize(m_minButtonSize);
 
-	auto flags = wxSizerFlags().Expand();
+	auto flags = wxSizerFlags().Expand().Border(wxTOP, 10);
 	m_sizer->Add(emptySpace, flags);
 	m_sizer->Add(keyboard, flags);
 	m_sizer->Add(controller, flags);


### PR DESCRIPTION
This fixes some very minor issues:
- The placeholders for the game list icons are now black instead of white when using dark mode.
- If you disable an activated graphic pack it'll no longer change the text to black when using dark mode.
- Some other minor fixes for things that already seemed to work in dark mode.