### PR TITLE
gui: Fix formatting error in TextureRelationWindow

### DIFF
--- a/src/gui/wxgui/windows/TextureRelationViewer/TextureRelationWindow.cpp
+++ b/src/gui/wxgui/windows/TextureRelationViewer/TextureRelationWindow.cpp
@@ -244,7 +244,7 @@ void TextureRelationViewerWindow::_setTextureRelationListItemTexture(wxListCtrl*
 	uiList->SetItem(rowIndex, columnIndex, texInfo->mipLevels == 1 ? "1 mip" : wxString::Format("%d mips", texInfo->mipLevels));
 	columnIndex++;
 	// last access
-	uiList->SetItem(rowIndex, columnIndex, wxString::Format("%lus", (GetTickCount() - texInfo->lastAccessTick + 499) / 1000));
+	uiList->SetItem(rowIndex, columnIndex, wxString::Format("%uus", (GetTickCount() - texInfo->lastAccessTick + 499) / 1000));
 	columnIndex++;
 	// overwrite resolution
 	wxString overwriteResLabel;


### PR DESCRIPTION
Caused crash in debug build because of wx assertions