### PR TITLE
Build: Correctly change rpath for libusb.dylib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,10 +130,10 @@ if (MACOS_BUNDLE)
 		COMMAND ${CMAKE_COMMAND} ARGS -E copy "${LIBUSB_PATH}" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/Frameworks/libusb-1.0.0.dylib"
 		COMMAND ${CMAKE_COMMAND} ARGS -E copy "${CMAKE_SOURCE_DIR}/src/resource/update.sh" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/update.sh"
 		COMMAND bash -c "install_name_tool -add_rpath @executable_path/../Frameworks ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME}"
-		COMMAND bash -c "install_name_tool -change ${LIBUSB_PATH} @executable_path/../Frameworks/libusb-1.0.0.dylib ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME}")
+		COMMAND install_name_tool -change @rpath/libusb-1.0.0.dylib @executable_path/../Frameworks/libusb-1.0.0.dylib ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME})
 else()
     if(APPLE)
-        find_library(MOLTENVK_LIBRARY 
+        find_library(MOLTENVK_LIBRARY
             NAMES MoltenVK moltenvk libMoltenVK.dylib
             PATHS /usr/local/lib /opt/homebrew/lib
         )
@@ -143,7 +143,7 @@ else()
         else()
             message(WARNING "libMoltenVK.dylib not found")
         endif()
-        set_target_properties(CemuBin PROPERTIES 
+        set_target_properties(CemuBin PROPERTIES
             BUILD_WITH_INSTALL_RPATH TRUE
             INSTALL_RPATH "/usr/local/lib;/opt/homebrew/lib"
         )


### PR DESCRIPTION
When making a macOS app bundle in CMake, we need to use `install_name_tool` to tell the Cemu executable where to find certain dylibs, because we will copy them over to the Frameworks folder inside the app bundle. 

Currently `install_name_tool` is used to change the rpath to `libusb.dylib` in the Cemu executable with this: 

```
install_name_tool -change ${LIBUSB_PATH} @executable_path/../Frameworks/libusb-1.0.0.dylib ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME}
```
This is incorrect and will fail to make any changes to the path.

The reason why it fails is that the `LIBUSB_PATH` variable is set to:

```
${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/libusb-1.0.0.dylib
```
which is the location of the dylib in the runner. This is not what we want and will fail to make any change.

If we run `otool -L Cemu`  on the executable, we can see that the path to `libusb.dylib` is:
```
@rpath/libusb-1.0.0.dylib
```
`install_name_tool -change` expects the path to be changed to already exist on the executable, not the location in the runner where the dylib was. And we want the executable to be able to find it in the Frameworks folder inside the app bundle. 

The command is `install_name_tool -change [Path to be replaced] [New path] [File to make changes to]`

So it is expecting:
```
install_name_tool -change @rpath/libusb-1.0.0.dylib @executable_path/../Frameworks/libusb-1.0.0.dylib ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/Cemu
```

Running `otool -L Cemu` on the executable after this will give us the result that we want: 
```
@executable_path/../Frameworks/libusb-1.0.0.dylib
```


### Testing: 
- Run `otool -L Cemu` on the Cemu executable. It should resolve to `@executable_path/../Frameworks/libusb-1.0.0.dylib` 


