### PR TITLE
Clamp OpenGL vsync value in UpdateVSyncState

### DIFF
--- a/src/gui/wxgui/canvas/OpenGLCanvas.cpp
+++ b/src/gui/wxgui/canvas/OpenGLCanvas.cpp
@@ -119,7 +119,7 @@ public:
 	void UpdateVSyncState()
 	{
 		int configValue = GetConfig().vsync.GetValue();
-		(value < 0) ? 0 : (value > 1) ? 1 : value;
+		configValue = configValue > 0 ? 1 : 0;
 		if(m_activeVSyncState != configValue)
 		{
 #if BOOST_OS_WINDOWS

--- a/src/gui/wxgui/canvas/OpenGLCanvas.cpp
+++ b/src/gui/wxgui/canvas/OpenGLCanvas.cpp
@@ -119,6 +119,7 @@ public:
 	void UpdateVSyncState()
 	{
 		int configValue = GetConfig().vsync.GetValue();
+		(value < 0) ? 0 : (value > 1) ? 1 : value;
 		if(m_activeVSyncState != configValue)
 		{
 #if BOOST_OS_WINDOWS


### PR DESCRIPTION
Before, this assumed that the vsync config value is only ever 0 or 1. But there's a possibility it isn't because of Vulkan. This becomes a problem in a game profile where the graphics api is OpenGL, but in the global config, its Vulkan. This fixes that issue.