### PR TITLE
coreinit: Return correct size from `MEMResizeForMBlockExpHeap` 

### DIFF
--- a/src/Cafe/OS/libs/coreinit/coreinit_MEM_ExpHeap.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_MEM_ExpHeap.cpp
@@ -643,6 +643,10 @@ uint32 MEMResizeForMBlockExpHeap(MEMHeapHandle heap, void* memBlock, uint32 size
 				newSize = 0;
 		}
 	}
+	else
+	{
+		newSize = dataSize;
+	}
 
 	heap->ReleaseLock();
 


### PR DESCRIPTION
When block size equalled the requested size, 0 was returned