### PR TITLE
Latte: mirror small 1D-tiled render targets back to guest memory

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteTexture.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteTexture.cpp
@@ -1312,6 +1312,15 @@ LatteTexture::LatteTexture(Latte::E_DIM dim, MPTR physAddress, MPTR physMipAddre
 	{
 		this->enableReadback = true;
 	}
+	else if (this->tileMode == Latte::E_HWTILEMODE::TM_1D_TILED_THIN1 && (width * height) <= 64 * 64)
+	{
+		// Some titles reduce a frame down to a tiny surface on the GPU and then read the result
+		// back on the CPU - Disney Infinity does this for auto exposure, ending in a 1x8 R32_FLOAT
+		// holding average scene luminance. Those surfaces are 1D tiled rather than linear, so they
+		// would never be mirrored back and the title reads stale memory, computes an exposure of
+		// zero and renders the whole scene black. They are small enough that mirroring them is cheap.
+		this->enableReadback = true;
+	}
 
 	// calculate number of potential mip levels (from effective size)
 	sint32 effectiveWidth = width;


### PR DESCRIPTION
### Problem

Disney Infinity renders the entire scene black. Audio, menus, HUD and input all work normally, and
the black scene reproduces identically on both the Vulkan and OpenGL backends.

### Cause

The game implements auto-exposure on the GPU. It reduces the frame through a chain of render
targets — 1152x600 → 284x150 → 96x48 → 17x16 → 4x8 → a final **1x8 R32_FLOAT** holding average
scene luminance — and then reads that value back on the CPU to compute an exposure scalar, which it
uploads as a shader uniform.

`LatteTexture` only sets `enableReadback` when `tileMode == TM_LINEAR_ALIGNED`. That chain is
`TM_1D_TILED_THIN1`, so the result was never mirrored back to guest memory. The game read stale
zeros, computed an exposure of `0`, and uploaded it. Cemu then passed that zero through perfectly
correctly — the lighting shader ends in

```glsl
R5i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R123i.y), intBitsToFloat(uf_remappedPS[13].x)));
passPixelColor0 = vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w));
```

so every lit pixel became black. UI is drawn after that multiply, which is why it stayed visible
and made this look like a render-target or presentation bug rather than a readback one.

### How it was diagnosed

Captured with RenderDoc:

- **Pixel History** on the HDR scene target shows fragments reaching it and **passing** every test
  (`passed=1`) while writing `shaderOut=(0.0000, 0.0000, 0.0000, 0.0000)` — so geometry rasterizes
  correctly and the pixel shader itself produces black.
- Dumping the generated GLSL showed the single scalar multiply above.
- Dumping the uniform block showed `uf_remappedPS[13] = (0, 0, 0, 0)` while every other entry was
  populated, and while the same frame's G-buffer pass had fully populated uniforms.

For completeness, these were ruled out along the way: depth-`EQUAL` rejection (disproved by forcing
`EQUAL`→`ALWAYS`), texture-cache format aliasing, scissor/viewport, colour write masks, swapchain
acquisition, and shader position invariance.

### Fix

Also enable readback for `TM_1D_TILED_THIN1` targets of at most 64x64. Full-size render targets are
untouched, so the common case is unaffected.

The size limit is a heuristic — it's meant to cover the "GPU reduces something to a tiny surface
that the CPU then reads" pattern while avoiding readback cost on real render targets. Happy to
change the bound, key it on something other than dimensions, or narrow the condition further if
you'd prefer something more targeted.

### Testing

- Disney Infinity 1.0 (US, `0005000010132900`), Vulkan, NVIDIA RTX 3080 — scene renders correctly
  with the fix, black without it. Verified on a clean build with all debug instrumentation removed.
- **Not yet tested:** other titles, and the framerate impact has not been measured. Readback
  introduces a GPU→CPU sync, so I'd appreciate a second opinion on whether the 64x64 bound is
  conservative enough, and I'm glad to run any specific title you'd like checked before merge.
