### PR TITLE
Build.md: Add pkgconf to homebrew dependencies & mention bundle flag

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -189,6 +189,10 @@ Alternatively, you can use the non-privateapi version of MoltenVK, but you may e
 4. `cmake --build build`
 5. You should now have a Cemu executable file in the /bin folder, which you can run using `./bin/Cemu_release`.
 
+#### Creating an app bundle
+- If you want to create an app bundle instead of a raw executable, append the following flag to the command in step 3:
+   - `-DMACOS_BUNDLE=ON`
+
 #### Troubleshooting steps
 - If step 3 gives you an error about not being able to find ninja, try appending the following to the command and try again:
    - **On an Apple Silicon Mac:** `-DCMAKE_MAKE_PROGRAM=/opt/homebrew/bin/ninja`

--- a/BUILD.md
+++ b/BUILD.md
@@ -164,7 +164,7 @@ To install the dependencies required to build Cemu, you will need to install Hom
 
 The following dependencies are required. You can install them using Homebrew with the following command:
 
-`brew install git cmake ninja nasm automake libtool boost`
+`brew install automake boost cmake git libtool nasm ninja pkgconf`
 
 ### MoltenVK
 


### PR DESCRIPTION
This PR adds `pkgconf` to the list of brew dependencies (and sorts them alphabetically to appease my OCD). 

Also mention the `-DMACOS_BUNDLE=ON` flag where is it clearly visible to someone following the instructions. 