### PR TITLE
Fix Mii Maker image export feature

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteTexture.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTexture.cpp
@@ -1307,8 +1307,9 @@ LatteTexture::LatteTexture(Latte::E_DIM dim, MPTR physAddress, MPTR physMipAddre
 			}
 		}
 	}
-	// determine if this texture should ever be mirrored to CPU RAM
-	if (this->tileMode == Latte::E_HWTILEMODE::TM_LINEAR_ALIGNED)
+	// determine if this texture should ever be mirrored to CPU RAM.
+	if (this->tileMode == Latte::E_HWTILEMODE::TM_LINEAR_ALIGNED ||
+		this->tileMode == Latte::E_HWTILEMODE::TM_LINEAR_GENERAL)
 	{
 		this->enableReadback = true;
 	}

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -275,7 +275,37 @@ namespace coreinit
 		cemuLog_log(LogType::Force, "FSShutdown called");
 	}
 
-	FS_RESULT FSAddClientEx(FSClient_t* fsClient, uint32 uknR4, uint32 errHandling)
+	/// Buffer for the notification passed to the FSAddClientEx callback.
+	/// Only the name at 0x18 ("sdcard") is read out of this from Mii Maker.
+	SysAllocator<uint8, 0x40> s_fsClientNotification;
+	// NOTE: Size is unknown, just using something generous.
+
+	/// Notifies the guest that the SD card is present when they
+	/// register a callback via FSAddClientEx's r4 parameter.
+	static void __FSInvokeNotificationSDCard(MPTR notifyParamMPTR)
+	{
+		constexpr uint32 nameOffset = 0x1c;
+
+		// The callback should be non-null before reaching this point.
+		MPTR callbackMPTR = memory_readU32(notifyParamMPTR + 0x00);
+		cemu_assert_debug(callbackMPTR != MPTR_NULL);
+		MPTR contextMPTR = memory_readU32(notifyParamMPTR + 0x04); // User object/context pointer.
+
+		// Zero-initialize the notification.
+		uint8* pNotification = s_fsClientNotification.GetPtr();
+		memset(pNotification, 0, s_fsClientNotification.GetByteSize());
+		// Copy the string "sdcard" into the notification at 0x18.
+		// Mii Maker USA v50 compares this at 0202e6a4
+		char* pMountName = reinterpret_cast<char*>(pNotification + nameOffset);
+		strcpy(pMountName, "sdcard");
+
+		// Invoke the user's callback. This happens synchronously in the same thread.
+		PPCCoreCallback(callbackMPTR,
+			0 /* r3 = Unknown */, 1 /* r4 = Set to 0 if not present */,
+			s_fsClientNotification.GetMPTR(), contextMPTR);
+	}
+
+	FS_RESULT FSAddClientEx(FSClient_t* fsClient, MPTR notifyParam, uint32 errHandling)
 	{
 		if (!sFSInitialized || sFSShutdown || !fsClient)
 		{
@@ -283,13 +313,13 @@ namespace coreinit
 			return FS_RESULT::FATAL_ERROR;
 		}
 		FSLockMutex();
-		if (uknR4 != 0)
+		if (notifyParam != MPTR_NULL)
 		{
-			uint32 uknValue = memory_readU32(uknR4 + 0x00);
-			if (uknValue == 0)
+			MPTR callbackMPTR = memory_readU32(notifyParam + 0x00);
+			if (callbackMPTR == MPTR_NULL)
 			{
 				FSUnlockMutex();
-				__FSErrorAndBlock("FSAddClientEx - unknown error");
+				__FSErrorAndBlock("FSAddClientEx: Notification parameter was passed, but the inner callback is null.");
 				return FS_RESULT::FATAL_ERROR;
 			}
 		}
@@ -324,6 +354,12 @@ namespace coreinit
 			fsClientBody->fsClientBodyNext = nullptr;
 		}
 		FSUnlockMutex();
+
+		// Emulate a notification that the SD card (always mounted) was
+		// attached, if the title (e.g. Mii Maker) specified a callback.
+		if (notifyParam != MPTR_NULL)
+			__FSInvokeNotificationSDCard(notifyParam);
+
 		return FS_RESULT::SUCCESS;
 	}
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -275,37 +275,7 @@ namespace coreinit
 		cemuLog_log(LogType::Force, "FSShutdown called");
 	}
 
-	/// Buffer for the notification passed to the FSAddClientEx callback.
-	/// Only the name at 0x18 ("sdcard") is read out of this from Mii Maker.
-	SysAllocator<uint8, 0x40> s_fsClientNotification;
-	// NOTE: Size is unknown, just using something generous.
-
-	/// Notifies the guest that the SD card is present when they
-	/// register a callback via FSAddClientEx's r4 parameter.
-	static void __FSInvokeNotificationSDCard(MPTR notifyParamMPTR)
-	{
-		constexpr uint32 nameOffset = 0x1c;
-
-		// The callback should be non-null before reaching this point.
-		MPTR callbackMPTR = memory_readU32(notifyParamMPTR + 0x00);
-		cemu_assert_debug(callbackMPTR != MPTR_NULL);
-		MPTR contextMPTR = memory_readU32(notifyParamMPTR + 0x04); // User object/context pointer.
-
-		// Zero-initialize the notification.
-		uint8* pNotification = s_fsClientNotification.GetPtr();
-		memset(pNotification, 0, s_fsClientNotification.GetByteSize());
-		// Copy the string "sdcard" into the notification at 0x18.
-		// Mii Maker USA v50 compares this at 0202e6a4
-		char* pMountName = reinterpret_cast<char*>(pNotification + nameOffset);
-		strcpy(pMountName, "sdcard");
-
-		// Invoke the user's callback. This happens synchronously in the same thread.
-		PPCCoreCallback(callbackMPTR,
-			0 /* r3 = Unknown */, 1 /* r4 = Set to 0 if not present */,
-			s_fsClientNotification.GetMPTR(), contextMPTR);
-	}
-
-	FS_RESULT FSAddClientEx(FSClient_t* fsClient, MPTR notifyParam, uint32 errHandling)
+	FS_RESULT FSAddClientEx(FSClient_t* fsClient, uint32 uknR4, uint32 errHandling)
 	{
 		if (!sFSInitialized || sFSShutdown || !fsClient)
 		{
@@ -313,13 +283,13 @@ namespace coreinit
 			return FS_RESULT::FATAL_ERROR;
 		}
 		FSLockMutex();
-		if (notifyParam != MPTR_NULL)
+		if (uknR4 != 0)
 		{
-			MPTR callbackMPTR = memory_readU32(notifyParam + 0x00);
-			if (callbackMPTR == MPTR_NULL)
+			uint32 uknValue = memory_readU32(uknR4 + 0x00);
+			if (uknValue == 0)
 			{
 				FSUnlockMutex();
-				__FSErrorAndBlock("FSAddClientEx: Notification parameter was passed, but the inner callback is null.");
+				__FSErrorAndBlock("FSAddClientEx - unknown error");
 				return FS_RESULT::FATAL_ERROR;
 			}
 		}
@@ -354,12 +324,6 @@ namespace coreinit
 			fsClientBody->fsClientBodyNext = nullptr;
 		}
 		FSUnlockMutex();
-
-		// Emulate a notification that the SD card (always mounted) was
-		// attached, if the title (e.g. Mii Maker) specified a callback.
-		if (notifyParam != MPTR_NULL)
-			__FSInvokeNotificationSDCard(notifyParam);
-
 		return FS_RESULT::SUCCESS;
 	}
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -275,7 +275,23 @@ namespace coreinit
 		cemuLog_log(LogType::Force, "FSShutdown called");
 	}
 
-	FS_RESULT FSAddClientEx(FSClient_t* fsClient, uint32 uknR4, uint32 errHandling)
+	struct AttachCallbackData
+	{
+		/* +0x00 */ uint8 unk[0x1c];
+		/* +0x1c */ char mountName[8];
+	};
+
+	SysAllocator<AttachCallbackData> s_fsAttachCallbackData;
+
+	void invokeAttachCallback(FSAttachParams& attachParams)
+	{
+		*s_fsAttachCallbackData = { .mountName = "sdcard" /* expected by Mii Maker */ };
+		PPCCoreCallback(attachParams.userCallback,
+			0 /* r3 = unknown */, 1 /* r4 = non-zero means device is attached */,
+			s_fsAttachCallbackData.GetMPTR(), attachParams.userContext);
+	}
+
+	FS_RESULT FSAddClientEx(FSClient_t* fsClient, FSAttachParams* attachParams, uint32 errHandling)
 	{
 		if (!sFSInitialized || sFSShutdown || !fsClient)
 		{
@@ -283,15 +299,13 @@ namespace coreinit
 			return FS_RESULT::FATAL_ERROR;
 		}
 		FSLockMutex();
-		if (uknR4 != 0)
+		if (attachParams != nullptr &&
+			attachParams->userCallback == nullptr)
 		{
-			uint32 uknValue = memory_readU32(uknR4 + 0x00);
-			if (uknValue == 0)
-			{
-				FSUnlockMutex();
-				__FSErrorAndBlock("FSAddClientEx - unknown error");
-				return FS_RESULT::FATAL_ERROR;
-			}
+			FSUnlockMutex();
+			// "FS: FSAddClient: attachParams->userCallback must be set.\n"
+			__FSErrorAndBlock("FSAddClientEx - unknown error");
+			return FS_RESULT::FATAL_ERROR;
 		}
 		if (__FSIsClientRegistered(__FSGetClientBody(fsClient)))
 		{
@@ -324,12 +338,16 @@ namespace coreinit
 			fsClientBody->fsClientBodyNext = nullptr;
 		}
 		FSUnlockMutex();
+
+		if (attachParams != nullptr) // invoke right before returning
+			invokeAttachCallback(*attachParams);
+
 		return FS_RESULT::SUCCESS;
 	}
 
 	FS_RESULT FSAddClient(FSClient_t* fsClient, uint32 errHandling)
 	{
-		return FSAddClientEx(fsClient, 0, errHandling);
+		return FSAddClientEx(fsClient, nullptr, errHandling);
 	}
 
 	FS_RESULT FSDelClient(FSClient_t* fsClient, uint32 errHandling)

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.cpp
@@ -570,6 +570,7 @@ namespace coreinit
 		case FSA_CMD_OPERATION_TYPE::MAKEDIR:
 		case FSA_CMD_OPERATION_TYPE::REMOVE:
 		case FSA_CMD_OPERATION_TYPE::RENAME:
+		case FSA_CMD_OPERATION_TYPE::REWINDDIR:
 		case FSA_CMD_OPERATION_TYPE::CLOSEDIR:
 		case FSA_CMD_OPERATION_TYPE::READ:
 		case FSA_CMD_OPERATION_TYPE::WRITE:
@@ -2718,6 +2719,8 @@ namespace coreinit
 		cafeExportRegister("coreinit", FSReadDir, LogType::CoreinitFile);
 		cafeExportRegister("coreinit", FSCloseDirAsync, LogType::CoreinitFile);
 		cafeExportRegister("coreinit", FSCloseDir, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSRewindDirAsync, LogType::CoreinitFile);
+		cafeExportRegister("coreinit", FSRewindDir, LogType::CoreinitFile);
 
 		// stat
 		cafeExportRegister("coreinit", FSGetFreeSpaceSizeAsync, LogType::CoreinitFile);

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.h
@@ -18,6 +18,13 @@ struct FSAsyncParams
 };
 static_assert(sizeof(FSAsyncParams) == 0xC);
 
+struct FSAttachParams
+{
+	MEMPTR<void> userCallback;
+	MEMPTR<void> userContext;
+};
+static_assert(sizeof(FSAttachParams) == 0x8);
+
 namespace coreinit
 {
 	struct FSCmdBlockBody;
@@ -242,7 +249,7 @@ namespace coreinit
 	sint32 __FSQueryInfoAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, uint8* queryString, uint32 queryType, void* queryResult, uint32 errHandling, FSAsyncParams* fsAsyncParams);
 
 	// coreinit exports
-	FS_RESULT FSAddClientEx(FSClient_t* fsClient, uint32 uknR4, uint32 errHandling);
+	FS_RESULT FSAddClientEx(FSClient_t* fsClient, FSAttachParams* attachParams, uint32 errHandling);
 	FS_RESULT FSAddClient(FSClient_t* fsClient, uint32 errHandling);
 	FS_RESULT FSDelClient(FSClient_t* fsClient, uint32 errHandling);
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_FS.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_FS.h
@@ -292,6 +292,8 @@ namespace coreinit
 	sint32 FSReadDir(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, FSDirEntry_t* dirEntryOut, uint32 errorMask, FSAsyncParams* fsAsyncParams);
 	sint32 FSCloseDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, uint32 errorMask, FSAsyncParams* fsAsyncParams);
 	sint32 FSCloseDir(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, uint32 errorMask);
+	sint32 FSRewindDirAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, uint32 errorMask, FSAsyncParams* fsAsyncParams);
+	sint32 FSRewindDir(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, FSDirHandle2 dirHandle, uint32 errorMask);
 
 	sint32 FSFlushQuotaAsync(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, uint32 errorMask, FSAsyncParams* fsAsyncParams);
 	sint32 FSFlushQuota(FSClient_t* fsClient, FSCmdBlock_t* fsCmdBlock, char* path, uint32 errorMask);

--- a/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_RenderTarget.cpp
@@ -176,8 +176,6 @@ void gx2Export_GX2SetColorBuffer(PPCInterpreter_t* hCPU)
 	gx2WriteGather_submitU32AsBE(mmCB_COLOR0_SIZE - 0xA000 + hCPU->gpr[4]);
 	gx2WriteGather_submitU32AsBE((uint32)colorBufferBE->reg_size);
 
-	cemu_assert_debug(tileMode != Latte::E_GX2TILEMODE::TM_LINEAR_SPECIAL);
-
 	// set mmCB_COLOR*_VIEW
 	gx2WriteGather_submit(
 		pm4HeaderType3(IT_SET_CONTEXT_REG, 2),


### PR DESCRIPTION
This PR gets rid of the "please insert an SD card" error that [previously showed up](https://discord.com/channels/286429969104764928/1017917335874572308/1259142305642840154) if you tried to use this feature, so that it now works and is fully preserved (like it is in Citra).
￼
<img height="400" alt="Saved image of" src="https://github.com/user-attachments/assets/ee09e370-4407-4c99-8354-35c2328e8a18" />

Mii QR codes can also export now, albehit the data is all zeroes because Mii encryption is unimplemented:
<img height="300" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/5358bca1-90e0-4df7-af55-556ce9cec41c" />

## Changes made

* 345ba088d1972f70374dcb98b4253cfadc632590: Invoke SD card callback/notification when FSAddClientEx is called.
  - If Mii Maker never receives this, it doesn't even try to mount the SD card despite it being present.
  - The workaround I applied is to invoke the callback immediately with the string "sdcard".
    * It’s possible this affects other games that use the SD card, if… there are any.
  - That `FSAttachCallback` is slightly [documented in Decaf](https://github.com/decaf-emu/decaf-emu/blob/e6c528a20a41c34e0f9eb91dd3da40f119db2dee/src/libdecaf/src/cafe/libraries/coreinit/coreinit_fs_client.cpp#L86-L102).
* 1e1b2c14c51808d363652e2315afb366a2e38a4d: Fix image texture readback in Mii Maker
  - As you can see, I had to remove an assertion that got hit while doing this. Context is needed on why it was originally added.
  - Also had to enable `TM_LINEAR_GENERAL` to be mirrored to CPU RAM as well as `TM_LINEAR_ALIGNED`.
  - Even with these changes, JPEGs for QR codes are still completely black under the Metal renderer while Vulkan is fine.
* 244aeb00dd42e9276dd499eb7318e8d28ede85f4: Extra change I snuck in to export `FSRewindDir`.
    * Already implemented, called by "FFLUtility". (Search in RGD Discord for more info)
        * According to the paths, it's built from the [same sources as Mii Maker](https://discord.com/channels/370011926823960576/374765704877965312/1296536499860410449). So yes, Mii
    * This patch and a mount at /fflutility will make the tool work (`--cos-mounts /path/to/hostio:/fflutility`)
        * Weirdly not required on a real console.
    * DM me if you'd like to test this.

## Fixing QR codes

Proper QR code exports involve implementing ACPMiiWrap/Unwrap, which I could do, but is out of scope and well documented anyway.
* Used for Mii QR code encryption yes, but also for some obscure Mii network features.
    * sonic2013.rpx: `WrapStoreData__31__N_15_FFLiNetwork_cpp_5a76681bFP20FFLiWrappedStoreDataPC16FFLiStoreDataCFLb`
* The concern here is with [the AES key it needs](https://github.com/azahar-emu/azahar/blob/0c19c33bd339827d35b15420f74e37c260e249ea/src/core/hle/service/apt/apt.cpp#L1351), which Citra uses from the txt.
    * Not my call if it should be included in the code, but does Cemu even require keys anywhere else?
    * Citra actually uses 0 as the key if unspecified. Those null-key QR codes, while mostly useless, CAN actually be read/created by [a tool I made](https://ariankordi.github.io/my-jsfiddles/mii-tomo-dachi-topia-qr-tool/index.html).
* Or we can defer this to until camera support works. Then the entire feature can be tested end-to-end.