### PR TITLE
Revert #1857

### DIFF
--- a/src/gui/wxgui/MainWindow.cpp
+++ b/src/gui/wxgui/MainWindow.cpp
@@ -623,35 +623,6 @@ bool MainWindow::FileLoad(const fs::path launchPath, wxLaunchGameEvent::INITIATE
     }
 #endif
 
-	// Workaround for BOTW + Mesa. Runes like Magnesis and the camera cause GPU crashes.
-	// Using the LLVM shader compiler prevents crashes which points to an issue with the default ACO compiler.
-	// Either that or Cemu is violating a specification (GLSL?) causing the shaders to be broken after compilation.
-#if BOOST_OS_LINUX
-	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
-	if (currentTitleId == 0x00050000101c9500 || currentTitleId == 0x00050000101c9400 || currentTitleId == 0x00050000101c9300)
-	{
-		// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it
-		if (const char* value; (value = getenv("RADV_DEBUG")) != NULL && strlen(value) != 0)
-		{
-			std::string valueStr{value};
-			// only append ,llvm when llvm or aco are not already passed as flags.
-			// "aco" is not a mesa flag (anymore, it used to be when llvm was default)
-			// but it will provide users with a way to override this workaround by setting RADV_DEBUG=aco
-			// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
-			if (valueStr.find("llvm") == std::string::npos && valueStr.find("aco") == std::string::npos)
-			{
-				valueStr.append(",llvm");
-				setenv("RADV_DEBUG", valueStr.c_str(), 1);
-			}
-		}
-		else
-		{
-			setenv("RADV_DEBUG", "llvm", 1);
-		}
-	}
-
-#endif
-
 	CreateCanvas();
 	CafeSystem::LaunchForegroundTitle();
 	RecreateMenu();


### PR DESCRIPTION
#1857 started manipulating RADV_DEBUG variables to force LLVM as a compiler backend. **This is really broken**, for multiple reasons.

First of all, the LLVM backend is completely unmaintained. Nobody is looking at issues for it, much less ever testing it. This has been the case for years.

Should any issues arise, modifying such environment variables under the user's belt is very misleading. Developers will not suspect the LLVM backend to be used at all, and unless this behavior is known by whoever is debugging the issue, it will probably cause lots of headaches.

Also, I'm not sure if this ends up applying to Cemu, but there are a ton of features that just plainly aren't there with the LLVM backend. Performance of generated shader ISA is worse, time required to compile shaders is also worse.

Worst of all, perhaps, is that RADV has no hard requirement on LLVM at all. If RADV is not compiled with LLVM (some distributions might disable this) and RADV_DEBUG=llvm is set, the driver will crash instantly.

All of this is to say that RADV_DEBUG options are strictly reserved for users debugging a specific issue and apps should never set them themselves, especially not RADV_DEBUG=llvm.

The issue this is working around has since been fixed in upstream Mesa, so the workaround is not required for a sufficiently new Mesa, either. The next stable release should pick this up, and for the time being mesa-git has the fix as well.