### PR TITLE
Make CMake ask for fmt 12.1 instead of 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ find_package(ZLIB REQUIRED)
 find_package(zstd MODULE REQUIRED) # MODULE so that zstd::zstd is available
 find_package(OpenSSL COMPONENTS Crypto SSL REQUIRED)
 find_package(glm REQUIRED)
-find_package(fmt 12 REQUIRED)
+find_package(fmt 12.1 REQUIRED)
 find_package(PNG REQUIRED)
 
 if(ENABLE_SDL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ find_package(ZLIB REQUIRED)
 find_package(zstd MODULE REQUIRED) # MODULE so that zstd::zstd is available
 find_package(OpenSSL COMPONENTS Crypto SSL REQUIRED)
 find_package(glm REQUIRED)
-find_package(fmt 9 REQUIRED)
+find_package(fmt 12 REQUIRED)
 find_package(PNG REQUIRED)
 
 if(ENABLE_SDL)


### PR DESCRIPTION
I imagine this was unnoticed when the vcpkg was changed. It's strange that CMake was just fine with it