### PR TITLE
macOS CMake fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,6 @@ jobs:
         mv bin/Cemu_release.app bin/Cemu_app/Cemu.app
         mv bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu_release bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         sed -i '' 's/Cemu_release/Cemu/g' bin/Cemu_app/Cemu.app/Contents/Info.plist
-        chmod a+x bin/Cemu_app/Cemu.app/Contents/MacOS/{Cemu,update.sh}
         codesign --entitlements ${{github.workspace}}/src/resource/cemu.macos.entitlements --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - --timestamp --options runtime bin/Cemu_app/Cemu.app/Contents/MacOS/Cemu
         ln -s /Applications bin/Cemu_app/Applications
         hdiutil create ./bin/tmp.dmg -ov -volname "Cemu" -fs HFS+ -srcfolder "./bin/Cemu_app"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
 
 if (MSVC)
 	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CemuBin)
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY XCODE_STARTUP_PROJECT CemuBin)
 	# floating point model: precise, fiber safe optimizations
 	add_compile_options(/EHsc /fp:precise)
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
 
 if (MSVC)
 	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT CemuBin)
-	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY XCODE_STARTUP_PROJECT CemuBin)
 	# floating point model: precise, fiber safe optimizations
 	add_compile_options(/EHsc /fp:precise)
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -92,6 +91,10 @@ if (MSVC)
 	# enable additional optimization flags for release builds
 	add_compile_options($<$<CONFIG:Release,RelWithDebInfo>:/Oi>) # enable intrinsic functions
 	add_compile_options($<$<CONFIG:Release,RelWithDebInfo>:/Ot>) # favor speed
+endif()
+
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY XCODE_STARTUP_PROJECT CemuBin)
 endif()
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ if(CEMU_ARCHITECTURE MATCHES "(aarch64)|(AARCH64)|(arm64)|(ARM64)")
 	add_subdirectory("dependencies/xbyak_aarch64" EXCLUDE_FROM_ALL)
 endif()
 
-find_package(ZArchive)
+find_package(ZArchive QUIET)
 if (NOT ZArchive_FOUND)
 	add_subdirectory("dependencies/ZArchive" EXCLUDE_FROM_ALL)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,12 @@ if(WIN32)
 	)
 endif()
 
+if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
+    set_target_properties(CemuBin PROPERTIES
+        XCODE_ATTRIBUTE_ENABLE_DEBUG_DYLIB[variant=Debug] "YES"
+    )
+endif()
+
 string(TIMESTAMP CURRENT_YEAR "%Y" UTC)
 
 set_property(TARGET CemuBin PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -127,12 +133,31 @@ if (MACOS_BUNDLE)
 		message(FATAL_ERROR "failed to find libMoltenVK.dylib")
 	endif ()
 
-	add_custom_command (TARGET CemuBin POST_BUILD
-		COMMAND ${CMAKE_COMMAND} ARGS -E copy "${MOLTENVK_PATH}" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/Frameworks/libMoltenVK.dylib"
-		COMMAND ${CMAKE_COMMAND} ARGS -E copy "${LIBUSB_PATH}" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/Frameworks/libusb-1.0.0.dylib"
-		COMMAND ${CMAKE_COMMAND} ARGS -E copy "${CMAKE_SOURCE_DIR}/src/resource/update.sh" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/update.sh"
-		COMMAND bash -c "install_name_tool -add_rpath @executable_path/../Frameworks ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME}"
-		COMMAND install_name_tool -change @rpath/libusb-1.0.0.dylib @executable_path/../Frameworks/libusb-1.0.0.dylib ${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/MacOS/${OUTPUT_NAME})
+	set(APP_BUNDLE_DIR "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app")
+	set(FRAMEWORKS_DIR "${APP_BUNDLE_DIR}/Contents/Frameworks")
+	set(RESOURCES_DIR  "${APP_BUNDLE_DIR}/Contents/Resources")
+
+	add_custom_command(TARGET CemuBin POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"${MOLTENVK_PATH}"
+			"${FRAMEWORKS_DIR}/libMoltenVK.dylib"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"${LIBUSB_PATH}"
+			"${FRAMEWORKS_DIR}/libusb-1.0.0.dylib"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"${CMAKE_SOURCE_DIR}/src/resource/update.sh"
+			"${RESOURCES_DIR}/update.sh"
+		COMMAND ${CMAKE_COMMAND} -E chmod +x "${RESOURCES_DIR}/update.sh"
+		COMMAND install_name_tool
+			-change @rpath/libusb-1.0.0.dylib
+					@executable_path/../Frameworks/libusb-1.0.0.dylib
+					"$<TARGET_FILE:CemuBin>"
+	)
+
+	set_target_properties(CemuBin PROPERTIES
+		BUILD_WITH_INSTALL_RPATH TRUE
+		INSTALL_RPATH "@executable_path/../Frameworks"
+	)
 else()
     if(APPLE)
         find_library(MOLTENVK_LIBRARY

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,7 +116,7 @@ if (MACOS_BUNDLE)
 	set(FOLDERS gameProfiles resources)
 	foreach(folder ${FOLDERS})
 		add_custom_command (TARGET CemuBin POST_BUILD
-			COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory "${CMAKE_SOURCE_DIR}/bin/${folder}" "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app/Contents/SharedSupport/${folder}")
+			COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory "${CMAKE_SOURCE_DIR}/bin/${folder}" "$<TARGET_BUNDLE_DIR:CemuBin>/Contents/SharedSupport/${folder}")
 	endforeach(folder)
 
 	if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -132,31 +132,36 @@ if (MACOS_BUNDLE)
 	else()
 		message(FATAL_ERROR "failed to find libMoltenVK.dylib")
 	endif ()
+	set(UPDATE_SH_PATH "${CMAKE_SOURCE_DIR}/src/resource/update.sh")
 
-	set(APP_BUNDLE_DIR "${CMAKE_SOURCE_DIR}/bin/${OUTPUT_NAME}.app")
+	set(APP_BUNDLE_DIR "$<TARGET_BUNDLE_DIR:CemuBin>")
 	set(FRAMEWORKS_DIR "${APP_BUNDLE_DIR}/Contents/Frameworks")
 	set(RESOURCES_DIR  "${APP_BUNDLE_DIR}/Contents/Resources")
 
 	add_custom_command(TARGET CemuBin POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		COMMAND ${CMAKE_COMMAND} -E copy 
 			"${MOLTENVK_PATH}"
 			"${FRAMEWORKS_DIR}/libMoltenVK.dylib"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		COMMAND ${CMAKE_COMMAND} -E copy
 			"${LIBUSB_PATH}"
 			"${FRAMEWORKS_DIR}/libusb-1.0.0.dylib"
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			"${CMAKE_SOURCE_DIR}/src/resource/update.sh"
+		COMMAND ${CMAKE_COMMAND} -E copy
+			"${UPDATE_SH_PATH}"
 			"${RESOURCES_DIR}/update.sh"
-		COMMAND ${CMAKE_COMMAND} -E chmod +x "${RESOURCES_DIR}/update.sh"
-		COMMAND install_name_tool
-			-change @rpath/libusb-1.0.0.dylib
-					@executable_path/../Frameworks/libusb-1.0.0.dylib
-					"$<TARGET_FILE:CemuBin>"
+		COMMAND chmod 755
+			"${RESOURCES_DIR}/update.sh"
 	)
 
 	set_target_properties(CemuBin PROPERTIES
 		BUILD_WITH_INSTALL_RPATH TRUE
 		INSTALL_RPATH "@executable_path/../Frameworks"
+	)
+
+	add_custom_command(TARGET CemuBin POST_BUILD
+		COMMAND install_name_tool
+			-change @rpath/libusb-1.0.0.dylib
+					@executable_path/../Frameworks/libusb-1.0.0.dylib
+					"$<TARGET_FILE:CemuBin>"
 	)
 else()
     if(APPLE)

--- a/src/gui/wxgui/CemuUpdateWindow.cpp
+++ b/src/gui/wxgui/CemuUpdateWindow.cpp
@@ -616,7 +616,8 @@ void CemuUpdateWindow::OnClose(wxCloseEvent& event)
 	{
 	    const auto tmppath = fs::temp_directory_path() / L"cemu_update/Cemu.dmg";
 	    fs::path exePath = ActiveSettings::GetExecutablePath().parent_path();
-	    const auto apppath = exePath / L"update.sh";
+		const auto appResources = exePath.parent_path().parent_path() / L"Resources";
+		const auto apppath = appResources / L"update.sh";
 	    execlp("sh", "sh", apppath.c_str(), NULL);
         
         exit(0);


### PR DESCRIPTION
While it _technically_ works, shell scripts like update.sh should not be in Contents/MacOS in an app bundle. The correct place to put them is in Contents/Resources. Contents/MacOS should be reserved only for executable binaries, and not for interpreted scripts, and it makes codesigning/notorization more fragile. The script has been moved now, and CemuUpdateWindow.cpp has been updated to use the new script location.

I've also swapped out the bash command (`COMMAND bash -c "install_name_tool ...`) for the proper CMake equivalent, and moved `chmod a+x` from the GitHub action over the CMake script, ~~so the updater works on home-compiled versions.~~ _Actually since it's being invoked from Cemu explicitly it doesn't need to be marked as executable. Still probably good to have this here._

As an added bonus this makes the project compilable with `-G Xcode`, so I've added two XCode lines in there to make building easier. This shouldn't affect Ninja compilation.

Not quite in scope of this PR put I also made ZArchive do `find_package(ZArchive QUIET)` because it was annoying me. Chucked it in here since idk if it's a big enough change to necessarilly need its own PR.