### PR TITLE
vulkan: Improve the Breath of the Wild RADV/LLVM workaround

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -339,12 +339,12 @@ void VulkanRenderer::GetDeviceFeatures()
 #if BOOST_OS_LINUX
 #include <sys/wait.h>
 
-void WorkaroundChildAbortHandler(int unused)
+static void WorkaroundChildAbortHandler(int unused)
 {
 	_exit(2);
 }
 
-void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
+static void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 {
 	int childID = fork();
 	if (childID == 0) // inside this if statement runs in child
@@ -439,7 +439,7 @@ void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 
 }
 
-void LinuxBreathOfTheWildWorkaround()
+static void LinuxBreathOfTheWildWorkaround()
 {
 	int subProcessPipes[2]{};
 	pipe(subProcessPipes);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -344,12 +344,8 @@ void WorkaroundChildAbortHandler(int unused)
 	_exit(2);
 }
 
-void LinuxBreathOfTheWildWorkaround()
+void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 {
-
-	int subProcessPipes[2]{};
-	pipe(subProcessPipes);
-
 	int childID = fork();
 	if (childID == 0) // inside this if statement runs in child
 	{
@@ -438,6 +434,17 @@ void LinuxBreathOfTheWildWorkaround()
 		setenv("RADV_DEBUG", "llvm", 1);
 	}
 
+}
+
+void LinuxBreathOfTheWildWorkaround()
+{
+	int subProcessPipes[2]{};
+	pipe(subProcessPipes);
+
+	PerformBOTWLinuxWorkaround(subProcessPipes);
+
+	close(subProcessPipes[0]);
+	close(subProcessPipes[1]);
 }
 #endif
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -417,10 +417,18 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 	{
 		setenv("CEMU_DETECT_RADV","1", 1);
 		execl("/proc/self/exe", "/proc/self/exe", nullptr);
+		_exit(2); // exec failed so err on the safe side and signal failure
 	}
 
 	int childStatus = 0;
 	waitpid(childID,  &childStatus, 0);
+
+	// if the process didn't exit cleanly or failed to determine LLVM status
+	if (!WIFEXITED(childStatus) || WEXITSTATUS(childStatus) == 2)
+	{
+		cemuLog_log(LogType::Force, "BOTW/RADV workaround not applied because detecting LLVM presence failed unexpectedly");
+		return;
+	}
 
 	if (WEXITSTATUS(childStatus) == 1)
 		cemuLog_log(LogType::Force, "BOTW/RADV workaround not applied because mesa was built without LLVM");

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -339,11 +339,6 @@ void VulkanRenderer::GetDeviceFeatures()
 #if BOOST_OS_LINUX
 #include <sys/wait.h>
 
-static void WorkaroundChildAbortHandler(int unused)
-{
-	_exit(1);
-}
-
 static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanceCreateInfo* create_info)
 {
 
@@ -394,7 +389,7 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 	int childID = fork();
 	if (childID == 0) // inside this if statement runs in child
 	{
-		struct sigaction sa{.sa_handler = WorkaroundChildAbortHandler};
+		struct sigaction sa{.sa_handler = [](int unused){_exit(1);}};
 		sigaction(SIGABRT, &sa, nullptr);
 
 		freopen("/dev/null", "w", stderr);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -344,7 +344,8 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 
 	// if the user specified either shader backend, do nothing.
 	// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
-	std::string_view debugEnv = getenv("RADV_DEBUG");
+	const char* debugEnvC = getenv("RADV_DEBUG");
+	std::string_view debugEnv = debugEnvC != nullptr ? debugEnvC : "";
 	if (debugEnv.find("aco") != std::string_view::npos || debugEnv.find("llvm") != std::string_view::npos)
 		return;
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -429,7 +429,10 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 
 	// recreate the vulkan instance to update debug setting
 	vkDestroyInstance(instance, nullptr);
-	vkCreateInstance(create_info, nullptr, &instance);
+	VkResult err = vkCreateInstance(create_info, nullptr, &instance);
+	// re-check for errors just in case.
+	if (err != VK_SUCCESS)
+		throw std::runtime_error(fmt::format("Unable to re-create a Vulkan instance after RADV/LLVM workaround: {}", err));
 	InitializeInstanceVulkan(instance);
 
 }

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -415,7 +415,7 @@ void LinuxBreathOfTheWildWorkaround()
 
 	// If the driver is unaffected skip the workaround.
 	// affected drivers:
-	// 25.3.0 - 26.0.3
+	// 25.3.0 - 26.0.4
 	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 5)) || major > 26)
 		return;
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -336,9 +336,123 @@ void VulkanRenderer::GetDeviceFeatures()
 	cemuLog_log(LogType::Force, fmt::format("VulkanLimits: UBAlignment {0} nonCoherentAtomSize {1}", prop2.properties.limits.minUniformBufferOffsetAlignment, prop2.properties.limits.nonCoherentAtomSize));
 }
 
+#if BOOST_OS_LINUX
+#include <sys/wait.h>
+
+void WorkaroundChildAbortHandler(int unused)
+{
+	_exit(2);
+}
+
+void LinuxBreathOfTheWildWorkaround()
+{
+
+	int subProcessPipes[2]{};
+	pipe(subProcessPipes);
+
+	int childID = fork();
+	if (childID == 0) // inside this if statement runs in child
+	{
+		struct sigaction sa{.sa_handler = WorkaroundChildAbortHandler};
+		sigaction(SIGABRT, &sa, nullptr);
+
+		freopen("/dev/null", "w", stderr);
+
+		setenv("RADV_DEBUG", "llvm", 1);
+
+		VkInstanceCreateInfo instanceCreateInfo = {};
+		instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+		VkInstance instance = VK_NULL_HANDLE;
+		if (vkCreateInstance(&instanceCreateInfo, nullptr, &instance) != VK_SUCCESS)
+			_exit(1);
+
+		InitializeInstanceVulkan(instance);
+
+		uint32_t count = 0;
+		vkEnumeratePhysicalDevices(instance, &count, nullptr);
+
+		std::vector<VkPhysicalDevice> physicalDevices{count};
+		vkEnumeratePhysicalDevices(instance, &count, physicalDevices.data());
+
+		for (auto& i : physicalDevices)
+		{
+			VkPhysicalDeviceProperties prop{};
+			vkGetPhysicalDeviceProperties(i, &prop);
+			if (prop.vendorID != 0x1002)
+				continue;
+
+			std::string_view deviceName = prop.deviceName;
+			if (deviceName.find("RADV") != std::string_view::npos)
+			{
+				write(subProcessPipes[1], &prop.driverVersion, sizeof(uint32_t));
+				_exit(0);
+			}
+		}
+
+		// no appropriate device found to query version
+		_exit(1);
+	}
+
+	int childStatus = 0;
+	waitpid(childID,  &childStatus, 0);
+
+	if (WEXITSTATUS(childStatus) == 2)
+	{
+		cemuLog_log(LogType::Force, "Breath of the Wild RADV workaround not applied because mesa was built without LLVM");
+	}
+
+	// only continue if the process exits with code zero, which means it determined the version and didn't crash.
+	if (WEXITSTATUS(childStatus) != 0)
+		return;
+
+	uint32_t version = 0;
+	if (read(subProcessPipes[0], &version, sizeof(version)) == -1)
+		return; // if we fail to read bail. Should never happen if the subprocess exited with 0
+
+	int major = VK_API_VERSION_MAJOR(version);
+	int minor = VK_API_VERSION_MINOR(version);
+	int patch = VK_API_VERSION_PATCH(version);
+
+	// If the driver is unaffected skip the workaround.
+	// affected drivers:
+	// 25.3.0 - 26.0.3
+	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 4)) || major > 26)
+		return;
+
+	// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it
+	if (const char* value; (value = getenv("RADV_DEBUG")) != NULL && strlen(value) != 0)
+	{
+		std::string valueStr{value};
+		// only append ,llvm when llvm or aco are not already passed as flags.
+		// "aco" is not a mesa flag (anymore, it used to be when llvm was default)
+		// but it will provide users with a way to override this workaround by setting RADV_DEBUG=aco
+		// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
+		if (valueStr.find("llvm") == std::string::npos && valueStr.find("aco") == std::string::npos)
+		{
+			valueStr.append(",llvm");
+			setenv("RADV_DEBUG", valueStr.c_str(), 1);
+		}
+	}
+	else
+	{
+		setenv("RADV_DEBUG", "llvm", 1);
+	}
+
+}
+#endif
+
 VulkanRenderer::VulkanRenderer()
 {
 	glslang::InitializeProcess();
+
+	// Workaround for BOTW + RADV. Runes like Magnesis and the camera cause GPU crashes.
+#if BOOST_OS_LINUX
+	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
+	if (currentTitleId == 0x00050000101c9500 || currentTitleId == 0x00050000101c9400 || currentTitleId == 0x00050000101c9300)
+	{
+		LinuxBreathOfTheWildWorkaround();
+	}
+#endif
 
 	cemuLog_log(LogType::Force, "------- Init Vulkan graphics backend -------");
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -396,7 +396,7 @@ void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 
 	if (WEXITSTATUS(childStatus) == 2)
 	{
-		cemuLog_log(LogType::Force, "Breath of the Wild RADV workaround not applied because mesa was built without LLVM");
+		cemuLog_log(LogType::Force, "BOTW/RADV workaround not applied because mesa was built without LLVM");
 	}
 
 	// only continue if the process exits with code zero, which means it determined the version and didn't crash.
@@ -417,6 +417,7 @@ void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 5)) || major > 26)
 		return;
 
+	cemuLog_log(LogType::Force, "BOTW/RADV workaround active. Adding llvm to RADV_DEBUG environment variable");
 	// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it
 	if (const char* value; (value = getenv("RADV_DEBUG")) != NULL && strlen(value) != 0)
 	{

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -416,7 +416,7 @@ void LinuxBreathOfTheWildWorkaround()
 	// If the driver is unaffected skip the workaround.
 	// affected drivers:
 	// 25.3.0 - 26.0.3
-	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 4)) || major > 26)
+	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 5)) || major > 26)
 		return;
 
 	// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -445,6 +445,8 @@ VulkanRenderer::VulkanRenderer()
 {
 	glslang::InitializeProcess();
 
+	cemuLog_log(LogType::Force, "------- Init Vulkan graphics backend -------");
+
 	// Workaround for BOTW + RADV. Runes like Magnesis and the camera cause GPU crashes.
 #if BOOST_OS_LINUX
 	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
@@ -453,8 +455,6 @@ VulkanRenderer::VulkanRenderer()
 		LinuxBreathOfTheWildWorkaround();
 	}
 #endif
-
-	cemuLog_log(LogType::Force, "------- Init Vulkan graphics backend -------");
 
 	const bool useValidationLayer = cemuLog_isLoggingEnabled(LogType::VulkanValidation);
 	if (useValidationLayer)

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -339,6 +339,31 @@ void VulkanRenderer::GetDeviceFeatures()
 #if BOOST_OS_LINUX
 #include <sys/wait.h>
 
+int BreathOfTheWildChildProcessMain()
+{
+	InitializeGlobalVulkan();
+	struct sigaction sa{.sa_handler = [](int unused){_exit(1);}};
+	int ret = sigaction(SIGABRT, &sa, nullptr);
+
+	freopen("/dev/null", "w", stderr);
+
+	setenv("RADV_DEBUG", "llvm", 1);
+
+	VkInstanceCreateInfo create_info{};
+	create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+	VkInstance instance = VK_NULL_HANDLE;
+	if (vkCreateInstance(&create_info, nullptr, &instance) != VK_SUCCESS)
+		return 1;
+	InitializeInstanceVulkan(instance);
+
+	// this function will abort() when LLVM is absent
+	uint32_t count = 0;
+	vkEnumeratePhysicalDevices(instance, &count, nullptr);
+
+	vkDestroyInstance(instance, nullptr);
+	return 0;
+}
+
 static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanceCreateInfo* create_info)
 {
 
@@ -390,20 +415,8 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 	int childID = fork();
 	if (childID == 0) // inside this if statement runs in child
 	{
-		struct sigaction sa{.sa_handler = [](int unused){_exit(1);}};
-		sigaction(SIGABRT, &sa, nullptr);
-
-		freopen("/dev/null", "w", stderr);
-
-		setenv("RADV_DEBUG", "llvm", 1);
-
-		VkInstance instance = VK_NULL_HANDLE;
-		vkCreateInstance(create_info, nullptr, &instance);
-		// this function will abort() when LLVM is absent
-		uint32_t count = 0;
-		vkEnumeratePhysicalDevices(instance, &count, nullptr);
-		vkDestroyInstance(instance, nullptr);
-		_exit(0);
+		setenv("CEMU_DETECT_RADV","1", 1);
+		execl("/proc/self/exe", "/proc/self/exe", nullptr);
 	}
 
 	int childStatus = 0;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -341,71 +341,44 @@ void VulkanRenderer::GetDeviceFeatures()
 
 static void WorkaroundChildAbortHandler(int unused)
 {
-	_exit(2);
+	_exit(1);
 }
 
-static void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
+static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanceCreateInfo* create_info)
 {
-	int childID = fork();
-	if (childID == 0) // inside this if statement runs in child
-	{
-		struct sigaction sa{.sa_handler = WorkaroundChildAbortHandler};
-		sigaction(SIGABRT, &sa, nullptr);
 
-		freopen("/dev/null", "w", stderr);
-
-		setenv("RADV_DEBUG", "llvm", 1);
-
-		VkInstanceCreateInfo instanceCreateInfo = {};
-		instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-		VkInstance instance = VK_NULL_HANDLE;
-		if (vkCreateInstance(&instanceCreateInfo, nullptr, &instance) != VK_SUCCESS)
-			_exit(1);
-
-		InitializeInstanceVulkan(instance);
-
-		uint32_t count = 0;
-		vkEnumeratePhysicalDevices(instance, &count, nullptr);
-
-		std::vector<VkPhysicalDevice> physicalDevices{count};
-		vkEnumeratePhysicalDevices(instance, &count, physicalDevices.data());
-
-		for (auto& i : physicalDevices)
-		{
-			VkPhysicalDeviceProperties prop{};
-			vkGetPhysicalDeviceProperties(i, &prop);
-			if (prop.vendorID != 0x1002)
-				continue;
-
-			std::string_view deviceName = prop.deviceName;
-			if (deviceName.find("RADV") != std::string_view::npos)
-			{
-				write(subProcessPipes[1], &prop.driverVersion, sizeof(uint32_t));
-				vkDestroyInstance(instance, nullptr);
-				_exit(0);
-			}
-		}
-
-		// no appropriate device found to query version
-		vkDestroyInstance(instance, nullptr);
-		_exit(1);
-	}
-
-	int childStatus = 0;
-	waitpid(childID,  &childStatus, 0);
-
-	if (WEXITSTATUS(childStatus) == 2)
-	{
-		cemuLog_log(LogType::Force, "BOTW/RADV workaround not applied because mesa was built without LLVM");
-	}
-
-	// only continue if the process exits with code zero, which means it determined the version and didn't crash.
-	if (WEXITSTATUS(childStatus) != 0)
+	// if the user specified either shader backend, do nothing.
+	// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
+	std::string_view debugEnv = getenv("RADV_DEBUG");
+	if (debugEnv.find("aco") != std::string_view::npos || debugEnv.find("llvm") != std::string_view::npos)
 		return;
 
-	uint32_t version = 0;
-	if (read(subProcessPipes[0], &version, sizeof(version)) == -1)
-		return; // if we fail to read bail. Should never happen if the subprocess exited with 0
+	uint32_t count = 0;
+	vkEnumeratePhysicalDevices(instance, &count, nullptr);
+
+	std::vector<VkPhysicalDevice> physicalDevices{count};
+	vkEnumeratePhysicalDevices(instance, &count, physicalDevices.data());
+
+	// Find the first AMD device using a RADV driver and store its version
+	int version = 0;
+	for (auto& i : physicalDevices)
+	{
+		VkPhysicalDeviceDriverProperties driverProps{};
+		driverProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+		VkPhysicalDeviceProperties2 prop{};
+		prop.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+		prop.pNext = &driverProps;
+		vkGetPhysicalDeviceProperties2(i, &prop);
+		if (prop.properties.vendorID != 0x1002 || driverProps.driverID != VK_DRIVER_ID_MESA_RADV)
+			continue;
+
+		version = prop.properties.driverVersion;
+		break;
+	}
+
+	if (version == 0)
+		return;
+
 
 	int major = VK_API_VERSION_MAJOR(version);
 	int minor = VK_API_VERSION_MINOR(version);
@@ -417,38 +390,55 @@ static void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 	if ((major <= 25 && minor < 3) || (major == 26 && (minor > 0 || patch >= 5)) || major > 26)
 		return;
 
-	cemuLog_log(LogType::Force, "BOTW/RADV workaround active. Adding llvm to RADV_DEBUG environment variable");
-	// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it
-	if (const char* value; (value = getenv("RADV_DEBUG")) != NULL && strlen(value) != 0)
+	// check if running with LLVM would crash because mesa is LLVM-less.
+	int childID = fork();
+	if (childID == 0) // inside this if statement runs in child
 	{
-		std::string valueStr{value};
-		// only append ,llvm when llvm or aco are not already passed as flags.
-		// "aco" is not a mesa flag (anymore, it used to be when llvm was default)
-		// but it will provide users with a way to override this workaround by setting RADV_DEBUG=aco
-		// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
-		if (valueStr.find("llvm") == std::string::npos && valueStr.find("aco") == std::string::npos)
-		{
-			valueStr.append(",llvm");
-			setenv("RADV_DEBUG", valueStr.c_str(), 1);
-		}
+		struct sigaction sa{.sa_handler = WorkaroundChildAbortHandler};
+		sigaction(SIGABRT, &sa, nullptr);
+
+		freopen("/dev/null", "w", stderr);
+
+		setenv("RADV_DEBUG", "llvm", 1);
+
+		VkInstance instance = VK_NULL_HANDLE;
+		vkCreateInstance(create_info, nullptr, &instance);
+		// this function will abort() when LLVM is absent
+		uint32_t count = 0;
+		vkEnumeratePhysicalDevices(instance, &count, nullptr);
+		vkDestroyInstance(instance, nullptr);
+		_exit(0);
 	}
-	else
+
+	int childStatus = 0;
+	waitpid(childID,  &childStatus, 0);
+
+	if (WEXITSTATUS(childStatus) == 1)
+		cemuLog_log(LogType::Force, "BOTW/RADV workaround not applied because mesa was built without LLVM");
+
+	// only continue if the process exits with code zero, which means it didn't crash
+	if (WEXITSTATUS(childStatus) != 0)
+		return;
+
+	cemuLog_log(LogType::Force, "BOTW/RADV workaround active. Adding \"llvm\" to RADV_DEBUG environment variable");
+	if (debugEnv.empty())
 	{
 		setenv("RADV_DEBUG", "llvm", 1);
 	}
+	else
+	{
+		std::string appendedDebugEnv{debugEnv};
+		appendedDebugEnv.append(",llvm");
+		setenv("RADV_DEBUG", appendedDebugEnv.c_str(), 1);
+	}
+
+	// recreate the vulkan instance to update debug setting
+	vkDestroyInstance(instance, nullptr);
+	vkCreateInstance(create_info, nullptr, &instance);
+	InitializeInstanceVulkan(instance);
 
 }
 
-static void LinuxBreathOfTheWildWorkaround()
-{
-	int subProcessPipes[2]{};
-	pipe(subProcessPipes);
-
-	PerformBOTWLinuxWorkaround(subProcessPipes);
-
-	close(subProcessPipes[0]);
-	close(subProcessPipes[1]);
-}
 #endif
 
 VulkanRenderer::VulkanRenderer()
@@ -456,15 +446,6 @@ VulkanRenderer::VulkanRenderer()
 	glslang::InitializeProcess();
 
 	cemuLog_log(LogType::Force, "------- Init Vulkan graphics backend -------");
-
-	// Workaround for BOTW + RADV. Runes like Magnesis and the camera cause GPU crashes.
-#if BOOST_OS_LINUX
-	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
-	if (currentTitleId == 0x00050000101c9500 || currentTitleId == 0x00050000101c9400 || currentTitleId == 0x00050000101c9300)
-	{
-		LinuxBreathOfTheWildWorkaround();
-	}
-#endif
 
 	const bool useValidationLayer = cemuLog_isLoggingEnabled(LogType::VulkanValidation);
 	if (useValidationLayer)
@@ -518,6 +499,15 @@ VulkanRenderer::VulkanRenderer()
 
 	if (!InitializeInstanceVulkan(m_instance))
 		throw std::runtime_error("Unable to load instanced Vulkan functions");
+
+	// Workaround for BOTW + RADV. Runes like Magnesis and the camera cause GPU crashes.
+#if BOOST_OS_LINUX
+	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
+	if (currentTitleId == 0x00050000101c9500 || currentTitleId == 0x00050000101c9400 || currentTitleId == 0x00050000101c9300)
+	{
+		LinuxBreathOfTheWildWorkaround(m_instance, &create_info);
+	}
+#endif
 
 	uint32_t device_count = 0;
 	vkEnumeratePhysicalDevices(m_instance, &device_count, nullptr);

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -338,6 +338,7 @@ void VulkanRenderer::GetDeviceFeatures()
 
 #if BOOST_OS_LINUX
 #include <sys/wait.h>
+#include "resource/IconsFontAwesome5.h"
 
 int BreathOfTheWildChildProcessMain()
 {
@@ -456,6 +457,8 @@ static void LinuxBreathOfTheWildWorkaround(VkInstance& instance, const VkInstanc
 	if (err != VK_SUCCESS)
 		throw std::runtime_error(fmt::format("Unable to re-create a Vulkan instance after RADV/LLVM workaround: {}", err));
 	InitializeInstanceVulkan(instance);
+
+	LatteOverlay_pushNotification(std::string{(const char*)ICON_FA_EXCLAMATION_TRIANGLE} + "RADV_DEBUG=llvm set automatically to avoid crashing due to a driver bug. If possible update mesa to 26.0.5 or newer", 10'000);
 
 }
 

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -381,11 +381,13 @@ void PerformBOTWLinuxWorkaround(int subProcessPipes[2])
 			if (deviceName.find("RADV") != std::string_view::npos)
 			{
 				write(subProcessPipes[1], &prop.driverVersion, sizeof(uint32_t));
+				vkDestroyInstance(instance, nullptr);
 				_exit(0);
 			}
 		}
 
 		// no appropriate device found to query version
+		vkDestroyInstance(instance, nullptr);
 		_exit(1);
 	}
 

--- a/src/gui/wxgui/MainWindow.cpp
+++ b/src/gui/wxgui/MainWindow.cpp
@@ -623,35 +623,6 @@ bool MainWindow::FileLoad(const fs::path launchPath, wxLaunchGameEvent::INITIATE
     }
 #endif
 
-	// Workaround for BOTW + Mesa. Runes like Magnesis and the camera cause GPU crashes.
-	// Using the LLVM shader compiler prevents crashes which points to an issue with the default ACO compiler.
-	// Either that or Cemu is violating a specification (GLSL?) causing the shaders to be broken after compilation.
-#if BOOST_OS_LINUX
-	uint64 currentTitleId = CafeSystem::GetForegroundTitleId();
-	if (currentTitleId == 0x00050000101c9500 || currentTitleId == 0x00050000101c9400 || currentTitleId == 0x00050000101c9300)
-	{
-		// if the variable is empty set it to llvm, otherwise check if it contains llvm/aco and if not append it
-		if (const char* value; (value = getenv("RADV_DEBUG")) != NULL && strlen(value) != 0)
-		{
-			std::string valueStr{value};
-			// only append ,llvm when llvm or aco are not already passed as flags.
-			// "aco" is not a mesa flag (anymore, it used to be when llvm was default)
-			// but it will provide users with a way to override this workaround by setting RADV_DEBUG=aco
-			// should parse the flag list but there are currently no other flags containing llvm or aco as a substring
-			if (valueStr.find("llvm") == std::string::npos && valueStr.find("aco") == std::string::npos)
-			{
-				valueStr.append(",llvm");
-				setenv("RADV_DEBUG", valueStr.c_str(), 1);
-			}
-		}
-		else
-		{
-			setenv("RADV_DEBUG", "llvm", 1);
-		}
-	}
-
-#endif
-
 	CreateCanvas();
 	CafeSystem::LaunchForegroundTitle();
 	RecreateMenu();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,8 +255,14 @@ int main(int argc, char* argv[])
 
 #else
 
+int BreathOfTheWildChildProcessMain();
 int main(int argc, char *argv[])
 {
+#if BOOST_OS_LINUX
+	if (getenv("CEMU_DETECT_RADV") != nullptr)
+		return BreathOfTheWildChildProcessMain();
+#endif
+
 #if BOOST_OS_LINUX || BOOST_OS_BSD
     XInitThreads();
 #endif


### PR DESCRIPTION
Use child process to detect the presence of the LLVM compiler
Only apply workaround on affected mesa versions.
Log the manipulation of RADV_DEBUG