### PR TITLE
fix trivial compiler warnings

### DIFF
--- a/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocatorRanges.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocatorRanges.cpp
@@ -276,7 +276,7 @@ void IMLRA_DeleteAllRanges(ppcImlGenContext_t* ppcImlGenContext)
 	for(auto& seg : ppcImlGenContext->segmentList2)
 	{
 		raLivenessRange* cur;
-		while(cur = seg->raInfo.linkedList_allSubranges)
+		while ((cur = seg->raInfo.linkedList_allSubranges))
 			IMLRA_DeleteRange(ppcImlGenContext, cur);
 		seg->raInfo.linkedList_allSubranges = nullptr;
 		seg->raInfo.linkedList_perVirtualRegister.clear();

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.cpp
@@ -80,7 +80,7 @@ private:
 
 		D3DKMT_OPENADAPTERFROMHDC OpenAdapterData;
 
-		*phAdapter = NULL;
+		*phAdapter = 0;
 		*pOutput = 0;
 
 		HMONITOR hMonitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_InitializeTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_InitializeTypes.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "nn_olv_InitializeTypes.h"
 #include "CafeSystem.h"
 #include "Cafe/OS/libs/nn_act/nn_act.h"

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
@@ -38,12 +38,12 @@ namespace nn
 				if (!pParam->communityId)
 					return OLV_RESULT_INVALID_PARAMETER;
 
-				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%lu.delete", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
+				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%u.delete", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
 			}
 			else
 			{
 				if (pParam->communityId)
-					snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%lu", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
+					snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%u", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
 				else
 					snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities", g_DiscoveryResults.apiEndpoint);
 			}

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
@@ -36,9 +36,9 @@ namespace nn
 
 			char requestUrl[512];
 			if (pParam->flags & UploadFavoriteToCommunityDataParam::FLAG_DELETION)
-				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%lu.unfavorite", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
+				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%u.unfavorite", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
 			else 
-				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%lu.favorite", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
+				snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%u.favorite", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
 			
 			CurlRequestHelper req;
 			req.initate(ActiveSettings::GetNetworkService(), requestUrl, CurlRequestHelper::SERVER_SSL_CONTEXT::OLIVE);

--- a/src/util/ChunkedHeap/ChunkedHeap.h
+++ b/src/util/ChunkedHeap/ChunkedHeap.h
@@ -283,7 +283,7 @@ private:
 				{
 					if (itr.chunkIndex != dbgRange.chunkIndex)
 						continue;
-					if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
+					if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) > dbgRange.offset)
 						cemu_assert_error();
 				}
 


### PR DESCRIPTION
```
[build] [452/525] Building CXX object src/gui/wxgui/CMakeFiles/CemuWxGui.dir/GeneralSettings2.cpp.obj
[build] In file included from C:/src/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureVk.h:5,
[build]                  from C:/src/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h:6,
[build]                  from C:/src/Cemu/src/gui/wxgui/GeneralSettings2.cpp:30:
[build] C:/src/Cemu/src/util/ChunkedHeap/ChunkedHeap.h: In member function 'void ChunkedHeap<TMinimumAlignment>::verifyHeap()':
[build] C:/src/Cemu/src/util/ChunkedHeap/ChunkedHeap.h:286:49: warning: expected 'template' keyword before dependent template name [-Wmissing-template-keyword]
[build]   286 |                                         if (itr.offset < (dbgRange.offset + dbgRange.size) && (itr.offset + itr.size) >(dbgRange.offset))
[build]       |                                                 ^~~~~~
[build]       |                                                 template

[build] [231/525] Building CXX object src/Cafe/CMakeFiles/CemuCafe.dir/HW/Latte/Renderer/Vulkan/VsyncDriver.cpp.obj
[build] C:/src/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.cpp: In member function 'HRESULT DeviceVsyncHandler::GetAdapterHandleFromHwnd(D3DKMT_HANDLE*, UINT*)':
[build] C:/src/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.cpp:83:30: warning: converting to non-pointer type 'D3DKMT_HANDLE' {aka 'unsigned int'} from NULL [-Wconversion-null]
[build]    83 |                 *phAdapter = NULL;
[build]       |                              ^~~~

[build] [361/525] Building CXX object src/Cafe/CMakeFiles/CemuCafe.dir/OS/libs/nn_olv/nn_olv_InitializeTypes.cpp.obj
[build] C:/src/Cemu/src/Cafe/OS/libs/nn_olv/nn_olv_InitializeTypes.cpp:1:9: warning: '#pragma once' in main file [-Wpragma-once-outside-header]
[build]     1 | #pragma once
[build]       |         ^~~~

[366/525] Building CXX object src/Cafe/CMakeFiles...OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp.ob
C:/src/Cemu/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp:41:110: warning: format specifies type 'unsigned long' but the argument has type 'unsigned int' [-Wformat]
   41 |                                 snprintf(requestUrl, sizeof(requestUrl), "%s/v1/communities/%lu.delete", g_DiscoveryResults.apiEndpoint, pParam->communityId.value());
      |                                                                                             ~~~                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   

[168/525] Building CXX object src/Cafe/CMakeFiles.../Recompiler/IML/IMLRegisterAllocatorRanges.cpp.ob
C:/src/Cemu/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocatorRanges.cpp:279:13: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
  279 |                 while(cur = seg->raInfo.linkedList_allSubranges)
      |                       ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/src/Cemu/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocatorRanges.cpp:279:13: note: place parentheses around the assignment to silence this warning
  279 |                 while(cur = seg->raInfo.linkedList_allSubranges)
      |                           ^
      |                       (                                        )
C:/src/Cemu/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocatorRanges.cpp:279:13: note: use '==' to turn this assignment into an equality comparison
  279 |                 while(cur = seg->raInfo.linkedList_allSubranges)
      |                           ^
      |                           ==
1 warning generated.
```