### PR TITLE
CI: Silence runner warnings as ninja is already installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         brew update
-        brew install ninja nasm automake libtool
+        brew install nasm automake libtool
 
     - name: "Install molten-vk"
       run: |


### PR DESCRIPTION
When building the macOS artifacts, there is no need to install ninja.

Silences these warnings:

<img width="768" height="193" alt="Screenshot 2026-04-16 at 23 24 38" src="https://github.com/user-attachments/assets/41564b9c-db49-4e1c-bd1a-79bcf0239a74" />
