### PR TITLE
vk: Always embed shader source code when RenderDoc (etc.) is attached

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/LatteTextureVk.cpp
@@ -87,7 +87,7 @@ LatteTextureVk::LatteTextureVk(class VulkanRenderer* vkRenderer, Latte::E_DIM di
 	if (vkCreateImage(m_vkr->GetLogicalDevice(), &imageInfo, nullptr, &vkObjTex->m_image) != VK_SUCCESS)
 		m_vkr->UnrecoverableError("Failed to create texture image");
 	
-	if (m_vkr->IsDebugUtilsEnabled() && vkSetDebugUtilsObjectNameEXT)
+	if (m_vkr->IsDebugMarkersEnabled())
 	{
 		VkDebugUtilsObjectNameInfoEXT objName{};
 		objName.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/RendererShaderVk.cpp
@@ -271,7 +271,7 @@ void RendererShaderVk::CreateVkShaderModule(std::span<uint32> spirvBuffer)
 	}
 
 	// set debug name
-	if (vkr->IsDebugUtilsEnabled() && vkSetDebugUtilsObjectNameEXT)
+	if (vkr->IsDebugMarkersEnabled())
 	{
 		VkDebugUtilsObjectNameInfoEXT objName{};
 		objName.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
@@ -292,7 +292,7 @@ void RendererShaderVk::FinishCompilation()
 
 void RendererShaderVk::CompileInternal(bool isRenderThread)
 {
-	bool compileWithDebugInfo = ((VulkanRenderer*)g_renderer.get())->IsDebugUtilsEnabled() && vkSetDebugUtilsObjectNameEXT;
+	const bool compileWithDebugInfo = ((VulkanRenderer*)g_renderer.get())->IsTracingToolEnabled();
 
 	// try to retrieve SPIR-V module from cache
 	if (s_isLoadingShadersVk && (m_isGameShader && !m_isGfxPackShader) && s_spirvCache && !compileWithDebugInfo)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.h
@@ -482,7 +482,8 @@ private:
 			uint32 nonCoherentAtomSize = 256;
 		}limits;
 
-		bool debugMarkersSupported{ false }; // frame debugger is attached
+		bool usingDebugMarkerTool{ false }; // validation layer or other tool capable of handling debug markers is used
+		bool usingTracingTool{ false }; // frame debugger or other API replaying tool is used
 		bool disableMultithreadedCompilation{ false }; // for old nvidia drivers
 
 	}m_featureControl{};
@@ -937,7 +938,8 @@ public:
 	bool GetDisableMultithreadedCompilation() const { return m_featureControl.disableMultithreadedCompilation; }
 	bool UseTFViaSSBO() const { return m_featureControl.mode.useTFEmulationViaSSBO; }
 	bool HasSPRIVRoundingModeRTE32() const { return m_featureControl.shaderFloatControls.shaderRoundingModeRTEFloat32; }
-	bool IsDebugUtilsEnabled() const { return m_featureControl.debugMarkersSupported && m_featureControl.instanceExtensions.debug_utils; }
+	bool IsDebugMarkersEnabled() const { return m_featureControl.usingDebugMarkerTool; }
+	bool IsTracingToolEnabled() const { return m_featureControl.usingTracingTool; }
 
 private:
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -245,7 +245,7 @@ void compilePipelineThread_queue(PipelineCompiler* v)
 bool VulkanRenderer::IsAsyncPipelineAllowed(uint32 numIndices)
 {
 	// frame debuggers dont handle async well (as of 2020)
-	if (IsDebugUtilsEnabled() && vkSetDebugUtilsObjectNameEXT)
+	if (IsTracingToolEnabled())
 		return false;
 
 	CachedFBOVk* currentFBO = m_state.activeFBO;


### PR DESCRIPTION
Previously:
* Cemu used EShMsgDebugInfo to emit shader debug info, which had some downsides like embedding both the un-preprocessed and preprocessed shader source code. Since RenderDoc shows both, it causes compilation errors and confusion, since really only the un-preprocessed source file is expected/useful.
* To get the source code to show in RenderDoc also required graphic pack developers to remove their shader caches to make sure that the shader source code is embedded and Cemu doesn't use an optimized spirv module.

With this PR:
* Cemu manually sets the shader source code, which causes RenderDoc to show the (easily editable) source code in RenderDoc.
* I also made it so that the spirv cache is always ignored when RenderDoc is attached. This does cause slightly longer load times when RenderDoc is attached and you had a prior shader cache that contained the non-debug shader.

<img width="1420" height="704" alt="image" src="https://github.com/user-attachments/assets/6f1568d4-865d-493c-9b92-7febadcfe062" />

