### PR TITLE
UI: fix sorting after style switch

### DIFF
--- a/src/gui/wxgui/components/wxGameList.cpp
+++ b/src/gui/wxgui/components/wxGameList.cpp
@@ -514,6 +514,9 @@ std::weak_ordering wxGameList::SortComparator(uint64 titleId1, uint64 titleId2, 
 	  return CafeTitleList::GetGameInfo(id).GetRegion();
 	};
 
+	if (!sortData->asc)
+		std::swap(titleId1, titleId2);
+
 	switch(sortData->column)
 	{
 	default:
@@ -542,7 +545,7 @@ std::weak_ordering wxGameList::SortComparator(uint64 titleId1, uint64 titleId2, 
 int wxGameList::SortFunction(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)
 {
 	const auto sort_data = (SortData*)sortData;
-	return sort_data->dir * order_to_int(sort_data->thisptr->SortComparator((uint64)item1, (uint64)item2, sort_data));
+	return order_to_int(sort_data->thisptr->SortComparator((uint64)item1, (uint64)item2, sort_data));
 }
 
 void wxGameList::SortEntries(int column)
@@ -566,7 +569,7 @@ void wxGameList::SortEntries(int column)
 	case ColumnRegion:
 	case ColumnTitleID:
 	{
-		SortData data{this, ItemColumns{column}, ascending ? 1 : -1};
+		SortData data{this, ItemColumns{column}, ascending};
 		SortItems(SortFunction, (wxIntPtr)&data);
 		ShowSortIndicator(column, ascending);
 		break;
@@ -1677,7 +1680,8 @@ void wxGameList::CreateShortcut(GameInfo2& gameInfo)
 			hres = shellLinkFile->Save(outputPath.wc_str(), TRUE);
 		}
 	}
-	if (!SUCCEEDED(hres)) {
+	if (FAILED(hres))
+	{
 		auto errorMsg = formatWxString(_("Failed to save shortcut to {}"), outputPath);
 		wxMessageBox(errorMsg, _("Error"), wxOK | wxCENTRE | wxICON_ERROR);
 	}

--- a/src/gui/wxgui/components/wxGameList.h
+++ b/src/gui/wxgui/components/wxGameList.h
@@ -89,7 +89,7 @@ private:
 	{
 		wxGameList* thisptr;
 		ItemColumns column;
-		int dir;
+		bool asc;
 	};
 
 	int FindInsertPosition(TitleId titleId);


### PR DESCRIPTION
When you switch the game list from list view to icon view and back again, it forgets which column was sorted. I fixed it.