### PR TITLE
erreula: fix inverted IsDecideSelectLeft/RightButtonError

### DIFF
--- a/src/Cafe/OS/libs/erreula/erreula.cpp
+++ b/src/Cafe/OS/libs/erreula/erreula.cpp
@@ -152,12 +152,12 @@ namespace erreula
 
 		bool IsDecideSelectLeftButtonError() const
 		{
-			return m_buttonSelection != BUTTON_SELECTION::LEFT;
+			return m_buttonSelection == BUTTON_SELECTION::LEFT;
 		}
 
 		bool IsDecideSelectRightButtonError() const
 		{
-			return m_buttonSelection != BUTTON_SELECTION::RIGHT;
+			return m_buttonSelection == BUTTON_SELECTION::RIGHT;
 		}
 
 		void SetButtonSelection(BUTTON_SELECTION selection)


### PR DESCRIPTION
`IsDecideSelectLeftButtonError` and `IsDecideSelectRightButtonError` return `!=` where `==` is meant.

The effect is that each reports **true for every selection except the one it is asking about**, and both return true when no button has been selected at all (`BUTTON_SELECTION::NONE`).

`IsDecideSelectButtonError` immediately above uses `!=` correctly, because it asks whether *any* button was selected — presumably where the copy-paste originated.

Affects any title that queries which ErrEula button the user pressed. Found while getting Disney Infinity past its missing-NNID dialog, where the inverted result made the title read the wrong button.