### PR TITLE
vcpkg: Update SDL2 to 2.32.10

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "sdl2",
-      "version": "2.32.8"
+      "version": "2.32.10"
     },
     {
       "name": "wxwidgets",


### PR DESCRIPTION
Update SDL2 to [2.32.10](https://github.com/libsdl-org/SDL/releases/tag/release-2.32.10). Minor bugfix update containing Switch Pro controller fixes. 