### PR TITLE
CI: homebrew - Untap aws and azure to silence warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,7 @@ jobs:
     - name: "Install system dependencies"
       run: |
         brew update
+        brew untap aws/tap azure/bicep
         brew install nasm automake libtool
 
     - name: "Install molten-vk"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,8 +230,10 @@ jobs:
 
     - name: "Install system dependencies"
       run: |
-        brew update
+        # Removing azure/bicep and aws to silence warnings in Github Actions
+        brew uninstall bicep
         brew untap aws/tap azure/bicep
+        brew update
         brew install nasm automake libtool
 
     - name: "Install molten-vk"


### PR DESCRIPTION
Homebrew emits 8 warnings about `aws` and `azure` taps not being trusted. I presume these are pre-installed in Github Actions runners. 

I don't think these are required for macOS builds, so this PR untaps them. Should silence the warnings. 