### PR TITLE
Add End emulation and better Recent files menu

### DIFF
--- a/src/gui/wxgui/MainWindow.h
+++ b/src/gui/wxgui/MainWindow.h
@@ -71,6 +71,7 @@ public:
 	[[nodiscard]] bool IsGameLaunched() const { return m_game_launched; }
 
 	void SetFullScreen(bool state);
+	void EndEmulation();
 	void SetMenuVisible(bool state);
 	void UpdateNFCMenu();
 	bool IsMenuHidden() const;

--- a/src/gui/wxgui/input/HotkeySettings.cpp
+++ b/src/gui/wxgui/input/HotkeySettings.cpp
@@ -6,6 +6,7 @@
 #include "HotkeySettings.h"
 #include "MainWindow.h"
 
+#include <wx/app.h>
 #include <wx/clipbrd.h>
 
 #if BOOST_OS_WINDOWS
@@ -157,6 +158,7 @@ HotkeySettings::HotkeySettings(wxWindow* parent)
 	CreateHotkeyRow(_tr("Toggle fullscreen"), s_cfgHotkeys.toggleFullscreen);
 	CreateHotkeyRow(_tr("Take screenshot"), s_cfgHotkeys.takeScreenshot);
 	CreateHotkeyRow(_tr("Toggle fast-forward"), s_cfgHotkeys.toggleFastForward);
+	CreateHotkeyRow(_tr("End emulation"), s_cfgHotkeys.endEmulation);
 
 	m_controllerTimer = new wxTimer(this);
 	Bind(wxEVT_TIMER, &HotkeySettings::OnControllerTimer, this);
@@ -191,6 +193,11 @@ void HotkeySettings::Init(MainWindow* mainWindowFrame)
 		 }},
 		{&s_cfgHotkeys.toggleFastForward, [](void) {
 			 ActiveSettings::SetTimerShiftFactor((ActiveSettings::GetTimerShiftFactor() < 3) ? 3 : 1);
+		 }},
+		{&s_cfgHotkeys.endEmulation, [](void) {
+			 wxTheApp->CallAfter([]() {
+				s_mainWindow->EndEmulation();
+			 });
 		 }},
 	});
 

--- a/src/gui/wxgui/wxCemuConfig.cpp
+++ b/src/gui/wxgui/wxCemuConfig.cpp
@@ -115,6 +115,7 @@ void wxCemuConfig::Load(XMLConfigParser& parser)
 	hotkeys.toggleFullscreenAlt = xml_hotkeys.get("ToggleFullscreenAlt", sHotkeyCfg{uKeyboardHotkey{WXK_CONTROL_M, true}}); // ALT+ENTER
 	hotkeys.takeScreenshot = xml_hotkeys.get("TakeScreenshot", sHotkeyCfg{uKeyboardHotkey{WXK_F12}});
 	hotkeys.toggleFastForward = xml_hotkeys.get("ToggleFastForward", sHotkeyCfg{});
+	hotkeys.endEmulation = xml_hotkeys.get("EndEmulation", sHotkeyCfg{uKeyboardHotkey{WXK_F5}});
 }
 
 void wxCemuConfig::Save(XMLConfigParser& config)

--- a/src/gui/wxgui/wxCemuConfig.h
+++ b/src/gui/wxgui/wxCemuConfig.h
@@ -127,6 +127,7 @@ struct wxCemuConfig
 		sHotkeyCfg exitFullscreen;
 		sHotkeyCfg takeScreenshot;
 		sHotkeyCfg toggleFastForward;
+		sHotkeyCfg endEmulation;
 	} hotkeys{};
 
 	void AddRecentlyLaunchedFile(std::string_view file);


### PR DESCRIPTION
Adds (or rather enables) an End emulation button under the File menu, making it possible to exit games without entirely closing Cemu, and made it assignable to a hotkey (set to F5 by default).

Also improves the the recent files list by making it a submenu instead, now being able to hold up to 10 entries.

Small improvements that are more in line with other emulators.