### PR TITLE
dependency update, correctness/security fixes, CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,7 @@ jobs:
     - name: "Install molten-vk"
       run: |
         curl -L -O https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.1/MoltenVK-macos-privateapi.tar
+        echo "5e662d77f7f280d9bd692ac5d626831198f404e28b0c8d4d11aac04bff8ff418  MoltenVK-macos-privateapi.tar" | shasum -a 256 -c -
         tar xf MoltenVK-macos-privateapi.tar
         sudo mkdir -p /usr/local/lib
         sudo cp MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib /usr/local/lib

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
 
+# Cancel superseded runs for the same ref to save CI minutes
+concurrency:
+  group: build-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/determine_release_version.yml
+++ b/.github/workflows/determine_release_version.yml
@@ -45,8 +45,7 @@ jobs:
             exit 1
           fi
 
-          echo "::set-output name=tag::$ALL_TAGS"
-          # echo "tag=$ALL_TAGS" >> $GITHUB_STATE
+          echo "tag=$ALL_TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Calculate next semver minor
         id: calculate_next_version

--- a/src/Cafe/Filesystem/WUD/wud.cpp
+++ b/src/Cafe/Filesystem/WUD/wud.cpp
@@ -43,8 +43,20 @@ wud_t* wud_open(const fs::path& path)
 		wud->offsetSectorArray = (wud->offsetSectorArray + (long long)(wud->sectorSize-1));
 		wud->offsetSectorArray = wud->offsetSectorArray - (wud->offsetSectorArray%(long long)wud->sectorSize);
 		// read index table
-		unsigned int indexTableSize = sizeof(unsigned int) * wud->indexTableEntryCount;
+		uint64 indexTableSize64 = (uint64)sizeof(unsigned int) * (uint64)wud->indexTableEntryCount;
+		if (indexTableSize64 == 0 || indexTableSize64 > 0x40000000ull || indexTableSize64 > (uint64)inputFileSize)
+		{
+			// reject implausible/crafted index table sizes to avoid integer overflow and over-allocation
+			wud_close(wud);
+			return nullptr;
+		}
+		unsigned int indexTableSize = (unsigned int)indexTableSize64;
 		wud->indexTable = (unsigned int*)malloc(indexTableSize);
+		if (!wud->indexTable)
+		{
+			wud_close(wud);
+			return nullptr;
+		}
 		wud->fs->SetPosition(wud->offsetIndexTable);
 		if( wud->fs->readData(wud->indexTable, indexTableSize) != indexTableSize )
 		{

--- a/src/Cafe/Filesystem/WUHB/WUHBReader.cpp
+++ b/src/Cafe/Filesystem/WUHB/WUHBReader.cpp
@@ -115,6 +115,8 @@ uint32 WUHBReader::GetHashTableEntryOffset(uint32 hash, bool isFile) const
 	const uint64 hash_table_ofs = (isFile ? m_header.file_hash_table_ofs : m_header.dir_hash_table_ofs);
 
 	const uint64 hash_table_entry_count = hash_table_size / sizeof(uint32);
+	if (hash_table_entry_count == 0)
+		return ROMFS_ENTRY_EMPTY;
 	const uint64 hash_table_entry_offset = hash_table_ofs + (hash % hash_table_entry_count) * sizeof(uint32);
 
 	m_fileIn->SetPosition(hash_table_entry_offset);
@@ -131,10 +133,15 @@ uint32 WUHBReader::GetHashTableEntryOffset(uint32 hash, bool isFile) const
 template<bool T>
 bool WUHBReader::SearchHashList(uint32& entryOffset, const fs::path& targetName) const
 {
-	for (;;)
+	for (uint32 iterations = 0; ; iterations++)
 	{
 		if (entryOffset == ROMFS_ENTRY_EMPTY)
 			return false;
+		if (iterations >= 0x100000)
+		{
+			cemuLog_log(LogType::Force, "WUHB: aborting suspected cyclic hash chain");
+			return false;
+		}
 		auto entry = GetEntry<T>(entryOffset);
 
 		if (entry.name == targetName)

--- a/src/Cafe/Filesystem/fscDeviceWuhb.cpp
+++ b/src/Cafe/Filesystem/fscDeviceWuhb.cpp
@@ -75,7 +75,8 @@ class FSCDeviceWuhbFileCtx : public FSCVirtualFile
 				dirEntry->isDirectory = true;
 				dirEntry->isFile = false;
 				dirEntry->fileSize = 0;
-				std::strncpy(dirEntry->path, entry.name.c_str(), FSC_MAX_DIR_NAME_LENGTH);
+				std::strncpy(dirEntry->path, entry.name.c_str(), FSC_MAX_DIR_NAME_LENGTH - 1);
+				dirEntry->path[FSC_MAX_DIR_NAME_LENGTH - 1] = '\0';
 				return true;
 			}
 		}
@@ -88,7 +89,8 @@ class FSCDeviceWuhbFileCtx : public FSCVirtualFile
 				dirEntry->isDirectory = false;
 				dirEntry->isFile = true;
 				dirEntry->fileSize = entry.size;
-				std::strncpy(dirEntry->path, entry.name.c_str(), FSC_MAX_DIR_NAME_LENGTH);
+				std::strncpy(dirEntry->path, entry.name.c_str(), FSC_MAX_DIR_NAME_LENGTH - 1);
+				dirEntry->path[FSC_MAX_DIR_NAME_LENGTH - 1] = '\0';
 				return true;
 			}
 		}

--- a/src/Cafe/HW/Espresso/Recompiler/IML/IMLInstruction.h
+++ b/src/Cafe/HW/Espresso/Recompiler/IML/IMLInstruction.h
@@ -47,7 +47,7 @@ public:
 		//m_raw |= (uint32)regId;
 	}
 
-	IMLReg(const IMLReg& other) : m_raw(other.m_raw) {}
+	IMLReg(const IMLReg& other) = default;
 
 	IMLRegFormat GetBaseFormat() const
 	{
@@ -351,10 +351,7 @@ struct IMLUsedRegisters
 struct IMLInstruction
 {
 	IMLInstruction() {}
-	IMLInstruction(const IMLInstruction& other) 
-	{
-		memcpy(this, &other, sizeof(IMLInstruction));
-	}
+	IMLInstruction(const IMLInstruction& other) = default;
 
 	uint8 type;
 	uint8 operation;

--- a/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocator.h
+++ b/src/Cafe/HW/Espresso/Recompiler/IML/IMLRegisterAllocator.h
@@ -63,19 +63,7 @@ public:
 	IMLPhysReg GetFirstAvailableReg()
 	{
 		cemu_assert_debug(m_regBitmask != 0);
-		sint32 regIndex = 0;
-		auto tmp = m_regBitmask;
-		while ((tmp & 0xFF) == 0)
-		{
-			regIndex += 8;
-			tmp >>= 8;
-		}
-		while ((tmp & 0x1) == 0)
-		{
-			regIndex++;
-			tmp >>= 1;
-		}
-		return regIndex;
+		return (IMLPhysReg)std::countr_zero(m_regBitmask);
 	}
 
 	// returns index of next available register (search includes any register index >= startIndex)
@@ -84,22 +72,10 @@ public:
 	{
 		if (startIndex >= 64)
 			return -1;
-		uint32 regIndex = startIndex;
-		auto tmp = m_regBitmask;
-		tmp >>= regIndex;
+		uint64 tmp = m_regBitmask >> startIndex;
 		if (!tmp)
 			return -1;
-		while ((tmp & 0xFF) == 0)
-		{
-			regIndex += 8;
-			tmp >>= 8;
-		}
-		while ((tmp & 0x1) == 0)
-		{
-			regIndex++;
-			tmp >>= 1;
-		}
-		return regIndex;
+		return startIndex + (IMLPhysReg)std::countr_zero(tmp);
 	}
 
 	sint32 CountAvailableRegs() const

--- a/src/Cafe/HW/Espresso/Recompiler/PPCRecompilerImlGen.cpp
+++ b/src/Cafe/HW/Espresso/Recompiler/PPCRecompilerImlGen.cpp
@@ -1545,7 +1545,7 @@ bool PPCRecompilerImlGen_STWCX(ppcImlGenContext_t* ppcImlGenContext, uint32 opco
 	IMLReg regCrGT = _GetRegCR(ppcImlGenContext, 0, Espresso::CR_BIT_INDEX_GT);
 	IMLReg regCrEQ = _GetRegCR(ppcImlGenContext, 0, Espresso::CR_BIT_INDEX_EQ);
 	IMLReg regCrSO = _GetRegCR(ppcImlGenContext, 0, Espresso::CR_BIT_INDEX_SO);
-	IMLReg regXerSO = _GetRegCR(ppcImlGenContext, 0, Espresso::CR_BIT_INDEX_SO);
+	IMLReg regXerSO = PPCRecompilerImlGen_loadRegister(ppcImlGenContext, PPCREC_NAME_XER_SO);
 	ppcImlGenContext->emitInst().make_r_s32(PPCREC_IML_OP_ASSIGN, regCrLT, 0);
 	ppcImlGenContext->emitInst().make_r_s32(PPCREC_IML_OP_ASSIGN, regCrGT, 0);
 	ppcImlGenContext->emitInst().make_r_r(PPCREC_IML_OP_ASSIGN, regCrSO, regXerSO);

--- a/src/Cafe/HW/Latte/Core/FetchShader.cpp
+++ b/src/Cafe/HW/Latte/Core/FetchShader.cpp
@@ -252,11 +252,10 @@ void _fetchShaderDecompiler_parseInstruction_VTX_SEMANTIC(LatteFetchShader* pars
 	}
 	// add attribute
 	sint32 groupAttribIndex = attribGroup->attribCount;
-	if (attribGroup->attribCount < (groupAttribIndex + 1))
-	{
-		attribGroup->attribCount = (groupAttribIndex + 1);
-		attribGroup->attrib = (LatteParsedFetchShaderAttribute_t*)realloc(attribGroup->attrib, sizeof(LatteParsedFetchShaderAttribute_t) * attribGroup->attribCount);
-	}
+	attribGroup->attribCount = groupAttribIndex + 1;
+	// grow the attribute array with power-of-two capacity to avoid O(n^2) reallocation as attributes are appended
+	if ((attribGroup->attribCount & (attribGroup->attribCount - 1)) == 0)
+		attribGroup->attrib = (LatteParsedFetchShaderAttribute_t*)realloc(attribGroup->attrib, sizeof(LatteParsedFetchShaderAttribute_t) * (size_t)attribGroup->attribCount * 2);
 	attribGroup->attrib[groupAttribIndex].semanticId = semanticId;
 	attribGroup->attrib[groupAttribIndex].format = (uint8)dataFormat;
 	attribGroup->attrib[groupAttribIndex].fetchType = fetchType;

--- a/src/Cafe/HW/Latte/Core/FetchShader.cpp
+++ b/src/Cafe/HW/Latte/Core/FetchShader.cpp
@@ -170,10 +170,13 @@ void LatteFetchShader::CalculateFetchShaderVkHash()
 	EVP_DigestFinal_ex(ctx, shaDigest, NULL);
 	EVP_MD_CTX_free(ctx);
 
-	// fold SHA1 hash into a 64bit value
-	uint64 h = *(uint64*)(shaDigest + 0);
-	h += *(uint64*)(shaDigest + 8);
-	h += (uint64)*(uint32*)(shaDigest + 16);
+	// fold SHA1 hash into a 64bit value (use memcpy to avoid unaligned/strict-aliasing UB)
+	uint64 shaLow, shaMid;
+	uint32 shaHigh;
+	std::memcpy(&shaLow, shaDigest + 0, sizeof(shaLow));
+	std::memcpy(&shaMid, shaDigest + 8, sizeof(shaMid));
+	std::memcpy(&shaHigh, shaDigest + 16, sizeof(shaHigh));
+	uint64 h = shaLow + shaMid + (uint64)shaHigh;
 	this->vkPipelineHashFragment = h;
 }
 
@@ -604,7 +607,7 @@ void LatteFetchShader::UnregisterInCache()
 		return;
 	s_spinlockFetchShaderCache.lock();
 	auto itr = s_fetchShaderByHash.find(m_cacheHash);
-	cemu_assert(itr == s_fetchShaderByHash.end());
+	cemu_assert(itr != s_fetchShaderByHash.end());
 	s_fetchShaderByHash.erase(itr);
 	s_spinlockFetchShaderCache.unlock();
 }

--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -187,6 +187,7 @@ void LatteSHRC_RemoveFromCaches(LatteDecompilerShader* shader)
 				removed = true;
 				break;
 			}
+			shaderChain = shaderChain->next;
 		}
 	}
 	cemu_assert(removed);
@@ -355,7 +356,7 @@ void LatteShader_CreateRendererShader(LatteDecompilerShader* shader, bool compil
 		shader->isCustomShader = true;
 	}
 	else
-		shaderSrc.assign(shader->strBuf_shaderSource->c_str());
+		shaderSrc.assign(shader->strBuf_shaderSource->c_str(), shader->strBuf_shaderSource->getLen());
 
 	if (shaderType == RendererShader::ShaderType::kVertex &&
 		(shader->baseHash == 0x15bc7edf9de2ed30 || shader->baseHash == 0x83a697d61a3b9202 ||

--- a/src/Cafe/HW/Latte/Core/LatteTextureCache.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureCache.cpp
@@ -159,7 +159,7 @@ uint32 LatteTexture_CalculateTextureDataHash(LatteTexture* hostTexture)
 					h256 = _mm256_xor_si256(h256, temp);
 				}
 #ifdef __clang__
-				hashVal = h256[0] + h256[1] + h256[2] + h256[3] + h256[4] + h256[5] + h256[6] + h256[7];
+				hashVal = (uint32)h256[0] + (uint32)(h256[0] >> 32) + (uint32)h256[1] + (uint32)(h256[1] >> 32) + (uint32)h256[2] + (uint32)(h256[2] >> 32) + (uint32)h256[3] + (uint32)(h256[3] >> 32);
 #else
 				hashVal = h256.m256i_u32[0] + h256.m256i_u32[1] + h256.m256i_u32[2] + h256.m256i_u32[3] + h256.m256i_u32[4] + h256.m256i_u32[5] + h256.m256i_u32[6] + h256.m256i_u32[7];
 #endif

--- a/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTextureReadback.cpp
@@ -151,11 +151,11 @@ void LatteTextureReadback_UpdateFinishedTransfers(bool forceFinish)
 		LatteTextureView* origTexView = LatteTextureViewLookupCache::lookupSlice(readbackInfo->hostTextureCopy.physAddress, readbackInfo->hostTextureCopy.width, readbackInfo->hostTextureCopy.height, readbackInfo->hostTextureCopy.pitch, 0, 0, readbackInfo->hostTextureCopy.format);
 		if (origTexView)
 			LatteTC_ResetTextureChangeTracker(origTexView->baseTexture, true);
-		delete readbackInfo;
 		// remove from queue
 		cemu_assert_debug(!sTextureActiveReadbackQueue.empty());
 		cemu_assert_debug(readbackInfo == sTextureActiveReadbackQueue.front());
 		sTextureActiveReadbackQueue.pop();
+		delete readbackInfo;
 	}
 	performanceMonitor.gpuTime_waitForAsync.endMeasuring();
 }

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h
@@ -535,9 +535,9 @@ private:
 	MetalEncoderType m_encoderType = MetalEncoderType::None;
 	MTL::CommandEncoder* m_commandEncoder = nullptr;
 
-    uint32 m_recordedDrawcalls;
-    uint32 m_defaultCommitTreshlod;
-    uint32 m_commitTreshold;
+	uint32 m_recordedDrawcalls = 0;
+	uint32 m_defaultCommitTreshlod = 0;
+	uint32 m_commitTreshold = 0;
 
 	// State
 	MetalState m_state;

--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRendererCore.cpp
@@ -1772,6 +1772,7 @@ void VulkanRenderer::draw_updateVertexBuffersDirectAccess()
 		VkBuffer attrBuffer = m_importedMem;
 		VkDeviceSize attrOffset = bufferAddress - m_importedMemBaseAddress;
 		vkCmdBindVertexBuffers(m_state.currentCommandBuffer, bufferIndex, 1, &attrBuffer, &attrOffset);
+		m_state.currentVertexBinding[bufferIndex].offset = bufferAddress;
 	}
 }
 

--- a/src/Cafe/IOSU/fsa/iosu_fsa.cpp
+++ b/src/Cafe/IOSU/fsa/iosu_fsa.cpp
@@ -556,7 +556,8 @@ namespace iosu
 			FSCDirEntry fscDirEntry;
 			if (fsc_nextDir(fscFile, &fscDirEntry) == false)
 				return FSA_RESULT::END_OF_DIRECTORY;
-			strcpy(dirEntryOut->name, fscDirEntry.path);
+			strncpy(dirEntryOut->name, fscDirEntry.path, sizeof(dirEntryOut->name));
+			dirEntryOut->name[sizeof(dirEntryOut->name) - 1] = '\0';
 			FSFlag statFlag = FSFlag::NONE;
 			dirEntryOut->stat.size = 0;
 			if (fscDirEntry.isDirectory)

--- a/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_Thread.cpp
@@ -154,8 +154,13 @@ namespace coreinit
 		}
 		if (alreadyActive == false)
 		{
-			activeThread[activeThreadCount] = threadMPTR;
-			activeThreadCount++;
+			if (activeThreadCount < 256)
+			{
+				activeThread[activeThreadCount] = threadMPTR;
+				activeThreadCount++;
+			}
+			else
+				cemuLog_log(LogType::Force, "coreinit: active thread list is full, cannot register thread");
 		}
 
 		__OSCreateHostThread(thread);

--- a/src/Common/betype.h
+++ b/src/Common/betype.h
@@ -157,7 +157,7 @@ public:
 		return *this;
 	}
 
-	betype<T>& operator|(const betype<T>& v) const requires (requires (T& x, const T& y) { x | y; })
+	betype<T> operator|(const betype<T>& v) const requires (requires (T& x, const T& y) { x | y; })
 	{
 		betype<T> tmp(*this);
 		tmp.m_value = tmp.m_value | v.m_value;

--- a/src/util/MemMapper/MemMapperUnix.cpp
+++ b/src/util/MemMapper/MemMapperUnix.cpp
@@ -32,7 +32,8 @@ namespace MemMapper
 
 	void* ReserveMemory(void* baseAddr, size_t size, PAGE_PERMISSION permissionFlags)
 	{
-		return mmap(baseAddr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		void* r = mmap(baseAddr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		return r == MAP_FAILED ? nullptr : r;
 	}
 
 	void FreeReservation(void* baseAddr, size_t size)
@@ -55,7 +56,11 @@ namespace MemMapper
                 r = nullptr;
 		}
 		else
+		{
 			r = mmap(baseAddr, size, GetProt(permissionFlags), MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+			if (r == MAP_FAILED)
+				r = nullptr;
+		}
 		return r;
 	}
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -81,6 +81,14 @@
     {
       "name": "wxwidgets",
       "version": "3.3.1"
+    },
+    {
+      "name": "openssl",
+      "version": "3.6.2"
+    },
+    {
+      "name": "curl",
+      "version": "8.20.0"
     }
   ]
 }


### PR DESCRIPTION
All-in-one review pass. Self-contained commits; low-risk changes (behaviour-preserving optimizations or bug fixes aligning a wrong path with an existing correct one).

## Dependencies (security)
- OpenSSL 3.5.0 -> 3.6.2, curl 8.14.1 -> 8.20.0 via targeted vcpkg overrides; builtin-baseline untouched. Vulkan-Headers + ZArchive update.

## Filesystem hardening (malformed disc/title files)
- WUD 64-bit index-table size + validation + malloc null-check; WUHB divide-by-zero + cyclic hash-chain guard; bounded NUL-terminated name copies (WUHB / FSA ReadDir).

## Core robustness
- MemMapperUnix mmap MAP_FAILED detection; bounded active-thread array; betype operator| returns by value.

## Latte (GPU)
- Shader-cache chain-removal infinite loop; redundant per-draw vkCmdBindVertexBuffers eliminated; clang __m256i OOB lane read; texture-readback use-after-free; inverted fetch-shader assertion; geometric growth for the fetch-shader attribute array.

## Espresso (CPU/JIT)
- stwcx. CR0[SO] fix; IML instructions trivially copyable; register-set bit scan -> std::countr_zero.

## CI
- Verify MoltenVK download checksum; PR concurrency cancellation; fix deprecated ::set-output.