### PR TITLE
CI: Update actions to silence Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
     needs: build-ubuntu
     steps:
       - name: Checkout Upstream Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/download-artifact@v8
         with:
@@ -131,7 +131,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
 
@@ -211,7 +211,7 @@ jobs:
         arch: [x86_64, arm64]
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: "recursive"
 

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [call-release-build, calculate-version]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/determine_release_version.yml
+++ b/.github/workflows/determine_release_version.yml
@@ -20,10 +20,10 @@ jobs:
     outputs:
       next_version: ${{ steps.calculate_next_version.outputs.next_version }}
       next_version_major: ${{ steps.calculate_next_version.outputs.next_version_major }}
-      next_version_minor: ${{ steps.calculate_next_version.outputs.next_version_minor }}      
+      next_version_minor: ${{ steps.calculate_next_version.outputs.next_version_minor }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Get all releases
         id: get_all_releases
@@ -35,7 +35,7 @@ jobs:
             cat response.json
             exit 1
           fi
-          
+
           # Extract and sort tags
           ALL_TAGS=$(jq -r '.[].tag_name' response.json | grep -E '^v[0-9]+\.[0-9]+(-[0-9]+)?$' | sed 's/-.*//' | sort -V | tail -n 1)
 
@@ -71,4 +71,4 @@ jobs:
           echo "Next version: $NEXT_VERSION"
           echo "::set-output name=next_version::$NEXT_VERSION"
           echo "::set-output name=next_version_major::$MAJOR"
-          echo "::set-output name=next_version_minor::$MINOR"          
+          echo "::set-output name=next_version_minor::$MINOR"

--- a/.github/workflows/generate_pot.yml
+++ b/.github/workflows/generate_pot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: "Install gettext"
         run: |


### PR DESCRIPTION
Currently the actions builds are triggering Node 20 deprecation warnings. 

This PR updates the following actions: 

- Checkout to v6
- Download-artifact to v8
- Upload-artifact to v6

This does not fully fix the issue, since `jwlawson/actions-setup-cmake@v2` has not been updated. 

In order to fully fix the issue either `setup-cmake` needs to be updated or replaced by something similar. 

Testing: 

- Ensure all actions builds are completed without issue. (Warnings will still be present) 