### PR TITLE
nn_ac: Add local IP getter implementation for Linux

### DIFF
--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -4,6 +4,9 @@
 
 #if BOOST_OS_WINDOWS
 #include <iphlpapi.h>
+#elif BOOST_OS_LINUX
+#include <ifaddrs.h>
+#include <net/if.h>
 #endif
 
 // AC lib (manages internet connection)
@@ -76,6 +79,37 @@ void _GetLocalIPAndSubnetMask(uint32& localIp, uint32& subnetMask)
 			return;
 		}
 		currentAddress = currentAddress->Next;
+	}
+	cemuLog_logDebug(LogType::Force, "_GetLocalIPAndSubnetMask(): Failed to find network IP and subnet mask");
+	_GetLocalIPAndSubnetMaskFallback(localIp, subnetMask);
+}
+#elif BOOST_OS_LINUX
+void _GetLocalIPAndSubnetMask(uint32& localIp, uint32& subnetMask)
+{
+	struct ifaddrs *ifaddr;
+	if (getifaddrs(&ifaddr) == -1)
+	{
+		cemuLog_log(LogType::Force, "Failed to acquire local IP and subnet mask");
+		_GetLocalIPAndSubnetMaskFallback(localIp, subnetMask);
+	}
+	stdx::scope_exit _ifa([&]{ freeifaddrs(ifaddr); });
+
+	for (const struct ifaddrs* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+	{
+		if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET)
+			continue;
+
+		if (!(ifa->ifa_flags & IFF_UP) || !(ifa->ifa_flags & IFF_RUNNING))
+			continue;
+
+		if (ifa->ifa_flags & IFF_LOOPBACK)
+			continue;
+
+		const auto* addr_in = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
+		localIp = ntohl(addr_in->sin_addr.s_addr);
+		const auto* mask_in = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_netmask);
+		subnetMask = ntohl(mask_in->sin_addr.s_addr);
+		return;
 	}
 	cemuLog_logDebug(LogType::Force, "_GetLocalIPAndSubnetMask(): Failed to find network IP and subnet mask");
 	_GetLocalIPAndSubnetMaskFallback(localIp, subnetMask);

--- a/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
+++ b/src/Cafe/OS/libs/nn_ac/nn_ac.cpp
@@ -102,7 +102,10 @@ void _GetLocalIPAndSubnetMask(uint32& localIp, uint32& subnetMask)
 		if (!(ifa->ifa_flags & IFF_UP) || !(ifa->ifa_flags & IFF_RUNNING))
 			continue;
 
-		if (ifa->ifa_flags & IFF_LOOPBACK)
+		if (ifa->ifa_flags & IFF_LOOPBACK || ifa->ifa_flags & IFF_POINTOPOINT)
+			continue;
+
+		if (boost::starts_with(ifa->ifa_name, "br-") || boost::starts_with(ifa->ifa_name, "docker"))
 			continue;
 
 		const auto* addr_in = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);


### PR DESCRIPTION
Adds implementation of `_GetLocalIPAndSubnetMask` for Linux. This allows LAN play in NEX games to work correctly. Previously, the fallback address was always used, which caused connection instability.