### PR TITLE
Vulkan: skip zero-size readback buffer barriers

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
@@ -21,6 +21,8 @@ void LatteTextureReadback_StartTransfer(LatteTextureView* textureView)
 	HRTick currentTick = HighResolutionTimer().now().getTick();
 	// create info entry and store in ordered linked list
 	LatteTextureReadbackInfo* readbackInfo = g_renderer->texture_createReadback(textureView);
+	if (!readbackInfo)
+		return;
 	sTextureActiveReadbackQueue.push(readbackInfo);
 	readbackInfo->StartTransfer();
 	readbackInfo->transferStartTime = currentTick;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -3670,14 +3670,14 @@ void VulkanRenderer::texture_copyImageSubData(LatteTexture* src, sint32 srcMip, 
 LatteTextureReadbackInfo* VulkanRenderer::texture_createReadback(LatteTextureView* textureView)
 {
 	auto* result = new LatteTextureReadbackInfoVk(m_logicalDevice, textureView);
-
-	LatteTextureVk* vkTex = (LatteTextureVk*)textureView->baseTexture;
-
-	VkMemoryRequirements memRequirements;
-	vkGetImageMemoryRequirements(m_logicalDevice, vkTex->GetImageObj()->m_image, &memRequirements);
-
 	const uint32 linearImageSize = result->GetImageSize();
-	const uint32 uploadSize = (linearImageSize == 0) ? memRequirements.size : linearImageSize;
+	if (linearImageSize == 0)
+	{
+		delete result;
+		return nullptr;
+	}
+
+	const uint32 uploadSize = linearImageSize;
 	const uint32 uploadAlignment = 256; // todo - use Vk optimalBufferCopyOffsetAlignment
 	m_textureReadbackBufferWriteIndex = (m_textureReadbackBufferWriteIndex + uploadAlignment - 1) & ~(uploadAlignment - 1);
 


### PR DESCRIPTION
Do not create Vulkan async texture readbacks when the format has no supported linear readback size. The shared readback launcher now tolerates a null readback object, which prevents zero-byte buffer barriers from being submitted for unsupported readback formats.

Warning: vkCmdPipelineBarrier(): pBufferMemoryBarriers[0] VkBuffer 0x1080000000108 has a size of 0. The Vulkan spec states: If size is not equal to VK_WHOLE_SIZE, size must be greater than 0.