### PR TITLE
build: Update vcpkg dependency SDL2 to 2.32.8

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -71,7 +71,7 @@
     },
     {
       "name": "sdl2",
-      "version": "2.30.3"
+      "version": "2.32.8"
     },
     {
       "name": "wxwidgets",


### PR DESCRIPTION
Fixes compilation failure on Linux with later libpipewire versions