### PR TITLE
cmake: fix usages of target_link_libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,6 @@ target_link_libraries(CemuBin PRIVATE
 	CemuGui
 	CemuInput
 	CemuUtil
-	OpenGL::GL
 	SDL2::SDL2
 )
 

--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -559,28 +559,17 @@ else()
 endif()
 
 target_link_libraries(CemuCafe PRIVATE
-	CemuAudio
 	CemuCommon
-	CemuComponents
-	CemuConfig
-	CemuGui
-	CemuInput
-	CemuResource
-	CemuUtil
-	imguiImpl
-	Boost::headers
-	Boost::nowide
-	CURL::libcurl
-	fmt::fmt
-	${glslang_target}
-	ih264d
-	OpenSSL::Crypto
-	OpenSSL::SSL
-	PNG::PNG
-	pugixml::pugixml
-	ZArchive::zarchive
-	ZLIB::ZLIB
-	zstd::zstd
+  CemuGui
+  ZArchive::zarchive
+  imguiImpl
+  pugixml::pugixml
+  ZLIB::ZLIB
+  CURL::libcurl
+  ih264d
+  ${glslang_target}
+  PUBLIC
+  OpenSSL::SSL
 )
 
 if (ENABLE_WAYLAND)

--- a/src/Cemu/CMakeLists.txt
+++ b/src/Cemu/CMakeLists.txt
@@ -43,17 +43,8 @@ set_property(TARGET CemuComponents PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$
 target_include_directories(CemuComponents PUBLIC "../")
 
 target_link_libraries(CemuComponents PRIVATE
-	CemuCafe
 	CemuCommon
-	CemuConfig
-	CemuGui
-	CemuUtil
-	Boost::headers
-	CURL::libcurl
-	OpenSSL::Crypto
-	OpenSSL::SSL
-	pugixml::pugixml
-	ZLIB::ZLIB
+  CemuGui
 )
 
 # PUBLIC because fmt/format.h is included in ExpressionParser/ExpressionParser.h

--- a/src/Common/CMakeLists.txt
+++ b/src/Common/CMakeLists.txt
@@ -59,9 +59,6 @@ target_precompile_headers(CemuCommon PUBLIC precompiled.h)
 target_include_directories(CemuCommon PUBLIC "../")
 
 target_link_libraries(CemuCommon PRIVATE
-	CemuCafe
-	CemuConfig
-	CemuComponents
 	Boost::nowide
 	Boost::filesystem
 	glm::glm

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -31,11 +31,8 @@ endif()
 target_include_directories(CemuAudio PUBLIC "../")
 
 target_link_libraries(CemuAudio PRIVATE
-	CemuCafe
-	CemuGui
 	CemuCommon
-	CemuConfig
-	CemuUtil
+	CemuGui
 )
 
 if(ENABLE_CUBEB)

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -16,11 +16,7 @@ set_property(TARGET CemuConfig PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<C
 target_include_directories(CemuConfig PUBLIC "../")
 
 target_link_libraries(CemuConfig PRIVATE
-	CemuCafe
 	CemuCommon
     CemuGui
-	CemuUtil
-	Boost::headers
-	Boost::program_options
-	pugixml::pugixml
+    Boost::program_options
 )

--- a/src/gui/wxgui/CMakeLists.txt
+++ b/src/gui/wxgui/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CemuWxGui 
+add_library(CemuWxGui STATIC
   canvas/IRenderCanvas.h
   canvas/OpenGLCanvas.cpp
   canvas/OpenGLCanvas.h
@@ -126,20 +126,16 @@ target_include_directories(CemuWxGui PUBLIC "../")
 target_include_directories(CemuWxGui PUBLIC ${RAPIDJSON_INCLUDE_DIRS})
 
 target_link_libraries(CemuWxGui PRIVATE
-	CemuAudio
-	CemuCafe
-	CemuCommon
-	CemuComponents
-	CemuConfig
-	CemuInput
-	CemuResource
-	CemuUtil
-	Boost::headers
-	CURL::libcurl
-	libzip::zip
-	OpenSSL::Crypto
-	pugixml::pugixml
-	ZArchive::zarchive
+  CemuCommon
+  CemuResource
+  libzip::zip
+  ZArchive::zarchive
+  CemuComponents
+  SDL2::SDL2
+  pugixml::pugixml
+  CemuCafe
+  PUBLIC
+  CURL::libcurl
 )
 
 if(ENABLE_WXWIDGETS AND UNIX AND NOT APPLE)
@@ -161,7 +157,7 @@ if(UNIX AND NOT APPLE)
 endif()
 if (ENABLE_WXWIDGETS)
 	# PUBLIC because wx/app.h is included in CemuApp.h
-	target_link_libraries(CemuWxGui PUBLIC wx::base wx::core wx::gl wx::propgrid wx::xrc)
+	target_link_libraries(CemuWxGui PUBLIC wxWidgets::wxWidgets)
 endif()
 
 if(WIN32)

--- a/src/imgui/CMakeLists.txt
+++ b/src/imgui/CMakeLists.txt
@@ -22,10 +22,6 @@ target_sources(imguiImpl PRIVATE
 target_include_directories(imguiImpl PUBLIC "../../dependencies/imgui/")
 
 target_link_libraries(imguiImpl PRIVATE
-	CemuCafe
 	CemuCommon
 	CemuGui
-	CemuInput
-	CemuResource
-	CemuUtil
 )

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -88,16 +88,8 @@ endif ()
 target_include_directories(CemuInput PUBLIC "../")
 
 target_link_libraries(CemuInput PRIVATE
-	CemuCafe
 	CemuCommon
-	CemuConfig
 	CemuGui
-	CemuUtil
-	Boost::headers
-	Boost::program_options
-	glm::glm
-	pugixml::pugixml
-	SDL2::SDL2
 )
 
 if (ENABLE_HIDAPI)

--- a/src/resource/CMakeLists.txt
+++ b/src/resource/CMakeLists.txt
@@ -22,4 +22,4 @@ target_sources(CemuResource PRIVATE CafeDefaultFont.cpp)
 
 target_include_directories(CemuResource PUBLIC "../")
 
-target_link_libraries(CemuResource PRIVATE CemuCommon CemuComponents)
+target_link_libraries(CemuResource PRIVATE CemuCommon)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -92,9 +92,5 @@ set_property(TARGET CemuUtil PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CON
 target_include_directories(CemuUtil PUBLIC "../")
 
 target_link_libraries(CemuUtil PRIVATE
-	CemuCommon
-	CemuConfig
-	Boost::headers
-	Boost::nowide
-	OpenSSL::Crypto
+  CemuCommon
 )


### PR DESCRIPTION
The usage of `target_link_libraries` is a mess. I cleaned it up.