### PR TITLE
Update to SDL 3.4.10 (and update vcpkg)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "sdl3",
-      "version": "3.4.2"
+      "version": "3.4.10"
     },
     {
       "name": "wxwidgets",


### PR DESCRIPTION
Since I use a Steam Controller and SDL 3.4.10 has support for it, I decided to try updating it on Cemu myself and it seems to work... No idea what I'm doing but I decided to do a pr!

vcpkg has been updated to its latest commit and not its latest release, which I thought would be good to mention. That was done to be able to get SDL 3.4.10.