### PR TITLE
Link zstd explicitly

### DIFF
--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -634,6 +634,7 @@ target_link_libraries(CemuCafe PRIVATE
   ZLIB::ZLIB
   CURL::libcurl
   ih264d
+  zstd::zstd
   ${glslang_target}
   PUBLIC
   OpenSSL::SSL


### PR DESCRIPTION
CemuCafe directly depends on zstd which is currently only linked implicitly by dependencies. This fixes linking issues on my end. 