### PR TITLE
[Test] CI: Codesign macOS app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
         mv bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu_release bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         sed -i '' 's/Cemu_release/Cemu/g' bin/Cemu_app/Cemu.app/Contents/Info.plist
         chmod a+x bin/Cemu_app/Cemu.app/Contents/MacOS/{Cemu,update.sh}
+        codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         ln -s /Applications bin/Cemu_app/Applications
         hdiutil create ./bin/tmp.dmg -ov -volname "Cemu" -fs HFS+ -srcfolder "./bin/Cemu_app"
         hdiutil convert ./bin/tmp.dmg -format UDZO -o bin/Cemu.dmg


### PR DESCRIPTION
Currently the macOS app bundles are not codesigned. This is not an issue for the x86 build, as all x86 apps can launch fine without a code signature. 

However, the Arm builds do require a signature. The linker signs it at compilation time, but the changes made to the app bundle afterwards invalidates it. 

This PR will add a signature step at the end of setting up the app bundle and before it is packaged in a `.dmg`. 

Testing: 

- [ ] Ensure the Arm build launches without requiring `xattr`
- [ ] Ensure the x86 build still launches fine (no changes expected) 