### PR TITLE
flush logs when forwarding

### DIFF
--- a/src/Cafe/OS/libs/coreinit/coreinit_Misc.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Misc.cpp
@@ -561,6 +561,7 @@ namespace coreinit
 		if (s_forwardConsoleLogs) {
 			if (cafeLogType == CafeLogType::OSCONSOLE) {
 				fwrite(msg, 1, len, stdout);
+				fflush(stdout);
 			} else {
 				fwrite(msg, 1, len, stderr);
 			}


### PR DESCRIPTION
I was running into some errors with my test binaries where CEMU would exit before the test binary had finished printing everything it needed to (only when piping the output to a file, or another process like jq). Sleeping in the program itself doesn't help, because that doesn't affect CEMU's log flushing to stdout.

I figure if you want to forward console logs you always want to see them, so always flush stdout (make it behave similar to stderr).