### PR TITLE
coreinit_DynLoad: Implement a few more functions

### DIFF
--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -273,6 +273,13 @@ bool RPLLoader_ProcessHeaders(std::string_view moduleName, uint8* rplData, uint3
 	// init modulename
 	rplLoaderContext->moduleName.assign(moduleName);
 
+	std::string fileName{moduleName};
+	fileName.append(rplLoaderContext->IsRPX() ? ".rpx" : ".rpl");
+
+	// allocate modulename in PPC memory
+	rplLoaderContext->ppcName = coreinit_allocFromSysArea(fileName.size() + 1, 4);
+	memcpy(rplLoaderContext->ppcName.GetPtr(), fileName.data(), fileName.size() + 1);
+
 	// load CRC section
 	uint32 crcTableExpectedSize = sectionCount * sizeof(uint32be);
 	if (!RPLLoader_CheckBounds(rplLoaderContext, crcSection->fileOffset, crcTableExpectedSize))
@@ -2068,6 +2075,18 @@ uint32 RPLLoader_GetHandleByModuleName(const char* name)
 		}
 	}
 	return RPL_INVALID_HANDLE;
+}
+
+const std::string RPLLoader_GetModuleNameByHandle(uint32 handle)
+{
+	for (auto& dep : rplDependencyList)
+	{
+		if (dep->coreinitHandle == handle)
+			return dep->moduleName;
+	}
+
+	return "";
+	
 }
 
 uint32 RPLLoader_GetMaxTLSModuleIndex()

--- a/src/Cafe/OS/RPL/rpl.h
+++ b/src/Cafe/OS/RPL/rpl.h
@@ -36,6 +36,7 @@ void RPLLoader_UpdateDependencies();
 void RPLLoader_LoadCoreinit();
 
 uint32 RPLLoader_GetHandleByModuleName(const char* name);
+const std::string RPLLoader_GetModuleNameByHandle(uint32 handle);
 uint32 RPLLoader_GetMaxTLSModuleIndex();
 bool RPLLoader_GetTLSDataByTLSIndex(sint16 tlsModuleIndex, uint8** tlsData, sint32* tlsSize);
 

--- a/src/Cafe/OS/RPL/rpl_structs.h
+++ b/src/Cafe/OS/RPL/rpl_structs.h
@@ -156,6 +156,7 @@ struct RPLModule
 	MEMPTR<void> regionMappingBase_text; // base destination address for text region
 	MPTR regionMappingBase_data; // base destination address for data region
 	MPTR regionMappingBase_loaderInfo; // base destination address for loaderInfo region
+	MEMPTR<char> ppcName; // name of the module in PPC memory
 	uint8* tempRegionPtr;
 	uint32 tempRegionAllocSize;
 

--- a/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
@@ -1,6 +1,7 @@
 #include "Cafe/OS/common/OSCommon.h"
 #include "Cafe/HW/Espresso/PPCCallback.h"
 #include "Cafe/OS/RPL/rpl.h"
+#include "Cafe/OS/RPL/rpl_structs.h"
 #include "Cafe/OS/libs/coreinit/coreinit_DynLoad.h"
 #include "Cafe/OS/libs/coreinit/coreinit_MEM.h"
 
@@ -97,6 +98,7 @@ namespace coreinit
 			RPLLoader_UpdateDependencies();
 			RPLLoader_Link();
 			RPLLoader_CallEntrypoints();
+			
 			rplHandle = RPLLoader_GetHandleByModuleName(libName);
 		}
 		if (rplHandle == RPL_INVALID_HANDLE)
@@ -146,6 +148,54 @@ namespace coreinit
 		return 0;
 	}
 
+	uint32 OSDynLoad_GetModuleName(uint32 moduleHandle, char* nameBuf, sint32be* nameBufSize) 
+	{
+		if (moduleHandle == 0xFFFFFFFF)
+		{
+			// main module
+			// Assassins Creed 4 has this handle hardcoded
+			moduleHandle = RPLLoader_GetMainModuleHandle();
+		}
+
+		const std::string moduleName = RPLLoader_GetModuleNameByHandle(moduleHandle);
+		std::strncpy(nameBuf, moduleName.c_str(), *nameBufSize);
+
+		return 0;
+
+	}
+
+	sint32 OSDynLoad_GetNumberOfRPLs()
+	{
+		return RPLLoader_GetModuleCount();
+	}
+
+	uint32 OSDynLoad_GetRPLInfo(uint32 first, uint32 count, OSDynLoad_NotifyData* outInfos) 
+	{
+		if (count == 0)
+			return 1;
+		RPLModule** modules = RPLLoader_GetModuleList();
+
+		for (uint32 i = first; i < count; i++)
+		{	
+			outInfos[i].name = modules[i]->ppcName.GetMPTR();
+
+			outInfos[i].textAddr = modules[i]->regionMappingBase_text.GetBEValue();
+			outInfos[i].textOffset = modules[i]->regionMappingBase_text.GetMPTR() - modules[i]->regionOrigAddr_text;
+			outInfos[i].textSize = modules[i]->regionSize_text;
+
+			outInfos[i].dataAddr = modules[i]->regionMappingBase_data;
+			outInfos[i].dataOffset = modules[i]->regionMappingBase_data - modules[i]->regionOrigAddr_data;
+			outInfos[i].dataSize = modules[i]->regionSize_data;
+
+			outInfos[i].readAddr = modules[i]->regionMappingBase_data;
+			outInfos[i].readOffset = modules[i]->regionMappingBase_data - modules[i]->regionOrigAddr_data;
+			outInfos[i].readSize = modules[i]->regionSize_data;
+
+		}
+
+		return 1;
+	}
+
 	void InitializeDynLoad()
 	{
 		cafeExportRegister("coreinit", OSDynLoad_SetAllocator, LogType::Placeholder);
@@ -157,5 +207,8 @@ namespace coreinit
 		cafeExportRegister("coreinit", OSDynLoad_Release, LogType::Placeholder);
 		cafeExportRegister("coreinit", OSDynLoad_IsModuleLoaded, LogType::Placeholder);
 		cafeExportRegister("coreinit", OSDynLoad_FindExport, LogType::Placeholder);
+		cafeExportRegister("coreinit", OSDynLoad_GetModuleName, LogType::Placeholder);
+		cafeExportRegister("coreinit", OSDynLoad_GetNumberOfRPLs, LogType::Placeholder);
+		cafeExportRegister("coreinit", OSDynLoad_GetRPLInfo, LogType::Placeholder);
 	}
 }

--- a/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
@@ -98,7 +98,6 @@ namespace coreinit
 			RPLLoader_UpdateDependencies();
 			RPLLoader_Link();
 			RPLLoader_CallEntrypoints();
-			
 			rplHandle = RPLLoader_GetHandleByModuleName(libName);
 		}
 		if (rplHandle == RPL_INVALID_HANDLE)

--- a/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.h
+++ b/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.h
@@ -2,6 +2,23 @@
 
 namespace coreinit
 {
+	struct OSDynLoad_NotifyData
+	{
+		MEMPTR<char> name;
+
+		uint32be textAddr;
+		uint32be textOffset;
+		uint32be textSize;
+
+		uint32be dataAddr;
+		uint32be dataOffset;
+		uint32be dataSize;
+
+		uint32be readAddr;
+		uint32be readOffset;
+		uint32be readSize;
+	};
+
 	uint32 OSDynLoad_SetAllocator(MPTR allocFunc, MPTR freeFunc);
 	void OSDynLoad_SetTLSAllocator(MPTR allocFunc, MPTR freeFunc);
 	uint32 OSDynLoad_GetAllocator(betype<MPTR>* funcAlloc, betype<MPTR>* funcFree);
@@ -13,6 +30,10 @@ namespace coreinit
 	uint32 OSDynLoad_Acquire(const char* libName, uint32be* moduleHandleOut);
 	void OSDynLoad_Release(uint32 moduleHandle);
 	uint32 OSDynLoad_FindExport(uint32 moduleHandle, uint32 isData, const char* exportName, betype<MPTR>* addrOut);
+
+	uint32 OSDynLoad_GetModuleName(uint32 moduleHandle, char* nameBuf, sint32be* nameBufSize);
+	sint32 OSDynLoad_GetNumberOfRPLs();
+	uint32 OSDynLoad_GetRPLInfo(uint32 first, uint32 count, OSDynLoad_NotifyData* outInfos);
 
 	void InitializeDynLoad();
 }


### PR DESCRIPTION
This PR implements the following coreinit_DynLoad functions:
- OSDynLoad_GetModuleName
- OSDynLoad_GetNumberOfRPLs
- OSDynLoad_GetRPLInfo

Notes:
- The struct for OSDynLoad_NotifyData has been sourced from [wut](https://github.com/devkitPro/wut/blob/master/include/coreinit/dynload.h)
- OSDynLoad_GetRPLInfo and OSDynLoad_GetNumberOfRPLs currently don't account for HLE modules
- The way that OSDynLoad_NotifyData's `name` field is populated isn't fully accurate to how it is on console, as normally the name sourced from the filename found in the RPL's fileInfo section