### PR TITLE
Few small fixes for Graphics packs, Game Profiles and Logging

### DIFF
--- a/src/gui/wxgui/GameProfileWindow.cpp
+++ b/src/gui/wxgui/GameProfileWindow.cpp
@@ -16,9 +16,10 @@
 #endif
 
 GameProfileWindow::GameProfileWindow(wxWindow* parent, uint64_t title_id)
-	: wxFrame(parent, wxID_ANY, _("Edit game profile"), wxDefaultPosition, wxSize{ 390, 350 }, wxCLOSE_BOX | wxCLIP_CHILDREN | wxCAPTION | wxRESIZE_BORDER | wxTAB_TRAVERSAL | wxSYSTEM_MENU), m_title_id(title_id)
+	: wxFrame(parent, wxID_ANY, _("Edit game profile"), wxDefaultPosition, wxDefaultSize, wxCLOSE_BOX | wxCLIP_CHILDREN | wxCAPTION | wxRESIZE_BORDER | wxTAB_TRAVERSAL | wxSYSTEM_MENU), m_title_id(title_id)
 {
 	SetIcon(wxICON(X_GAME_PROFILE));
+	SetSize(FromDIP(wxSize(390, 350)));
 
 	m_game_profile.Reset();
 	m_game_profile.Load(title_id);
@@ -71,7 +72,7 @@ GameProfileWindow::GameProfileWindow(wxWindow* parent, uint64_t title_id)
 
 			wxString quantum_values[] = { "20000", "45000", "60000", "80000" ,"100000" };
 			m_thread_quantum = new wxChoice(box, wxID_ANY, wxDefaultPosition, wxDefaultSize, std::size(quantum_values), quantum_values);
-			m_thread_quantum->SetMinSize(wxSize(85, -1));
+			m_thread_quantum->SetMinSize(FromDIP(wxSize(85, -1)));
 			m_thread_quantum->SetToolTip(_("EXPERT OPTION\nSet the maximum thread slice runtime (in virtual cycles)"));
 			quantum_sizer->Add(m_thread_quantum, 0, wxALL, 5);
 
@@ -196,7 +197,7 @@ GameProfileWindow::GameProfileWindow(wxWindow* parent, uint64_t title_id)
 			profile_sizer->Add(new wxStaticText(panel, wxID_ANY, formatWxString(_("Controller {}"), i + 1)), 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
 			m_controller_profile[i] = new wxComboBox(panel, wxID_ANY,"", wxDefaultPosition, wxDefaultSize, 0, nullptr, wxCB_DROPDOWN| wxCB_READONLY);
-			m_controller_profile[i]->SetMinSize(wxSize(250, -1));
+			m_controller_profile[i]->SetMinSize(FromDIP(wxSize(250, -1)));
 			m_controller_profile[i]->Bind(wxEVT_COMBOBOX_DROPDOWN, &GameProfileWindow::OnControllerProfileDropdown, this);
 			m_controller_profile[i]->SetToolTip(_("Forces a given controller profile"));
 			profile_sizer->Add(m_controller_profile[i], 0, wxALL, 5);

--- a/src/gui/wxgui/GraphicPacksWindow2.h
+++ b/src/gui/wxgui/GraphicPacksWindow2.h
@@ -16,14 +16,14 @@ class wxChoice;
 
 class GraphicPacksWindow2 : public wxDialog
 {
-public:
+  public:
 	GraphicPacksWindow2(wxWindow* parent, uint64_t title_id_filter);
 	~GraphicPacksWindow2();
 
 	static void RefreshGraphicPacks();
 	void UpdateTitleRunning(bool running);
 
-private:
+  private:
 	std::string m_filter;
 	bool m_filter_installed_games;
 	std::vector<uint64_t> m_installed_games;
@@ -32,17 +32,17 @@ private:
 	void FillGraphicPackList() const;
 	void GetChildren(const wxTreeItemId& id, std::vector<wxTreeItemId>& children) const;
 	void ExpandChildren(const std::vector<wxTreeItemId>& ids, size_t& counter) const;
-	
-	wxSplitterWindow * m_splitter_window;
+
+	wxSplitterWindow* m_splitter_window;
 
 	wxPanel* m_right_panel;
 	wxScrolled<wxPanel>* m_gp_options;
-	
-	wxCheckTree * m_graphic_pack_tree;
+
+	wxCheckTree* m_graphic_pack_tree;
 	wxTextCtrl* m_filter_text;
 	wxCheckBox* m_installed_games_only;
 
-	wxStaticText* m_graphic_pack_name, *m_graphic_pack_description;
+	wxStaticText *m_graphic_pack_name, *m_graphic_pack_description;
 	wxBoxSizer* m_preset_sizer;
 	std::vector<wxChoice*> m_active_preset;
 	wxButton* m_reload_shaders;
@@ -59,12 +59,14 @@ private:
 
 	wxTreeItemId FindTreeItem(const wxTreeItemId& root, const wxString& text) const;
 	void LoadPresetSelections(const GraphicPackPtr& gp);
+	void UpdateContentLayout();
 
 	void OnTreeSelectionChanged(wxTreeEvent& event);
 	void OnTreeChoiceChanged(wxTreeEvent& event);
 	void OnActivePresetChanged(wxCommandEvent& event);
 	void OnReloadShaders(wxCommandEvent& event);
 	void OnCheckForUpdates(wxCommandEvent& event);
+	void OnRightPanelResized(wxSizeEvent& event);
 	void OnSizeChanged(wxSizeEvent& event);
 	void SashPositionChanged(wxEvent& event);
 	void OnFilterUpdate(wxEvent& event);

--- a/src/gui/wxgui/GraphicPacksWindow2.h
+++ b/src/gui/wxgui/GraphicPacksWindow2.h
@@ -16,14 +16,14 @@ class wxChoice;
 
 class GraphicPacksWindow2 : public wxDialog
 {
-  public:
+public:
 	GraphicPacksWindow2(wxWindow* parent, uint64_t title_id_filter);
 	~GraphicPacksWindow2();
 
 	static void RefreshGraphicPacks();
 	void UpdateTitleRunning(bool running);
 
-  private:
+private:
 	std::string m_filter;
 	bool m_filter_installed_games;
 	std::vector<uint64_t> m_installed_games;
@@ -32,17 +32,17 @@ class GraphicPacksWindow2 : public wxDialog
 	void FillGraphicPackList() const;
 	void GetChildren(const wxTreeItemId& id, std::vector<wxTreeItemId>& children) const;
 	void ExpandChildren(const std::vector<wxTreeItemId>& ids, size_t& counter) const;
-
-	wxSplitterWindow* m_splitter_window;
+	
+	wxSplitterWindow * m_splitter_window;
 
 	wxPanel* m_right_panel;
 	wxScrolled<wxPanel>* m_gp_options;
-
-	wxCheckTree* m_graphic_pack_tree;
+	
+	wxCheckTree * m_graphic_pack_tree;
 	wxTextCtrl* m_filter_text;
 	wxCheckBox* m_installed_games_only;
 
-	wxStaticText *m_graphic_pack_name, *m_graphic_pack_description;
+	wxStaticText* m_graphic_pack_name, *m_graphic_pack_description;
 	wxBoxSizer* m_preset_sizer;
 	std::vector<wxChoice*> m_active_preset;
 	wxButton* m_reload_shaders;

--- a/src/gui/wxgui/LoggingWindow.cpp
+++ b/src/gui/wxgui/LoggingWindow.cpp
@@ -10,8 +10,10 @@
 wxDEFINE_EVENT(EVT_LOG, wxLogEvent);
 
 LoggingWindow::LoggingWindow(wxFrame* parent)
-	: wxFrame(parent, wxID_ANY, _("Logging window"), wxDefaultPosition, wxSize(800, 600), wxDEFAULT_FRAME_STYLE | wxTAB_TRAVERSAL)
+	: wxFrame(parent, wxID_ANY, _("Logging window"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_FRAME_STYLE | wxTAB_TRAVERSAL)
 {
+	SetSize(FromDIP(wxSize(800, 600)));
+
 	auto* sizer = new wxBoxSizer( wxVERTICAL );
 	{
 		auto filter_row = new wxBoxSizer( wxHORIZONTAL );


### PR DESCRIPTION
Wrap graphics pack text such as descriptions, updating the text wrap as dragged.
use DIP to make the window sizes  work properly at high DPI, the current behavior at DPI's above 100% requires that the user manually resize them to show all controls.

Before @ 250%

<img width="1022" height="1230" alt="image" src="https://github.com/user-attachments/assets/7ff71808-9482-42de-a6f5-1ce262ef4e2a" />


After

<img width="2467" height="1645" alt="image" src="https://github.com/user-attachments/assets/eae40585-a156-42ec-bbea-2c8eb70ca25e" />
<img width="930" height="850" alt="image" src="https://github.com/user-attachments/assets/9545d40c-b996-4da9-8421-9a3a6da17274" />
<img width="1967" height="1467" alt="image" src="https://github.com/user-attachments/assets/482b1f54-7f9f-4926-aa28-82fb73c3ad19" />

Wrapping works on long description text, somewhat on drop lists when filtered, or graphics packs with long option value friendly names aren't present
<img width="1197" height="1650" alt="image" src="https://github.com/user-attachments/assets/972375bb-21e2-4a2d-8e1f-1851d9e1f5a3" />
