### PR TITLE
Vulkan/GLSL: type pixel shader color outputs to match render-target datatype

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteShader.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteShader.cpp
@@ -690,6 +690,22 @@ uint64 LatteSHRC_CalcPSAuxHash(LatteDecompilerShader* pixelShader, uint32* conte
 	}
 #endif
 
+	// GLSL: generated pixel-color output types depend on the bound color buffer's datatype
+	// (see LatteDecompilerEmitGLSLHeader.hpp / LatteDecompilerEmitGLSL.cpp). That GLSL is shared
+	// by both GLSL-based backends (Vulkan and OpenGL), so it must be part of shader identity for
+	// both. Renderer-neutral (no ENABLE_METAL dependency) so this is correct on Windows/Linux
+	// builds as well, not just macOS.
+	if (g_renderer->GetType() == RendererAPI::Vulkan || g_renderer->GetType() == RendererAPI::OpenGL)
+	{
+		for (uint8 i = 0; i < LATTE_NUM_COLOR_TARGET; i++)
+		{
+			auto format = LatteMRT::GetColorBufferFormat(i, LatteGPUState.contextNew);
+			uint8 dataType = (uint8)Latte::GetColorBufferDataType(format);
+			auxHash = std::rotl<uint64>(auxHash, 7);
+			auxHash += (uint64)dataType;
+		}
+	}
+
 	return auxHash;
 }
 

--- a/src/Cafe/HW/Latte/ISA/LatteReg.h
+++ b/src/Cafe/HW/Latte/ISA/LatteReg.h
@@ -309,6 +309,26 @@ namespace Latte
 	};
 	DEFINE_ENUM_FLAG_OPERATORS(E_GX2SURFFMT);
 
+	// Renderer-neutral classification of a GX2 color-buffer format's scalar datatype.
+	// Used by the GLSL pixel shader generator (Vulkan and OpenGL) and its pixel-shader
+	// cache key, to match the native Metal backend's render-target-aware output typing.
+	enum class ColorBufferDataType
+	{
+		NONE,
+		INT,
+		UINT,
+		FLOAT,
+	};
+
+	inline ColorBufferDataType GetColorBufferDataType(E_GX2SURFFMT format)
+	{
+		if (format == E_GX2SURFFMT::INVALID_FORMAT)
+			return ColorBufferDataType::NONE;
+		if ((uint32)(format & E_GX2SURFFMT::FMT_BIT_INT) == 0)
+			return ColorBufferDataType::FLOAT;
+		return (uint32)(format & E_GX2SURFFMT::FMT_BIT_SIGNED) != 0 ? ColorBufferDataType::INT : ColorBufferDataType::UINT;
+	}
+
 	inline uint32 GetFormatBits(const Latte::E_HWSURFFMT hwFmt)
 	{
 		const uint8 sBitsTable[0x40] = {

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSL.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSL.cpp
@@ -5,6 +5,7 @@
 #include "Cafe/HW/Latte/Core/Latte.h"
 #include "Cafe/HW/Latte/Core/LatteDraw.h"
 #include "Cafe/HW/Latte/Core/LatteShader.h"
+#include "Cafe/HW/Latte/Core/LatteCachedFBO.h"
 #include "Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h"
 #include "Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInternal.h"
 #include "Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerInstructions.h"
@@ -3316,9 +3317,22 @@ void _emitExportCode(LatteDecompilerShaderContext* shaderContext, LatteDecompile
 					src->add(") == false) discard;" _CRLF);
 				}
 				// pixel color output
-				src->addFmt("passPixelColor{} = ", pixelColorOutputIndex);
-				_emitExportGPRReadCode(shaderContext, cfInstruction, LATTE_DECOMPILER_DTYPE_FLOAT, i);
-				src->add(";" _CRLF);
+				// output scalar type must match the bound color buffer's datatype (float/uint/int) -
+				// mirrors the native Metal backend's as_type<> bit-reinterpretation, see LatteDecompilerEmitMSL.cpp.
+				// register read stays float; only the wrapping bitcast depends on the target's datatype.
+				auto pixelColorDataType = Latte::GetColorBufferDataType(LatteMRT::GetColorBufferFormat(pixelColorOutputIndex, *shaderContext->contextRegistersNew));
+				if (pixelColorDataType != Latte::ColorBufferDataType::NONE)
+				{
+					src->addFmt("passPixelColor{} = ", pixelColorOutputIndex);
+					if (pixelColorDataType == Latte::ColorBufferDataType::UINT)
+						src->add("floatBitsToUint(");
+					else if (pixelColorDataType == Latte::ColorBufferDataType::INT)
+						src->add("floatBitsToInt(");
+					_emitExportGPRReadCode(shaderContext, cfInstruction, LATTE_DECOMPILER_DTYPE_FLOAT, i);
+					if (pixelColorDataType == Latte::ColorBufferDataType::UINT || pixelColorDataType == Latte::ColorBufferDataType::INT)
+						src->add(")");
+					src->add(";" _CRLF);
+				}
 
 				if( cfInstruction->exportArrayBase+i >= 8 )
 					cemu_assert_unimplemented();

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitGLSLHeader.hpp
@@ -527,11 +527,23 @@ namespace LatteDecompiler
 		if (decompilerContext->shaderType == LatteConst::ShaderType::Pixel)
 		{
 			// generate pixel outputs for pixel shader
+			// output scalar type must match the bound color buffer's datatype, mirroring the
+			// native Metal backend (LatteDecompilerEmitMSLHeader.hpp); render targets with no
+			// bound format (NONE) get no declaration at all, same as Metal.
 			for (uint32 i = 0; i < LATTE_NUM_COLOR_TARGET; i++)
 			{
 				if ((decompilerContext->shader->pixelColorOutputMask&(1 << i)) != 0)
 				{
-					src->addFmt("layout(location = {}) out vec4 passPixelColor{};" _CRLF, i, i);
+					auto colorDataType = Latte::GetColorBufferDataType(LatteMRT::GetColorBufferFormat(i, *decompilerContext->contextRegistersNew));
+					if (colorDataType != Latte::ColorBufferDataType::NONE)
+					{
+						const char* glslType = "vec4";
+						if (colorDataType == Latte::ColorBufferDataType::UINT)
+							glslType = "uvec4";
+						else if (colorDataType == Latte::ColorBufferDataType::INT)
+							glslType = "ivec4";
+						src->addFmt("layout(location = {}) out {} passPixelColor{};" _CRLF, i, glslType, i);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses the integer render-target pipeline failure reported in #396.

### Problem

Cemu's GLSL pixel shader generator (shared by the Vulkan and OpenGL backends)
unconditionally declares and exports color outputs as `float`/`vec4`,
regardless of the actual datatype of the bound render target. The native
Metal backend already handles this correctly via `GetColorBufferDataType()`.

On macOS with MoltenVK, this mismatch fails pipeline creation outright
whenever a game binds an integer-format render target (e.g. `RGBA16Uint`):

```
output of type float4 is not compatible with a MTLPixelFormatRGBA16Uint color attachment
```

This blocks affected titles - Breath of the Wild included - from rendering
at all on Vulkan/MoltenVK past the point where such a render target is
first bound.

### Fix

- Add a renderer-neutral `Latte::ColorBufferDataType` classifier
  (`LatteReg.h`), derived from the existing GX2 format `FMT_BIT_INT`/
  `FMT_BIT_SIGNED` flags, rather than duplicating Metal's format table.
- `LatteDecompilerEmitGLSLHeader.hpp`: declare `uvec4`/`ivec4`/`vec4` per
  color output based on the bound target's datatype, matching what the
  Metal backend already does. Skip the declaration entirely when no
  target is bound, also matching Metal.
- `LatteDecompilerEmitGLSL.cpp`: wrap the color export in
  `floatBitsToUint`/`floatBitsToInt` for integer targets. The GPR read
  stays float-typed throughout - only the bitcast at the export site
  changes, mirroring Metal's `as_type<>` there. Only the
  `passPixelColorN` assignment is touched; the alpha-test float read a
  few lines above is untouched.
- `LatteShader.cpp`: since the generated GLSL is now render-target-type
  dependent, fold that datatype into the pixel shader's cache identity
  (`LatteSHRC_CalcPSAuxHash`) for both GLSL-based backends (Vulkan and
  OpenGL), so a shader compiled for one render-target datatype can't be
  reused against a different one. Kept outside any Metal-specific gate
  so this applies correctly on non-Apple Vulkan/OpenGL builds too, and
  scoped narrowly to just the datatype (not full `VkFormat`, depth
  state, or Metal's texture-as-render-target hashing).

Vulkan and OpenGL are the only backends touched; the native Metal
backend's own (already-correct) typing logic is unchanged.

### Testing

- Reproduced the failure on an unmodified `main` build first, to confirm
  it wasn't specific to any local changes.
- Built with the fix and ran Breath of the Wild for an extended real
  session (13+ minutes) past the point that previously failed
  immediately - no pipeline-creation errors, stable throughout.
- Audited the Vulkan pixel-shader cache/variant key specifically for
  this change (a first version of the fix had a gap here: the cache key
  needs the render-target datatype folded in, or a shader compiled
  against one datatype can get incorrectly reused against another).

### Scope note

This is a rendering-correctness fix, not a performance change. It
doesn't touch the deeper Vulkan/MoltenVK performance characteristics on
this title - that's tracked separately.
