### PR TITLE
Add support for Wii Remote Plus by handling the inactive MotionPlus extension events

### DIFF
--- a/src/input/api/Wiimote/WiimoteControllerProvider.cpp
+++ b/src/input/api/Wiimote/WiimoteControllerProvider.cpp
@@ -344,6 +344,9 @@ void WiimoteControllerProvider::reader_thread()
 							new_state.m_extension = {};
 							request_status(index);
 							break;
+						case kExtensionMotionPlusInactive:
+                            cemuLog_logDebug(LogType::Force,"Extension Type Received: Inactive MotionPlus");
+							break;
 						default:
                             cemuLog_logDebug(LogType::Force,"Unknown extension: {:#x}", be_type.value());
                             new_state.m_extension = {};

--- a/src/input/api/Wiimote/WiimoteMessages.h
+++ b/src/input/api/Wiimote/WiimoteMessages.h
@@ -53,6 +53,7 @@ enum ExtensionType : uint64
 	kExtensionDrums = 0x0100A4200103,
 	kExtensionBalanceBoard = 0x2A2C,
 
+	kExtensionMotionPlusInactive = 0xa4200005,
 	kExtensionMotionPlus = 0xa6200005,
 
 	kExtensionPartialyInserted = 0xffffffffffff,


### PR DESCRIPTION
This is a fix for issue https://github.com/cemu-project/Cemu/issues/1664

This code is straight from the referenced issue. It adds handling of the [inactive MotionPlus extension events](https://github.com/supertuxkart/stk-code/blob/d4be5d133893f8a871c318d355f6e051fca38091/lib/wiiuse/src/wiiuse_internal.h#L230) which cause Wii Remote Plus controllers to constantly disconnect and reconnect.

I ran into this bug, found the issue and saw that @capitalistspz had requested a pull request. So I've done so.
