### PR TITLE
fix hang on close on linux

### DIFF
--- a/dependencies/vcpkg_overlay_ports/wxwidgets/fix-linux-clipboard-hang.patch
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/fix-linux-clipboard-hang.patch
@@ -1,0 +1,10 @@
+--- a/src/gtk/clipbrd.cpp
++++ a/src/gtk/clipbrd.cpp
+@@ -623,7 +623,6 @@
+         GtkClipboard* clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+ 
+         gtk_clipboard_set_can_store(clipboard, nullptr, 0);
+-        gtk_clipboard_store(clipboard);
+ 
+         return true;
+     }

--- a/dependencies/vcpkg_overlay_ports/wxwidgets/portfile.cmake
+++ b/dependencies/vcpkg_overlay_ports/wxwidgets/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         relocatable-wx-config.patch
         nanosvg-ext-depend.patch
         fix-libs-export.patch
+        fix-linux-clipboard-hang.patch
         fix-pcre2.patch
         gtk3-link-libraries.patch
         sdl2.patch


### PR DESCRIPTION
I noticed that sometimes when I try to close Cemu it doesn't actually close. Using a debugger I saw that in MainWindow::OnClose wxTheClipboard::Flush is called to save clipboard contents (screenshots) after Cemu closes and that this call doesn't return, causing Cemu to never close.

Drilling further down it is caused by a call to gtk_clipboard_store, which as you can see [here](https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gtk/gtkclipboard.c#L2180) enters the main window loop again. So this is likely a wxWidgets bug.

On my system clipboard data was still available even without Calling wxTheClipboard::Flush, but removing it probably will cause issues for other platforms. (Wayland, MSW, Mac)

So instead of removing the call altogether we should avoid calling gtk_clipboard_store.
Before Flush calls [gtk_clipboard_store](https://docs.gtk.org/gtk3/method.Clipboard.store.html) it calls [gtk_clipboard_set_can_store](https://docs.gtk.org/gtk3/method.Clipboard.set_can_store.html).
Looking at the docs for both functions it appears that the call to gtk_clipboard_store is redundant.
`gtk_clipboard_set_can_store: Hints that the clipboard data should be stored somewhere when the application exits or when gtk_clipboard_store () is called.`