### PR TITLE
gui: fix TV and GamePad screenshot filenames being swapped

### DIFF
--- a/src/gui/wxgui/input/HotkeySettings.cpp
+++ b/src/gui/wxgui/input/HotkeySettings.cpp
@@ -99,7 +99,9 @@ std::optional<std::string> SaveScreenshot(std::vector<uint8> data, int width, in
 	}
 	if (save_screenshot)
 	{
-		auto imagePath = GenerateScreenshotFilename(mainWindow);
+		// GenerateScreenshotFilename takes isDRC, which is the opposite of mainWindow. Passing
+		// mainWindow directly gave TV captures the _GamePad suffix and GamePad captures none
+		auto imagePath = GenerateScreenshotFilename(!mainWindow);
 		if (imagePath.has_value() && SaveScreenshotToFile(imagePath.value(), image))
 		{
 			if (mainWindow)


### PR DESCRIPTION
`GenerateScreenshotFilename(bool isDRC)` is called with `mainWindow`, which is its exact inverse — `VulkanRenderer::HandleScreenshotRequest` passes `!padView` as `mainWindow`.

So TV screenshots are saved with the `_GamePad` suffix, and GamePad screenshots are saved without it. Only the filename is affected; the image content is correct.

Noticed while debugging a black screen, where a TV capture arriving labelled `_GamePad` briefly sent the investigation down the wrong path.