### PR TITLE
CI: Update actions to silence Node 20 deprecation warnings (second attempt)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: "recursive"
         fetch-depth: 0
@@ -83,7 +83,7 @@ jobs:
       run: mv bin/Cemu_release bin/Cemu
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cemu-bin-linux-${{ matrix.arch }}
         path: ./bin/Cemu
@@ -103,9 +103,9 @@ jobs:
     needs: build-ubuntu
     steps:
     - name: Checkout Upstream Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: cemu-bin-linux-${{ matrix.arch }}
         path: bin
@@ -122,7 +122,7 @@ jobs:
         dist/linux/appimage.sh ${{ runner.arch }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cemu-appimage-${{ matrix.arch }}
         path: artifacts
@@ -131,7 +131,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: "recursive"
 
@@ -193,13 +193,13 @@ jobs:
         makensis /DPRODUCT_VERSION=${{ inputs.next_version_major }}.${{ inputs.next_version_minor }} installer.nsi
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cemu-bin-windows-x64
         path: ./bin/Cemu.exe
 
     - name: Upload NSIS Installer
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cemu-installer-windows-x64
         path: ./src/resource/cemu-${{ inputs.next_version_major }}.${{ inputs.next_version_minor }}-windows-x64-installer.exe
@@ -211,7 +211,7 @@ jobs:
         arch: [x86_64, arm64]
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: "recursive"
 
@@ -289,7 +289,7 @@ jobs:
         rm bin/tmp.dmg
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cemu-bin-macos-${{ matrix.arch }}
         path: ./bin/Cemu.dmg

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [call-release-build, calculate-version]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -78,27 +78,27 @@ jobs:
           if [ -n "${{ github.event.inputs.changelog9 }}" ]; then CHANGELOG="$CHANGELOG- ${{ github.event.inputs.changelog9 }}\n"; fi
           echo -e "$CHANGELOG"
           echo "RELEASE_BODY=$CHANGELOG" >> $GITHUB_ENV
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cemu-bin-linux-x64
           path: cemu-bin-linux-x64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cemu-appimage-x64
           path: cemu-appimage-x64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cemu-bin-windows-x64
           path: cemu-bin-windows-x64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cemu-installer-windows-x64
           path: cemu-installer-windows-x64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: cemu-bin-macos*
           path: cemu-macos

--- a/.github/workflows/determine_release_version.yml
+++ b/.github/workflows/determine_release_version.yml
@@ -23,7 +23,7 @@ jobs:
       next_version_minor: ${{ steps.calculate_next_version.outputs.next_version_minor }}      
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Get all releases
         id: get_all_releases

--- a/.github/workflows/generate_pot.yml
+++ b/.github/workflows/generate_pot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: "Install gettext"
         run: |
@@ -36,7 +36,7 @@ jobs:
           -o cemu.pot
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: POT file
           path: ./cemu.pot


### PR DESCRIPTION
This PR is to replace #1835

Currently the actions builds are triggering [Node 20 deprecation warnings](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This PR updates the following actions:

- Checkout to v6
- Download-artifact to v8
- Upload-artifact to v6

This does not fully fix the issue, since `jwlawson/actions-setup-cmake@v2` has [not been updated](https://github.com/jwlawson/actions-setup-cmake).

In order to fully resolve, either `setup-cmake` needs to be updated or replaced by something similar.

Testing:

- Ensure all actions builds are completed without issue. (Warnings will still be present)