### PR TITLE
Clean up includes in MainWindow and remove duplicate helper

### DIFF
--- a/src/Cemu/nex/nex.h
+++ b/src/Cemu/nex/nex.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "nexTypes.h"
-#include<mutex>
+#include <mutex>
 
 const int NEX_PROTOCOL_AUTHENTICATION = 0xA;
 const int NEX_PROTOCOL_SECURE = 0xB;

--- a/src/gui/wxgui/MainWindow.cpp
+++ b/src/gui/wxgui/MainWindow.cpp
@@ -1,76 +1,67 @@
-#include "Cafe/HW/Latte/Renderer/Renderer.h"
-#include "interface/WindowSystem.h"
-#include "wxCemuConfig.h"
-#include "wxgui/wxgui.h"
-#include "wxgui/MainWindow.h"
-#include "wxgui/GameUpdateWindow.h"
-#include "wxgui/PadViewFrame.h"
-#include "wxgui/windows/TextureRelationViewer/TextureRelationWindow.h"
-#include "wxgui/windows/PPCThreadsViewer/DebugPPCThreadsWindow.h"
+#include "MainWindow.h"
+
+// subwindows
+#include "TitleManager.h"
+#include "GeneralSettings2.h"
+#include "GameUpdateWindow.h"
+#include "CemuUpdateWindow.h"
+#include "GraphicPacksWindow2.h"
 #include "AudioDebuggerWindow.h"
-#ifdef ENABLE_OPENGL
-#include "wxgui/canvas/OpenGLCanvas.h"
-#endif
-#ifdef ENABLE_VULKAN
-#include "wxgui/canvas/VulkanCanvas.h"
-#include "Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.h"
-#endif
-#ifdef ENABLE_METAL
-#include "wxgui/canvas/MetalCanvas.h"
-#include "Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h"
-#endif
-#include "Cafe/OS/libs/nfc/nfc.h"
-#include "Cafe/OS/libs/swkbd/swkbd.h"
-#include "wxgui/debugger/DebuggerWindow2.h"
-#include "util/helpers/helpers.h"
-#include "config/CemuConfig.h"
-#include "Cemu/DiscordPresence/DiscordPresence.h"
-#include "util/ScreenSaver/ScreenSaver.h"
-#include "wxgui/GeneralSettings2.h"
-#include "wxgui/GraphicPacksWindow2.h"
-#include "wxgui/CemuApp.h"
-#include "wxgui/CemuUpdateWindow.h"
-#include "wxgui/LoggingWindow.h"
-#include "config/ActiveSettings.h"
-#include "config/LaunchSettings.h"
+#include "input/InputSettings2.h"
+#include "input/HotkeySettings.h"
+#include "debugger/DebuggerWindow2.h"
+#include "EmulatedUSBDevices/EmulatedUSBDeviceFrame.h"
+#include "windows/PPCThreadsViewer/DebugPPCThreadsWindow.h"
+#include "windows/TextureRelationViewer/TextureRelationWindow.h"
 
-#include "Cafe/Filesystem/FST/FST.h"
-
-#include "wxgui/TitleManager.h"
-#include "wxgui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h"
-
-#include "Cafe/CafeSystem.h"
-
-#include "util/helpers/SystemException.h"
-#include "wxgui/DownloadGraphicPacksWindow.h"
-#include "wxgui/GettingStartedDialog.h"
-#include "wxgui/helpers/wxHelpers.h"
-#include "wxgui/input/InputSettings2.h"
-#include "wxgui/input/HotkeySettings.h"
-#include "input/InputManager.h"
-
-#if BOOST_OS_WINDOWS
-#define exit(__c) ExitProcess(__c)
-#else
-#define exit(__c) _Exit(__c)
-#endif
+//wxgui + misc.
+#include "wxgui.h"
+#include "wxCemuConfig.h"
+#include "interface/WindowSystem.h"
+#include "wxHelper.h"
+#include "helpers/wxHelpers.h"
+#include "PadViewFrame.h"
 
 #if BOOST_OS_LINUX || BOOST_OS_MACOS || BOOST_OS_BSD
 #include "resource/embedded/resources.h"
 #endif
 
-#if ( BOOST_OS_LINUX || BOOST_OS_BSD ) && HAS_WAYLAND
-#include "wxgui/helpers/wxWayland.h"
-#endif
+// settings
+#include "config/CemuConfig.h"
+#include "config/LaunchSettings.h"
+#include "config/ActiveSettings.h"
 
-//GameMode support
-#if BOOST_OS_LINUX && defined(ENABLE_FERAL_GAMEMODE)
-#include "gamemode_client.h"
-#endif
-
-#include "Cafe/TitleList/TitleInfo.h"
+// External functionality headers
+#include "input/InputManager.h"
 #include "Cafe/TitleList/TitleList.h"
-#include "wxHelper.h"
+#include "Cemu/DiscordPresence/DiscordPresence.h"
+#include "util/ScreenSaver/ScreenSaver.h"
+#include "util/helpers/SystemException.h"
+#include "Cafe/HW/Latte/Renderer/Vulkan/VsyncDriver.h"
+#if BOOST_OS_LINUX && defined(ENABLE_FERAL_GAMEMODE)
+#include <gamemode_client.h>
+#endif
+#if ( BOOST_OS_LINUX || BOOST_OS_BSD ) && HAS_WAYLAND
+#include "helpers/wxWayland.h"
+#endif
+
+// Renderer Canvasses
+#ifdef ENABLE_OPENGL
+#include "canvas/OpenGLCanvas.h"
+#endif
+#ifdef ENABLE_VULKAN
+#include "canvas/VulkanCanvas.h"
+#endif
+#ifdef ENABLE_METAL
+#include "canvas/MetalCanvas.h"
+#include "Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h"
+#endif
+
+//Cafe libs
+#include "Cafe/OS/libs/nfc/nfc.h"
+#include "Cafe/OS/libs/swkbd/swkbd.h"
+
+#include "Cafe/HW/Latte/Renderer/Renderer.h" // For renderer API checks
 
 extern WindowSystem::WindowInfo g_window_info;
 extern std::shared_mutex g_mutex;

--- a/src/input/api/InputAPI.h
+++ b/src/input/api/InputAPI.h
@@ -46,7 +46,7 @@ namespace InputAPI
 			break;
 		}
 
-		throw std::runtime_error(fmt::format("unknown input api: {}", to_underlying(type)));
+		throw std::runtime_error(fmt::format("unknown input api: {}", stdx::to_underlying(type)));
 	}
 
 	constexpr Type from_string(std::string_view str)

--- a/src/input/emulated/EmulatedController.cpp
+++ b/src/input/emulated/EmulatedController.cpp
@@ -16,7 +16,7 @@ std::string_view EmulatedController::type_to_string(Type type)
 	case Wiimote: return "Wiimote";
 	}
 
-	throw std::runtime_error(fmt::format("unknown emulated controller: {}", to_underlying(type)));
+	throw std::runtime_error(fmt::format("unknown emulated controller: {}", stdx::to_underlying(type)));
 }
 
 EmulatedController::Type EmulatedController::type_from_string(std::string_view str)

--- a/src/input/emulated/EmulatedController.h
+++ b/src/input/emulated/EmulatedController.h
@@ -135,6 +135,6 @@ struct fmt::formatter<EmulatedController::Type> : formatter<string_view> {
 		case EmulatedController::Type::Classic: return formatter<string_view>::format("Wii U Classic Controller Pro", ctx);
 		case EmulatedController::Type::Wiimote: return formatter<string_view>::format("Wiimote", ctx);
 		}
-		throw std::invalid_argument(fmt::format("invalid emulated controller type with value {}", to_underlying(v)));
+		throw std::invalid_argument(fmt::format("invalid emulated controller type with value {}", stdx::to_underlying(v)));
 	}
 };

--- a/src/util/helpers/helpers.h
+++ b/src/util/helpers/helpers.h
@@ -12,12 +12,6 @@
 #include "Common/unix/fast_float.h"
 #endif
 
-template <typename TType>
-constexpr auto to_underlying(TType v) noexcept
-{
-	return static_cast<std::underlying_type_t<TType>>(v);
-}
-
 // wrapper to allow reverse iteration with range-based loops before C++20
 template<typename T>
 class reverse_itr {


### PR DESCRIPTION
Here is a good overview of the differences in MainWindow.cpp
<img width="1704" height="955" alt="image" src="https://github.com/user-attachments/assets/5b2bbba3-2727-4274-9a38-523b824c3dd5" />


CafeSystem is included from MainWindow.h, likewise for LoggingWindow.h
TitleInfo is included from TitleList, which is already included.
If relying on cascading includes like this is undesired I can add them back.

As far as I can tell the following were entirely unused in MainWindow.cpp:
- Cafe/Filesystem/FST/FST.h
- CemuApp.h
- DownloadGraphicPacksWindow.h
- GettingStartedDialog.h
- util/helpers/helpers.h

I've also removed the duplicate to_underlying in favor of the new one in precompiled.h