### PR TITLE
nn_fp: Use proper Comment struct and fix invalid Mii name on Linux

### DIFF
--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -68,7 +68,7 @@ namespace iosu
 			std::atomic_uint64_t m_notificationQueueIndex{1};
 		}g_NotificationQueue;
 
-		struct  
+		struct
 		{
 			bool isThreadStarted;
 			bool isInitialized2;
@@ -214,12 +214,9 @@ namespace iosu
 			friendData->friendExtraData.gameKey.ukn08 = frd->presence.gameKey.ukn;
 			NexPresenceToGameMode(&frd->presence, &friendData->friendExtraData.gameMode);
 
-			auto fixed_presence_msg = '\0' + frd->presence.msg; // avoid first character of comment from being cut off
-			friendData->friendExtraData.gameModeDescription.assignFromUTF8(fixed_presence_msg);
-			
-			auto fixed_comment = '\0' + frd->comment.commentString; // avoid first character of comment from being cut off
-			friendData->friendExtraData.comment.assignFromUTF8(fixed_comment);
-			
+			convertMultiByteStringToBigEndianWidechar(frd->presence.msg.c_str(), friendData->friendExtraData.gameModeDescription, GAMEMODE_MAX_MESSAGE_LENGTH);
+			convertMultiByteStringToBigEndianWidechar(frd->comment.commentString.c_str(), friendData->friendExtraData.comment.commentString, MY_COMMENT_LENGTH);
+
 			// set valid dates
 			friendData->uknDate.year = 2018;
 			friendData->uknDate.day = 1;
@@ -293,7 +290,7 @@ namespace iosu
 			memset(friendRequest, 0, sizeof(FriendRequest));
 
 			friendRequest->pid = frdReq->principalInfo.principalId;
-			
+
 			strncpy((char*)friendRequest->nnid, frdReq->principalInfo.nnid, sizeof(friendRequest->nnid));
 			friendRequest->nnid[sizeof(friendRequest->nnid) - 1] = '\0';
 
@@ -723,20 +720,19 @@ namespace iosu
 			{
 				if(numVecIn != 0 || numVecOut != 1)
 					return FPResult_InvalidIPCParam;
-				std::vector<uint16be> myComment;
+				Comment outComment;
 				if(g_fpd.nexFriendSession)
 				{
-					if(vecOut->size != MY_COMMENT_LENGTH * sizeof(uint16be))
+					if(vecOut->size != sizeof(Comment))
 					{
 						cemuLog_log(LogType::Force, "GetMyComment: Unexpected output size");
 						return FPResult_InvalidIPCParam;
 					}
 					nexComment myNexComment;
 					g_fpd.nexFriendSession->getMyComment(myNexComment);
-					myComment = StringHelpers::FromUtf8(myNexComment.commentString);
+					convertMultiByteStringToBigEndianWidechar(myNexComment.commentString.c_str(), outComment.commentString, MY_COMMENT_LENGTH);
 				}
-				myComment.insert(myComment.begin(), '\0');
-				memcpy(vecOut->basePhys.GetPtr(), myComment.data(), MY_COMMENT_LENGTH * sizeof(uint16be));
+				memcpy(vecOut->basePhys.GetPtr(), &outComment, sizeof(Comment));
 				return FPResult_Ok;
 			}
 
@@ -1166,10 +1162,9 @@ namespace iosu
 				}
 				IPCCommandBody* cmd = ServiceCallDelayCurrentResponse();
 
-				auto utf8_comment = StringHelpers::ToUtf8(newComment, messageLength);
 				nexComment temporaryComment;
 				temporaryComment.ukn0 = 0;
-				temporaryComment.commentString = utf8_comment;
+				temporaryComment.commentString = StringHelpers::ToUtf8(newComment, messageLength-1);
 				temporaryComment.ukn1 = 0;
 
 				g_fpd.nexFriendSession->updateCommentAsync(temporaryComment, [cmd](NexFriends::RpcErrorCode result) {
@@ -1456,7 +1451,7 @@ namespace iosu
 				iosu::act::getAccountId(currentSlot, accountId);
 				FFLData_t miiData;
 				act::getMii(currentSlot, &miiData);
-				uint16 screenName[ACT_NICKNAME_LENGTH + 1] = { 0 };
+				uint16 screenName[ACT_NICKNAME_SIZE] = { 0 };
 				act::getScreenname(currentSlot, screenName);
 				uint32 countryCode = 0;
 				act::getCountryIndex(currentSlot, &countryCode);
@@ -1488,7 +1483,7 @@ namespace iosu
 				const uint32_t hostIp = ((struct sockaddr_in*)addrs->ai_addr)->sin_addr.s_addr;
 				freeaddrinfo(addrs);
 				g_fpd.mtxFriendSession.lock();
-				g_fpd.nexFriendSession = new NexFriends(hostIp, nexTokenResult.nexToken.port, "ridfebb9", myPid, nexTokenResult.nexToken.nexPassword, nexTokenResult.nexToken.token, accountId, (uint8*)&miiData, (wchar_t*)screenName, (uint8)countryCode, g_fpd.myPresence);
+				g_fpd.nexFriendSession = new NexFriends(hostIp, nexTokenResult.nexToken.port, "ridfebb9", myPid, nexTokenResult.nexToken.nexPassword, nexTokenResult.nexToken.token, accountId, (uint8*)&miiData, screenName, (uint8)countryCode, g_fpd.myPresence);
 				g_fpd.nexFriendSession->setNotificationHandler(NotificationHandler);
 				g_fpd.mtxFriendSession.unlock();
 				cemuLog_log(LogType::Force, "IOSU_FPD: Created friend server session");
@@ -1532,4 +1527,3 @@ namespace iosu
 
 	}
 }
-

--- a/src/Cafe/IOSU/legacy/iosu_fpd.cpp
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.cpp
@@ -214,8 +214,8 @@ namespace iosu
 			friendData->friendExtraData.gameKey.ukn08 = frd->presence.gameKey.ukn;
 			NexPresenceToGameMode(&frd->presence, &friendData->friendExtraData.gameMode);
 
-			convertMultiByteStringToBigEndianWidechar(frd->presence.msg.c_str(), friendData->friendExtraData.gameModeDescription, GAMEMODE_MAX_MESSAGE_LENGTH);
-			convertMultiByteStringToBigEndianWidechar(frd->comment.commentString.c_str(), friendData->friendExtraData.comment.commentString, MY_COMMENT_LENGTH);
+			friendData->friendExtraData.gameModeDescription.assignFromUTF8(frd->presence.msg);
+			friendData->friendExtraData.comment.commentString.assignFromUTF8(frd->comment.commentString);
 
 			// set valid dates
 			friendData->uknDate.year = 2018;
@@ -730,7 +730,7 @@ namespace iosu
 					}
 					nexComment myNexComment;
 					g_fpd.nexFriendSession->getMyComment(myNexComment);
-					convertMultiByteStringToBigEndianWidechar(myNexComment.commentString.c_str(), outComment.commentString, MY_COMMENT_LENGTH);
+					outComment.commentString.assignFromUTF8(myNexComment.commentString);
 				}
 				memcpy(vecOut->basePhys.GetPtr(), &outComment, sizeof(Comment));
 				return FPResult_Ok;

--- a/src/Cafe/IOSU/legacy/iosu_fpd.h
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.h
@@ -6,6 +6,14 @@ namespace iosu
 {
 	namespace fpd
 	{
+		static const int RELATIONSHIP_INVALID = 0;
+		static const int RELATIONSHIP_FRIENDREQUEST_OUT = 1;
+		static const int RELATIONSHIP_FRIENDREQUEST_IN = 2;
+		static const int RELATIONSHIP_FRIEND = 3;
+
+		static const int GAMEMODE_MAX_MESSAGE_LENGTH = 0x80; // limit includes null-terminator character, so only 0x7F actual characters can be used
+		static const int MY_COMMENT_LENGTH = 0x11; // includes null-terminator character
+
 		struct FPDDate
 		{
 			/* +0x0 */ uint16be year;
@@ -67,6 +75,14 @@ namespace iosu
 		};
 		static_assert(sizeof(GameMode) == 0x2C);
 
+		struct Comment
+		{
+			/* +0x00 */ uint8 unk0;
+			/* +0x01 */ uint8 unk1;
+			/* +0x02 */ uint16be commentString[MY_COMMENT_LENGTH];
+		};
+		static_assert(sizeof(Comment) == 0x24);
+
 		struct FriendData
 		{
 			/* +0x000 */ uint8 type; // type (Non-Zero -> Friend, 0 -> Friend request ? )
@@ -83,23 +99,27 @@ namespace iosu
 			// sub struct (the part above seems to be shared with friend requests)
 			union
 			{
-				struct 
+				struct
 				{
 					/* +0x0A0 */ Profile profile; // this is returned for nn_fp.GetFriendProfile
 					/* +0x0A4 */ uint32be ukn0A4;
 					/* +0x0A8 */ GameKey gameKey;
 					/* +0x0B8 */ GameMode gameMode;
-					/* +0x0E4 */ CafeWideString<0x82> gameModeDescription;
+					/* +0x0E4 */ uint8 unk0E4;
+					/* +0x0E5 */ uint8 unk0E5;
+					/* +0x0E6 */ uint16be gameModeDescription[GAMEMODE_MAX_MESSAGE_LENGTH];
+					/* +0x1E6 */ uint8 unk1E6;
+					/* +0x1E7 */ uint8 unk1E7;
 					/* +0x1E8 */ Profile profile1E8; // how does it differ from the one at 0xA0? Returned by GetFriendPresence
 					/* +0x1EC */ uint8 isOnline;
 					/* +0x1ED */ uint8 _padding1ED[3];
 					// some other sub struct?
-					/* +0x1F0 */ CafeWideString<0x12> comment; // pops up every few seconds in friend list
+					/* +0x1F0 */ Comment comment; // pops up every few seconds in friend list
 					/* +0x214 */ uint32be _padding214;
 					/* +0x218 */ FPDDate approvalTime;
 					/* +0x220 */ FPDDate lastOnline;
 				}friendExtraData;
-				struct 
+				struct
 				{
 					/* +0x0A0 */ uint64be messageId; // guessed. If 0, then relationship is FRIENDSHIP_REQUEST_OUT, otherwise FRIENDSHIP_REQUEST_IN
 					/* +0x0A8 */ uint8 ukn0A8;
@@ -118,9 +138,9 @@ namespace iosu
 		};
 		static_assert(sizeof(FriendData) == 0x228);
 		static_assert(offsetof(FriendData, friendExtraData.gameKey) == 0x0A8);
-		static_assert(offsetof(FriendData, friendExtraData.gameModeDescription) == 0x0E4);
+		static_assert(offsetof(FriendData, friendExtraData.gameModeDescription) == 0x0E6);
 		static_assert(offsetof(FriendData, friendExtraData.comment) == 0x1F0);
-		
+
 		static_assert(offsetof(FriendData, requestExtraData.messageId) == 0x0A0);
 		static_assert(offsetof(FriendData, requestExtraData.comment) == 0x0AA);
 		static_assert(offsetof(FriendData, requestExtraData.uknMessage) == 0x12C);
@@ -205,14 +225,6 @@ namespace iosu
 			uint8be ukn; // probably padding?
 		};
 		static_assert(sizeof(FPDPreference) == 4);
-
-		static const int RELATIONSHIP_INVALID = 0;
-		static const int RELATIONSHIP_FRIENDREQUEST_OUT = 1;
-		static const int RELATIONSHIP_FRIENDREQUEST_IN = 2;
-		static const int RELATIONSHIP_FRIEND = 3;
-
-		static const int GAMEMODE_MAX_MESSAGE_LENGTH = 0x80; // limit includes null-terminator character, so only 0x7F actual characters can be used
-		static const int MY_COMMENT_LENGTH = 0x12;
 
 		enum class FPD_REQUEST_ID
 		{

--- a/src/Cafe/IOSU/legacy/iosu_fpd.h
+++ b/src/Cafe/IOSU/legacy/iosu_fpd.h
@@ -79,7 +79,7 @@ namespace iosu
 		{
 			/* +0x00 */ uint8 unk0;
 			/* +0x01 */ uint8 unk1;
-			/* +0x02 */ uint16be commentString[MY_COMMENT_LENGTH];
+			/* +0x02 */ CafeWideString<MY_COMMENT_LENGTH> commentString;
 		};
 		static_assert(sizeof(Comment) == 0x24);
 
@@ -107,7 +107,7 @@ namespace iosu
 					/* +0x0B8 */ GameMode gameMode;
 					/* +0x0E4 */ uint8 unk0E4;
 					/* +0x0E5 */ uint8 unk0E5;
-					/* +0x0E6 */ uint16be gameModeDescription[GAMEMODE_MAX_MESSAGE_LENGTH];
+					/* +0x0E6 */ CafeWideString<GAMEMODE_MAX_MESSAGE_LENGTH> gameModeDescription;
 					/* +0x1E6 */ uint8 unk1E6;
 					/* +0x1E7 */ uint8 unk1E7;
 					/* +0x1E8 */ Profile profile1E8; // how does it differ from the one at 0xA0? Returned by GetFriendPresence

--- a/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
+++ b/src/Cafe/OS/libs/nn_fp/nn_fp.cpp
@@ -484,7 +484,7 @@ namespace nn
 		{
 			FP_API_BASE();
 			auto ipcCtx = std::make_unique<FPIpcContext>(iosu::fpd::FPD_REQUEST_ID::GetMyComment);
-			ipcCtx->AddOutput(myComment, iosu::fpd::MY_COMMENT_LENGTH * sizeof(uint16be));
+			ipcCtx->AddOutput(myComment, sizeof(iosu::fpd::Comment));
 			return ipcCtx->Submit(std::move(ipcCtx));
 		}
 
@@ -627,13 +627,13 @@ namespace nn
 		{
 			FP_API_BASE();
 			auto ipcCtx = std::make_unique<FPIpcContext>(iosu::fpd::FPD_REQUEST_ID::UpdateCommentAsync);
-			uint32 commentLen = CafeStringHelpers::Length(newComment, iosu::fpd::MY_COMMENT_LENGTH-1);
-			if (commentLen >= iosu::fpd::MY_COMMENT_LENGTH-1)
+			uint32 commentLen = CafeStringHelpers::Length(newComment, iosu::fpd::MY_COMMENT_LENGTH);
+			if (commentLen >= iosu::fpd::MY_COMMENT_LENGTH)
 			{
 				cemuLog_log(LogType::Force, "UpdateCommentAsync: message too long");
 				return FPResult_InvalidIPCParam;
 			}
-			ipcCtx->AddInput(newComment, sizeof(uint16be) * commentLen + 2);    
+			ipcCtx->AddInput(newComment, sizeof(uint16be) * (commentLen + 1));
 			return ipcCtx->SubmitAsync(std::move(ipcCtx), funcPtr, customParam);
 		}
 
@@ -840,4 +840,3 @@ namespace nn
 
 	}
 }
-

--- a/src/Cemu/nex/nexFriends.cpp
+++ b/src/Cemu/nex/nexFriends.cpp
@@ -1,7 +1,9 @@
+#include "Cafe/IOSU/legacy/iosu_act.h"
 #include "prudp.h"
 #include "nex.h"
 #include "nexFriends.h"
 #include "Cafe/CafeSystem.h"
+#include "util/helpers/StringHelpers.h"
 
 static const int NOTIFICATION_SRV_FRIEND_OFFLINE = 0x0A; // the opposite event (friend online) is notified via _PRESENCE_CHANGE
 static const int NOTIFICATION_SRV_FRIEND_PRESENCE_CHANGE = 0x18;
@@ -195,7 +197,7 @@ void nexFriends_protocolNotification_processRequest(nexServiceRequest_t* request
 	request->nex->sendRequestResponse(request, 0x80000000, nullptr, 0);
 }
 
-NexFriends::NexFriends(uint32 authServerIp, uint16 authServerPort, const char* accessKey, uint32 pid, const char* nexPassword, const char* nexToken, const char* nnid, uint8* miiData, const wchar_t* miiNickname, uint8 countryCode, nexPresenceV2& myPresence)
+NexFriends::NexFriends(uint32 authServerIp, uint16 authServerPort, const char* accessKey, uint32 pid, const char* nexPassword, const char* nexToken, const char* nnid, uint8* miiData, const uint16* miiNickname, uint8 countryCode, nexPresenceV2& myPresence)
 	: nexCon(nullptr)
 {
 	memcpy(this->miiData, miiData, FFL_SIZE);
@@ -203,7 +205,7 @@ NexFriends::NexFriends(uint32 authServerIp, uint16 authServerPort, const char* a
 	this->pid = pid;
 	this->countryCode = countryCode;
 	this->myPresence = myPresence;
-	this->miiNickname = boost::nowide::narrow(miiNickname);
+	this->miiNickname = StringHelpers::ToUtf8FromLE(miiNickname, ACT_NICKNAME_LENGTH);
 	cemu_assert_debug(this->miiNickname.size() <= 96-1);
 	auth.serverIp = authServerIp;
 	auth.port = authServerPort;
@@ -511,7 +513,7 @@ void NexFriends::trackNotifications()
 	{
 		bool entryFound = false;
 		for (auto& frqNew : list_friendReqIncoming)
-		{	
+		{
 			if (frqNew.principalInfo.principalId == frqPrevious.principalInfo.principalId)
 			{
 				entryFound = true;

--- a/src/Cemu/nex/nexFriends.h
+++ b/src/Cemu/nex/nexFriends.h
@@ -264,7 +264,7 @@ public:
 		pb->writeU8(showGame);
 		pb->writeU8(blockFriendRequests);
 	}
-	
+
 	void readData(nexPacketBuffer* pb) override
 	{
 		showOnline = pb->readU8();
@@ -537,7 +537,7 @@ public:
 	};
 
 public:
-	NexFriends(uint32 authServerIp, uint16 authServerPort, const char* accessKey, uint32 pid, const char* nexPassword, const char* nexToken, const char* nnid, uint8* miiData, const wchar_t* miiNickname, uint8 countryCode, nexPresenceV2& myPresence);
+	NexFriends(uint32 authServerIp, uint16 authServerPort, const char* accessKey, uint32 pid, const char* nexPassword, const char* nexToken, const char* nnid, uint8* miiData, const uint16* miiNickname, uint8 countryCode, nexPresenceV2& myPresence);
 
 	~NexFriends();
 
@@ -586,7 +586,7 @@ private:
 
 	void generateNotification(NOTIFICATION_TYPE notificationType, uint32 pid);
 	void trackNotifications();
-	
+
 	// notification-service handlers
 	void processServerNotification_friendOffline(uint32 pid);
 	void processServerNotification_presenceChange(uint32 pid, nexPresenceV2& presence);
@@ -612,7 +612,7 @@ private:
 	uint32 numFailedLogins;
 	uint32 numSuccessfulLogins;
 	// auth
-	struct  
+	struct
 	{
 		uint32 serverIp;
 		uint16 port;
@@ -629,7 +629,7 @@ private:
 	std::vector<nexFriend> list_friends;
 	std::vector<nexFriendRequest> list_friendReqOutgoing;
 	std::vector<nexFriendRequest> list_friendReqIncoming;
-	struct  
+	struct
 	{
 		std::vector<nexFriend> list_friends;
 		std::vector<nexFriendRequest> list_friendReqOutgoing;

--- a/src/util/helpers/StringHelpers.h
+++ b/src/util/helpers/StringHelpers.h
@@ -110,6 +110,20 @@ namespace StringHelpers
 		return ToUtf8(input.data(), input.size());
 	}
 
+	// convert little-endian wide string to utf8 string
+	static std::string ToUtf8FromLE(const uint16* ptr, size_t maxLength)
+	{
+		std::wstringstream result;
+		while (*ptr != 0 && maxLength > 0)
+		{
+			auto c = (uint16)*ptr;
+			result << static_cast<wchar_t>(c);
+			ptr++;
+			maxLength--;
+		}
+		return boost::nowide::narrow(result.str());
+	}
+
 	// convert utf8 string to Wii U big-endian wchar_t string
 	static std::vector<uint16be> FromUtf8(std::string_view str)
 	{
@@ -285,4 +299,3 @@ namespace StringHelpers
 		std::string_view m_str;
 	};
 };
-


### PR DESCRIPTION
This fixes empty comments from appearing as corrupted characters because GetMyComment incorrectly treated the whole comment as a uint16 array (also applied this to friend comments).

| Before | After |
| - | - |
<img width="1016" height="427" alt="comment_without_pr" src="https://github.com/user-attachments/assets/55af262b-0e03-45ae-959e-4b1db1bdc032" /> | <img width="994" height="420" alt="comment_with_pr" src="https://github.com/user-attachments/assets/bbe68038-09cc-4348-adf8-cb4f9fc6e657" />

This also fixes sending invalid Mii names to online servers on Linux since the name is a uint16 array but is casted as a pointer to wchar_t, which is 4 bytes long on Linux when it should be 2.
| Before | After |
| - | - |
<img width="424" height="244" alt="nickname_without_pr" src="https://github.com/user-attachments/assets/4476d992-1cd0-4aed-832e-4bb7ba3e4a13" /> | <img width="485" height="245" alt="nickname_with_pr" src="https://github.com/user-attachments/assets/6973c201-3539-4d38-8733-7a63cadc5b8c" />

The last change is that gamemode descriptions start at 0xE6, not 0xE4, so prepending \0 to it is unnecessary.
