### PR TITLE
fix pugixml deprecation warnings

### DIFF
--- a/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_DownloadCommunityTypes.cpp
@@ -87,7 +87,7 @@ namespace nn
 			if (httpCode != 200)
 				return OLV_RESULT_STATUS(httpCode + 4000);
 
-			std::string request_name = doc.select_single_node("//request_name").node().child_value();
+			std::string request_name = doc.select_node("//request_name").node().child_value();
 			if (request_name.size() == 0)
 			{
 				cemuLog_log(LogType::Force, "Community download response doesn't contain <request_name>");
@@ -100,7 +100,7 @@ namespace nn
 				return OLV_RESULT_INVALID_XML;
 			}
 
-			pugi::xml_node communities = doc.select_single_node("//communities").node();
+			pugi::xml_node communities = doc.select_node("//communities").node();
 			if (!communities)
 			{
 				cemuLog_log(LogType::Force, "Community download response doesn't contain <communities>");

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadCommunityTypes.cpp
@@ -223,12 +223,12 @@ namespace nn
 			if (pOutData)
 			{
 
-				std::string_view app_data = doc.select_single_node("//app_data").node().child_value();
-				std::string_view community_id = doc.select_single_node("//community_id").node().child_value();
-				std::string_view name = doc.select_single_node("//name").node().child_value();
-				std::string_view description = doc.select_single_node("//description").node().child_value();
-				std::string_view pid = doc.select_single_node("//pid").node().child_value();
-				std::string_view icon = doc.select_single_node("//icon").node().child_value();
+				std::string_view app_data = doc.select_node("//app_data").node().child_value();
+				std::string_view community_id = doc.select_node("//community_id").node().child_value();
+				std::string_view name = doc.select_node("//name").node().child_value();
+				std::string_view description = doc.select_node("//description").node().child_value();
+				std::string_view pid = doc.select_node("//pid").node().child_value();
+				std::string_view icon = doc.select_node("//icon").node().child_value();
 
 				if (app_data.size() != 0)
 				{

--- a/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
+++ b/src/Cafe/OS/libs/nn_olv/nn_olv_UploadFavoriteTypes.cpp
@@ -88,12 +88,12 @@ namespace nn
 
 			if (pOutData)
 			{
-				std::string_view app_data = doc.select_single_node("//app_data").node().child_value();
-				std::string_view community_id = doc.select_single_node("//community_id").node().child_value();
-				std::string_view name = doc.select_single_node("//name").node().child_value();
-				std::string_view description = doc.select_single_node("//description").node().child_value();
-				std::string_view pid = doc.select_single_node("//pid").node().child_value();
-				std::string_view icon = doc.select_single_node("//icon").node().child_value();
+				std::string_view app_data = doc.select_node("//app_data").node().child_value();
+				std::string_view community_id = doc.select_node("//community_id").node().child_value();
+				std::string_view name = doc.select_node("//name").node().child_value();
+				std::string_view description = doc.select_node("//description").node().child_value();
+				std::string_view pid = doc.select_node("//pid").node().child_value();
+				std::string_view icon = doc.select_node("//icon").node().child_value();
 
 				if (app_data.size() != 0)
 				{


### PR DESCRIPTION
There is no functional change. `select_single_node` has been renamed to `select_node` and deprecated https://pugixml.org/docs/manual.html#v1.5.