### PR TITLE
Don't set menu bar to nullptr on macos

### DIFF
--- a/src/gui/wxgui/MainWindow.cpp
+++ b/src/gui/wxgui/MainWindow.cpp
@@ -1790,7 +1790,9 @@ void MainWindow::SetMenuVisible(bool state)
 	if (m_menu_visible == state)
 		return;
 
+#if !BOOST_OS_MACOS
 	SetMenuBar(state ? m_menuBar : nullptr);
+#endif
 	m_menu_visible = state;
 }
 


### PR DESCRIPTION
Fixes #609. Removing the menu bar like this stops OnOptionsInput from being called, and the menu bar is hidden anyway by default in macOS fullscreen apps.