### PR TITLE
macOS: Bump minimum version to 13.4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ if (MACOS_BUNDLE)
 	set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2024 Cemu Project")
 
 	set(MACOSX_BUNDLE_CATEGORY "public.app-category.games")
- 	set(MACOSX_MINIMUM_SYSTEM_VERSION "12.0")
+ 	set(MACOSX_MINIMUM_SYSTEM_VERSION "13.4")
   	set(MACOSX_BUNDLE_TYPE_EXTENSION "wua")
 
 	set_target_properties(CemuBin PROPERTIES


### PR DESCRIPTION
The Metal backend requires macOS 13.4. 

This PR bumps the minimum version in the info.plist from 12.0 to 13.4. 