### PR TITLE
GraphicPack: Allow overriding cos.xml permissions

### DIFF
--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -950,6 +950,23 @@ namespace CafeSystem
 	{
 		if (sLaunchModeIsStandalone)
 			return CosCapabilityBits::All;
+
+		uint64 resultMask = 0;
+		for (const auto& pack : GraphicPack2::GetGraphicPacks())
+		{
+			if (pack->IsEnabled()) 
+			{	
+				for (const auto& permissionOverrides : pack->GetPermissionOverrides()) 
+				{
+					if (permissionOverrides.first == group)
+						resultMask |= permissionOverrides.second;
+				}
+			}
+		}
+
+		if (resultMask != 0)
+    		return static_cast<CosCapabilityBits>(resultMask);
+
 		auto& update = sGameInfo_ForegroundTitle.GetUpdate();
 		if (update.IsValid())
 		{

--- a/src/Cafe/CafeSystem.cpp
+++ b/src/Cafe/CafeSystem.cpp
@@ -951,35 +951,29 @@ namespace CafeSystem
 		if (sLaunchModeIsStandalone)
 			return CosCapabilityBits::All;
 
-		uint64 resultMask = 0;
-		for (const auto& pack : GraphicPack2::GetGraphicPacks())
+		CosCapabilityBits resultMask = static_cast<CosCapabilityBits>(0);
+		for (const auto& pack : GraphicPack2::GetActiveGraphicPacks())
 		{
-			if (pack->IsEnabled()) 
-			{	
-				for (const auto& permissionOverrides : pack->GetPermissionOverrides()) 
-				{
-					if (permissionOverrides.first == group)
-						resultMask |= permissionOverrides.second;
-				}
+			for (const auto& permissionOverrides : pack->GetPermissionOverrides()) 
+			{
+				if (permissionOverrides.first == group)
+					resultMask |= static_cast<CosCapabilityBits>(permissionOverrides.second);
 			}
 		}
-
-		if (resultMask != 0)
-    		return static_cast<CosCapabilityBits>(resultMask);
 
 		auto& update = sGameInfo_ForegroundTitle.GetUpdate();
 		if (update.IsValid())
 		{
 			ParsedCosXml* cosXml = update.GetCosInfo();
 			if (cosXml)
-				return cosXml->GetCapabilityBits(group);
+				return cosXml->GetCapabilityBits(group) | resultMask;
 		}
 		auto& base = sGameInfo_ForegroundTitle.GetBase();
 		if(base.IsValid())
 		{
 			ParsedCosXml* cosXml = base.GetCosInfo();
 			if (cosXml)
-				return cosXml->GetCapabilityBits(group);
+				return cosXml->GetCapabilityBits(group) | resultMask;
 		}
 		return CosCapabilityBits::All;
 	}

--- a/src/Cafe/GraphicPack/GraphicPack2.cpp
+++ b/src/Cafe/GraphicPack/GraphicPack2.cpp
@@ -451,6 +451,39 @@ GraphicPack2::GraphicPack2(fs::path rulesPath, IniParser& rules)
 				}
 			}
 		}
+		else if (boost::iequals(currentSectionName, "Permissions")) 
+		{
+			std::array<std::pair<std::string_view, CosCapabilityGroup>, 15> permissionTable
+			{{
+				{"BSP",  CosCapabilityGroup::BSP},
+				{"DK",   CosCapabilityGroup::DK},
+				{"USB",  CosCapabilityGroup::USB},
+				{"UHS",  CosCapabilityGroup::UHS},
+				{"FS",   CosCapabilityGroup::FS},
+				{"MCP",  CosCapabilityGroup::MCP},
+				{"NIM",  CosCapabilityGroup::NIM},
+				{"ACT",  CosCapabilityGroup::ACT},
+				{"FPD",  CosCapabilityGroup::FPD},
+				{"BOSS", CosCapabilityGroup::BOSS},
+				{"ACP",  CosCapabilityGroup::ACP},
+				{"PDM",  CosCapabilityGroup::PDM},
+				{"AC",   CosCapabilityGroup::AC},
+				{"NDM",  CosCapabilityGroup::NDM},
+				{"NSEC", CosCapabilityGroup::NSEC}
+			}};
+
+			for (const auto& [name, group] : permissionTable)
+			{
+				const auto permissionOption = rules.FindOption(name);
+				if (permissionOption)
+				{
+					cemuLog_log(LogType::Force, "Graphic pack \"{}\": has permission mask {} for {}", GetNormalizedPathString(), *permissionOption, name);
+					uint64 permissionMask = ConvertString<uint64>(*permissionOption, 16);
+					m_permissions.push_back({group, permissionMask});
+				}
+
+			}
+		}
 	}
 
 	if (m_version >= 5)

--- a/src/Cafe/GraphicPack/GraphicPack2.h
+++ b/src/Cafe/GraphicPack/GraphicPack2.h
@@ -2,6 +2,7 @@
 
 #include "util/helpers/helpers.h"
 #include "Cemu/ExpressionParser/ExpressionParser.h"
+#include "Cafe/TitleList/TitleInfo.h"
 #include "Cafe/HW/Latte/Renderer/RendererOuputShader.h"
 #include "util/helpers/Serializer.h"
 #include "Cafe/OS/RPL/rpl.h"
@@ -147,6 +148,9 @@ public:
 
 	[[nodiscard]] const std::vector<PresetPtr>& GetPresets() const { return m_presets; }
 	[[nodiscard]] std::unordered_map<std::string, std::vector<PresetPtr>> GetCategorizedPresets(std::vector<std::string>& order) const;
+	
+	// permissions
+	const std::vector<std::pair<CosCapabilityGroup, uint64>>& GetPermissionOverrides() { return m_permissions; }
 
 	// shaders
 	void LoadShaders();
@@ -264,6 +268,9 @@ private:
 
 	// ram mappings
 	std::vector<std::pair<MPTR, MPTR>> m_ramMappings;
+	
+	// permissions
+	std::vector<std::pair<CosCapabilityGroup, uint64>> m_permissions;
 
 	// patches
 	void LoadPatchFiles(); // loads Cemuhook or Cemu patches

--- a/src/Cafe/TitleList/TitleInfo.h
+++ b/src/Cafe/TitleList/TitleInfo.h
@@ -51,6 +51,18 @@ enum class CosCapabilityBits : uint64
 	All = 0xFFFFFFFFFFFFFFFFull
 };
 
+inline CosCapabilityBits operator|(CosCapabilityBits a, CosCapabilityBits b)
+{
+    return static_cast<CosCapabilityBits>(
+        static_cast<uint64>(a) | static_cast<uint64>(b));
+}
+
+inline CosCapabilityBits& operator|=(CosCapabilityBits& a, CosCapabilityBits b)
+{
+    a = a | b;
+    return a;
+}
+
 enum class CosCapabilityBitsFS : uint64
 {
 	ODD_READ         = (1llu << 0),


### PR DESCRIPTION
Allows overriding cos.xml permission masks in `rules.txt`, using the newly added `Permissions` section.

Example:
```
[Permissions]
FS = 0xFFFFFFFFFFFFFFFF
UHS = 0x100
```