### PR TITLE
CI: Don't automatically cancel both macOS builds if one fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
   build-macos:
     runs-on: macos-14
     strategy:
+      fail-fast: false
       matrix:
         arch: [x86_64, arm64]
     steps:


### PR DESCRIPTION
This PR sets `fail-fast: false` for macOS builds. 

It currently defaults to true, meaning that if one build fails the other is automatically cancelled. 

