### PR TITLE
VulkanRenderer: Fix compile error on glibc 2.43

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -343,7 +343,9 @@ void VulkanRenderer::GetDeviceFeatures()
 int BreathOfTheWildChildProcessMain()
 {
 	InitializeGlobalVulkan();
-	struct sigaction sa{.sa_handler = [](int unused){_exit(1);}};
+	struct sigaction sa{};
+	sa.sa_handler = [](int unused) { _exit(1); };
+
 	int ret = sigaction(SIGABRT, &sa, nullptr);
 
 	freopen("/dev/null", "w", stderr);


### PR DESCRIPTION
sa_handler may not be a direct member of struct sigaction, in glibc 2.43 it may be defined as part of a union of sa_handler and sa_sigaction, then a preprocessor macro is defined for compatibility purposes. Here it expands as `sa{.__sigaction_handler.sa_handler = ...}` which is not supported in C++.

```
/home/sapphire/code/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp: In function ‘int BreathOfTheWildChildProcessMain()’: /home/sapphire/code/Cemu/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp:346:29: error: expected primary-expression before ‘.’ token
  346 |         struct sigaction sa{.sa_handler = [](int unused){_exit(1);}};
      |                             ^
```