### PR TITLE
Build: Codesign macOS app bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,6 +283,7 @@ jobs:
         mv bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu_release bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         sed -i '' 's/Cemu_release/Cemu/g' bin/Cemu_app/Cemu.app/Contents/Info.plist
         chmod a+x bin/Cemu_app/Cemu.app/Contents/MacOS/{Cemu,update.sh}
+        codesign --entitlements ${{github.workspace}}/src/resource/cemu.macos.entitlements --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - --timestamp --options runtime bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         ln -s /Applications bin/Cemu_app/Applications
         hdiutil create ./bin/tmp.dmg -ov -volname "Cemu" -fs HFS+ -srcfolder "./bin/Cemu_app"
         hdiutil convert ./bin/tmp.dmg -format UDZO -o bin/Cemu.dmg

--- a/src/resource/cemu.macos.entitlements
+++ b/src/resource/cemu.macos.entitlements
@@ -1,0 +1,13 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds an entitlements file and uses it to codesign the app bundle in the Github Actions runs. 

I conferred with @SamoZ256 as to which entitlements would be appropriate for Cemu, and I believe these should be ok. 

It would be preferable to get CMake to perform the codesigning step, but further changes would have to be made. This could be done in a future PR. 
