### PR TITLE
Input: fix mapping races

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -697,7 +697,7 @@ std::shared_ptr<VPADController> InputManager::get_vpad_controller(size_t index) 
 		return {};
 
 	std::shared_lock lock(m_mutex);
-	return std::static_pointer_cast<VPADController>(m_vpad[index]);
+	return std::dynamic_pointer_cast<VPADController>(m_vpad[index]);
 }
 
 std::shared_ptr<WPADController> InputManager::get_wpad_controller(size_t index) const
@@ -706,7 +706,7 @@ std::shared_ptr<WPADController> InputManager::get_wpad_controller(size_t index) 
 		return {};
 
 	std::shared_lock lock(m_mutex);
-	return std::static_pointer_cast<WPADController>(m_wpad[index]);
+	return std::dynamic_pointer_cast<WPADController>(m_wpad[index]);
 }
 
 std::pair<size_t, size_t> InputManager::get_controller_count() const

--- a/src/input/emulated/EmulatedController.cpp
+++ b/src/input/emulated/EmulatedController.cpp
@@ -263,6 +263,7 @@ void EmulatedController::clear_controllers()
 
 float EmulatedController::get_axis_value(uint64 mapping) const
 {
+	std::shared_lock lock(m_mutex);
 	const auto it = m_mappings.find(mapping);
 	if (it != m_mappings.cend())
 	{
@@ -276,6 +277,7 @@ float EmulatedController::get_axis_value(uint64 mapping) const
 
 bool EmulatedController::is_mapping_down(uint64 mapping) const
 {
+	std::shared_lock lock(m_mutex);
 	const auto it = m_mappings.find(mapping);
 	if (it != m_mappings.cend())
 	{
@@ -288,6 +290,7 @@ bool EmulatedController::is_mapping_down(uint64 mapping) const
 
 std::string EmulatedController::get_mapping_name(uint64 mapping) const
 {
+	std::shared_lock lock(m_mutex);
 	const auto it = m_mappings.find(mapping);
 	if (it != m_mappings.cend())
 	{
@@ -301,6 +304,7 @@ std::string EmulatedController::get_mapping_name(uint64 mapping) const
 
 std::shared_ptr<ControllerBase> EmulatedController::get_mapping_controller(uint64 mapping) const
 {
+	std::shared_lock lock(m_mutex);
 	const auto it = m_mappings.find(mapping);
 	if (it != m_mappings.cend())
 	{
@@ -314,17 +318,20 @@ std::shared_ptr<ControllerBase> EmulatedController::get_mapping_controller(uint6
 
 void EmulatedController::delete_mapping(uint64 mapping)
 {
+	std::scoped_lock lock(m_mutex);
 	m_mappings.erase(mapping);
 }
 
 void EmulatedController::clear_mappings()
 {
+	std::scoped_lock lock(m_mutex);
 	m_mappings.clear();
 }
 
 void EmulatedController::set_mapping(uint64 mapping, const std::shared_ptr<ControllerBase>& controller,
                                      uint64 button)
 {
+	std::scoped_lock lock(m_mutex);
 	m_mappings[mapping] = { controller, button };
 }
 


### PR DESCRIPTION
I was spamming a button during the startup of Devil's Third and Cemu crashed. The reason is missing synchronization in `EmulatedController`. This PR fixes the crash.