### PR TITLE
Log CPU and OS version on macOS

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -539,7 +539,23 @@ namespace CafeSystem
 		else
 			platform = "Linux";
 		#elif BOOST_OS_MACOS
-		platform = "MacOS";
+		char productVersion[256]{};
+		size_t productVersionSize = sizeof(productVersion);
+		const int productVersionResult = sysctlbyname("kern.osproductversion", productVersion, &productVersionSize, nullptr, 0);
+
+		char buildVersion[256]{};
+		size_t buildVersionSize = sizeof(buildVersion);
+		const int buildVersionResult = sysctlbyname("kern.osversion", buildVersion, &buildVersionSize, nullptr, 0);
+
+		if (productVersionResult == 0 && buildVersionResult == 0)
+			buffer = fmt::format("macOS {} ({})", productVersion, buildVersion);
+		else if (productVersionResult == 0)
+			buffer = fmt::format("macOS {}", productVersion);
+		else
+			buffer = "macOS";
+
+		platform = buffer.c_str();
+		
 		#elif BOOST_OS_BSD
 		#if defined(__FreeBSD__)
 		platform = "FreeBSD";

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -467,7 +467,18 @@ namespace CafeSystem
 
 	void logCPUAndMemoryInfo()
 	{
+		#if BOOST_OS_MACOS
+		std::string cpuName;
+		size_t cpu_len = 0;
+		if (sysctlbyname("machdep.cpu.brand_string", NULL, &cpu_len, NULL, 0) == 0 && cpu_len > 1)
+		{
+			cpuName.resize(cpu_len);
+			if (sysctlbyname("machdep.cpu.brand_string", cpuName.data(), &cpu_len, NULL, 0) != 0)
+				cpuName.clear();
+		}
+		#else
 		std::string cpuName = g_CPUFeatures.GetCPUName();
+		#endif
 		if (!cpuName.empty())
 			cemuLog_log(LogType::Force, "CPU: {}", cpuName);
 		#if BOOST_OS_WINDOWS

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -473,8 +473,10 @@ namespace CafeSystem
 		if (sysctlbyname("machdep.cpu.brand_string", NULL, &cpu_len, NULL, 0) == 0 && cpu_len > 1)
 		{
 			cpuName.resize(cpu_len);
-			if (sysctlbyname("machdep.cpu.brand_string", cpuName.data(), &cpu_len, NULL, 0) != 0)
+			if (sysctlbyname("machdep.cpu.brand_string", cpuName.data(), &cpu_len, NULL, 0) != 0 || cpu_len == 0)
 				cpuName.clear();
+			else if (!cpuName.empty() && cpuName.back() == '\0')
+				cpuName.pop_back();
 		}
 		#else
 		std::string cpuName = g_CPUFeatures.GetCPUName();

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -467,20 +467,7 @@ namespace CafeSystem
 
 	void logCPUAndMemoryInfo()
 	{
-		#if BOOST_OS_MACOS
-		std::string cpuName;
-		size_t cpu_len = 0;
-		if (sysctlbyname("machdep.cpu.brand_string", NULL, &cpu_len, NULL, 0) == 0 && cpu_len > 1)
-		{
-			cpuName.resize(cpu_len);
-			if (sysctlbyname("machdep.cpu.brand_string", cpuName.data(), &cpu_len, NULL, 0) != 0 || cpu_len == 0)
-				cpuName.clear();
-			else if (!cpuName.empty() && cpuName.back() == '\0')
-				cpuName.pop_back();
-		}
-		#else
 		std::string cpuName = g_CPUFeatures.GetCPUName();
-		#endif
 		if (!cpuName.empty())
 			cemuLog_log(LogType::Force, "CPU: {}", cpuName);
 		#if BOOST_OS_WINDOWS

--- a/src/Common/cpu_features.cpp
+++ b/src/Common/cpu_features.cpp
@@ -1,5 +1,10 @@
 #include "cpu_features.h"
 
+#if BOOST_OS_MACOS
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
 // wrappers with uniform prototype for implementation-specific x86 CPU id
 #if defined(ARCH_X86_64)
 #ifdef __GNUC__
@@ -30,7 +35,23 @@ inline void cpuidex(int cpuInfo[4], int functionId, int subFunctionId) {
 
 CPUFeaturesImpl::CPUFeaturesImpl()
 {
-#if defined(ARCH_X86_64)
+#if BOOST_OS_MACOS
+	std::string cpuName;
+	size_t size = 0;
+
+	if (sysctlbyname("machdep.cpu.brand_string", nullptr, &size, nullptr, 0) == 0 && size > 0)
+	{
+		std::vector<char> buffer(size);
+
+		if (sysctlbyname("machdep.cpu.brand_string", buffer.data(), &size, nullptr, 0) == 0 && size > 0)
+		{
+			cpuName.assign(buffer.data());
+		}
+	}
+
+	strncpy(m_cpuBrandName, cpuName.c_str(), sizeof(m_cpuBrandName) - 1);
+	m_cpuBrandName[sizeof(m_cpuBrandName) - 1] = '\0';
+#elif defined(ARCH_X86_64)
 	int cpuInfo[4];
 	cpuid(cpuInfo, 0x80000001);
 	x86.lzcnt = ((cpuInfo[2] >> 5) & 1) != 0;


### PR DESCRIPTION
This PR brings the macOS logs in line with the Windows/Linux logs.

Before:
```
[16:32:27.393] RAM: 24576MB
[16:32:27.393] Platform: MacOS
```

After:
```
[16:36:26.981] CPU: Apple M5 Pro
[16:36:26.981] RAM: 24576MB
[16:36:26.981] Platform: macOS 26.4 (25E246)
```