### PR TITLE
gui: ENABLE_BLUEZ=OFF: bluetooth/bluetooth.h uneeded

### DIFF
--- a/src/gui/wxgui/CMakeLists.txt
+++ b/src/gui/wxgui/CMakeLists.txt
@@ -76,8 +76,6 @@ add_library(CemuWxGui STATIC
   input/InputAPIAddWindow.h
   input/InputSettings2.cpp
   input/InputSettings2.h
-  input/PairingDialog.cpp
-  input/PairingDialog.h
   input/panels/ClassicControllerInputPanel.cpp
   input/panels/ClassicControllerInputPanel.h
   input/panels/InputPanel.cpp
@@ -117,6 +115,13 @@ add_library(CemuWxGui STATIC
   wxgui.h
   wxHelper.h
 )
+
+if (ENABLE_BLUEZ)
+  add_library(CemuWxGui STATIC
+    input/PairingDialog.cpp
+    input/PairingDialog.h
+  )
+endif()
 
 set_property(TARGET CemuWxGui PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/src/gui/wxgui/CMakeLists.txt
+++ b/src/gui/wxgui/CMakeLists.txt
@@ -117,7 +117,7 @@ add_library(CemuWxGui STATIC
 )
 
 if (ENABLE_BLUEZ)
-  add_library(CemuWxGui STATIC
+  target_sources(CemuWxGui PRIVATE
     input/PairingDialog.cpp
     input/PairingDialog.h
   )

--- a/src/gui/wxgui/input/InputSettings2.cpp
+++ b/src/gui/wxgui/input/InputSettings2.cpp
@@ -21,7 +21,9 @@
 #include "wxgui/input/InputAPIAddWindow.h"
 #include "input/ControllerFactory.h"
 
+#ifdef HAS_BLUEZ
 #include "wxgui/input/PairingDialog.h"
+#endif
 
 #include "wxgui/input/panels/VPADInputPanel.h"
 #include "wxgui/input/panels/ProControllerInputPanel.h"
@@ -255,12 +257,14 @@ wxWindow* InputSettings2::initialize_page(size_t index)
 			page_data.m_controller_api_remove = remove_api;
 		}
 
+#ifdef HAS_BLUEZ
 		auto* pairingDialog = new wxButton(page, wxID_ANY, _("Pair Wii/Wii U Controller"));
 		pairingDialog->Bind(wxEVT_BUTTON, [this](wxEvent&) {
 			PairingDialog pairing_dialog(this);
 			pairing_dialog.ShowModal();
 		});
 		sizer->Add(pairingDialog, wxGBPosition(5, 0), wxDefaultSpan, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+#endif
 
 		// controller
 		auto* controller_bttns = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
Use case: packaging cemu for gentoo users (WIP)

ENABLE_BLUEZ=OFF should prevent using bluetooth under linux.
However wxgui still expose some:
`#include <bluetooth/bluetooth.h>`

To be able to compile I just used
```
sed -i -e '/input\/PairingDialog/d' src/gui/wxgui/CMakeLists.txt
sed -i -e '/auto\* pairingDialog/,/sizer->Add(pairingDialog/d;' \
       -e '/include.*PairingDialog/d' src/gui/wxgui/input/InputSettings2.cpp
```

This early PR based on local work I did when upgrading package but uses build system logic