### PR TITLE
Fix fmt format spec crash in WPADGetInfoAsync

### DIFF
--- a/src/Cafe/OS/libs/padscore/padscore.cpp
+++ b/src/Cafe/OS/libs/padscore/padscore.cpp
@@ -134,7 +134,7 @@ void padscoreExport_WPADGetInfoAsync(PPCInterpreter_t* hCPU)
 	ppcDefineParamU32(channel, 0);
 	ppcDefineParamStructPtr(wpadInfo, WPADInfo_t, 1);
 	ppcDefineParamMPTR(callbackFunc, 2);
-	cemuLog_log(LogType::InputAPI, "WPADGetInfoAsync({}, {:p}, 0x{:08x})", channel, fmt::ptr(wpadInfo), callbackFunc);
+	cemuLog_log(LogType::InputAPI, "WPADGetInfoAsync({}, 0x{:08x}, 0x{:08x})", channel, memory_getVirtualOffsetFromPointer(wpadInfo), callbackFunc);
 
 	if (channel < InputManager::kMaxWPADControllers)
 	{


### PR DESCRIPTION
Fix crash in WPADGetInfoAsync where applying {:08x} format spec to a void const* returned by fmt::ptr() causes fmt to throw an invalid format spec exception

