### PR TITLE
Don't re-attach stdio when piping output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,14 +174,18 @@ void requireConsole()
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     DWORD dwFileType = GetFileType(hOut);
 
-    if (dwFileType == FILE_TYPE_UNKNOWN || dwFileType == FILE_TYPE_CHAR) {
-        if (AttachConsole(ATTACH_PARENT_PROCESS) != FALSE) {
+    if (dwFileType == FILE_TYPE_UNKNOWN || dwFileType == FILE_TYPE_CHAR)
+    {
+        if (AttachConsole(ATTACH_PARENT_PROCESS) != FALSE)
+        {
             freopen("CONOUT$", "w", stdout);
             freopen("CONOUT$", "w", stderr);
             freopen("CONIN$", "r", stdin);
             isConsoleConnected = true;
         }
-    } else {
+    }
+    else
+    {
         isConsoleConnected = true; 
     }
     #endif


### PR DESCRIPTION
Previously `attachConsole()` would bypass `stdout: pipe` when launching Cemu as a subprocess and attempting to read the verbose log output. We now skip re-attaching the stdio streams to the console in this case. This fixes the problem of being unable to read Cemu's stdout on Windows. (It works fine on Mac/Linux)