### PR TITLE
FSC: Retry WUA lookup with percent-encoded '@'

### DIFF
--- a/src/Cafe/Filesystem/fscDeviceWua.cpp
+++ b/src/Cafe/Filesystem/fscDeviceWua.cpp
@@ -125,6 +125,23 @@ class fscDeviceWUAC : public fscDeviceC
 		cemu_assert_debug(!HAS_FLAG(accessFlags, FSC_ACCESS_FLAG::WRITE_PERMISSION)); // writing to WUA is not supported
 
 		ZArchiveNodeHandle fileHandle = archive->LookUp(path, true, true);
+		if (fileHandle == ZARCHIVE_INVALID_NODE && path.find('@') != std::string_view::npos)
+		{
+			// Some WUA packers percent-encode '@' in entry names (stored as "%40"),
+			// so a byte-literal LookUp for "@bg0010.arc" misses "%40bg0010.arc".
+			// Retry with '@' percent-encoded. Affects Twilight Princess HD, whose
+			// DVD thread uses '@'-prefixed archive names for Forest Temple rooms.
+			std::string retryPath;
+			retryPath.reserve(path.size() + 16);
+			for (char c : path)
+			{
+				if (c == '@')
+					retryPath += "%40";
+				else
+					retryPath += c;
+			}
+			fileHandle = archive->LookUp(retryPath, true, true);
+		}
 		if (fileHandle == ZARCHIVE_INVALID_NODE)
 		{
 			*fscStatus = FSC_STATUS_FILE_NOT_FOUND;


### PR DESCRIPTION
Some WUA packers percent-encode reserved characters in entry names (`@` stored as `%40`). ZArchive's `LookUp` is byte-literal, so a query for `@bg0010.arc` misses the stored `%40bg0010.arc` and `FSOpenFile` returns `-6`.

This affects **Twilight Princess HD**: its DVD thread (`mDoDvdThd_mountArchive_c`) uses `@`-prefixed archive names for the Forest Temple room backgrounds. Without the retry, room archives like `@bg0010.arc` fail to mount, so the cage room is missing its cage and monkey, softlocking the player on the first-dungeon monkey puzzle.

On affected WUAs the log shows:
```
coreinit.FSOpenFile(..., "/vol/content/res/Object/@bg0010.arc", ...)
    coreinit.FSOpenFile -> -6
[OSConsole] [ERROR]mDoDvdThd_mountArchive_c::execute Mount failure
[OSConsole] [ERROR]<@bg0010.arc> setRes: archive mount error !!
```

The fix is scoped to `fscDeviceWua` and only kicks in when the initial lookup fails and the path contains `@`, so it has no effect on normal lookups or on correctly-packed WUAs.

## Test plan
- [x] Twilight Princess HD (US, title `000500001019e500`): Forest Temple cage room now mounts, cage/monkey present with collision, dungeon progresses.
- [x] Other TPHD rooms that previously hit the same error path (`@bg000f`, `@bg0034`, `@bg0056`) now mount.
- [x] Normal WUA lookups unaffected (retry branch only runs on failure + `@` present).