### PR TITLE
Metal: independent texture/sampler binding mapping

### DIFF
--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompiler.h
@@ -53,12 +53,21 @@ struct LatteDecompilerShaderResourceMapping
 		std::fill(relBindingPointToRelTextureUnit, relBindingPointToRelTextureUnit + LATTE_NUM_MAX_TEX_UNITS, UNUSED_BINDING);
 		std::fill(uniformBuffersBindingPoint, uniformBuffersBindingPoint + LATTE_NUM_MAX_UNIFORM_BUFFERS, UNUSED_BINDING);
 		std::fill(attributeMapping, attributeMapping + LATTE_NUM_MAX_ATTRIBUTE_LOCATIONS, UNUSED_BINDING);
+		std::fill(textureUnitToSamplerBindingPoint, textureUnitToSamplerBindingPoint + LATTE_NUM_MAX_TEX_UNITS, UNUSED_BINDING);
 	}
 	// texture
 	sint8 textureUnitToBindingPoint[LATTE_NUM_MAX_TEX_UNITS]; // mostly for OpenGL backwards compatibility where texture units are not remapped and binding points are sparse
 	sint8 relBindingPointToRelTextureUnit[LATTE_NUM_MAX_TEX_UNITS]; // (only used on VK and Metal) index is relative binding point (absoluteBindingPoint - textureUnitBaseBindingPoint)
 	sint8 textureUnitBaseBindingPoint{UNUSED_BINDING};
 	sint8 textureUnitCount{0}; // number of entries set in textureUnitToBindingPoint
+	// Metal exclusive: independent sampler mapping, keyed by texture unit. Deliberately separate
+	// from textureUnitToBindingPoint - Metal's texture (31-slot) and sampler (16-slot) argument
+	// tables are genuinely distinct, and reusing one index for both overflows the smaller table
+	// once a shader has >16 active texture units. Densely assigned by unique guest sampler ID
+	// (see _initTextureBindingPointsMTL), so texture units sharing a guest sampler share a Metal
+	// sampler slot too. UNUSED_BINDING means this shader exceeded MAX_MTL_SAMPLERS unique guest
+	// sampler ids - shader->hasError is set in that case, this value should never reach emission.
+	sint8 textureUnitToSamplerBindingPoint[LATTE_NUM_MAX_TEX_UNITS];
 	// uniform buffer
 	sint8 uniformVarsBufferBindingPoint{UNUSED_BINDING}; // special block for uniform registers/remapped array/custom variables
 	sint8 uniformBuffersBindingPoint[LATTE_NUM_MAX_UNIFORM_BUFFERS];
@@ -88,6 +97,14 @@ struct LatteDecompilerShaderResourceMapping
 	sint32 getTextureBaseBindingPoint()
 	{
 		return textureUnitBaseBindingPoint;
+	}
+
+	// returns -1 if this texture unit has no valid Metal sampler binding (see
+	// textureUnitToSamplerBindingPoint)
+	sint32 getSamplerBindingPoint(sint32 textureUnit)
+	{
+		cemu_assert_debug(textureUnit >= 0 && textureUnit < LATTE_NUM_MAX_TEX_UNITS);
+		return textureUnitToSamplerBindingPoint[textureUnit];
 	}
 
 	bool getUniformBufferBindingRange(sint32& minBinding, sint32& maxBinding)

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerAnalyzer.cpp
@@ -522,6 +522,11 @@ namespace LatteDecompiler
 	{
 		decompilerContext->output->resourceMappingMTL.textureUnitBaseBindingPoint = decompilerContext->currentTextureBindingPointMTL;
 		sint32 relBindingPointIndex = 0;
+		// independent dense Metal sampler mapping, keyed by unique guest sampler ID. Texture
+		// units that share a guest sampler ID share a Metal sampler slot.
+		uint16 seenSamplerIds[LATTE_NUM_MAX_TEX_UNITS];
+		sint8 seenSamplerSlots[LATTE_NUM_MAX_TEX_UNITS]; // parallel to seenSamplerIds; -1 if that id overflowed MAX_MTL_SAMPLERS
+		sint32 seenSamplerIdCount = 0;
 		for (sint32 i = 0; i < LATTE_NUM_MAX_TEX_UNITS; i++)
 		{
 			if (!decompilerContext->output->textureUnitMask[i] || decompilerContext->shader->textureRenderTargetIndex[i] != 255)
@@ -531,6 +536,42 @@ namespace LatteDecompiler
 			relBindingPointIndex++;
 			decompilerContext->output->resourceMappingMTL.textureUnitCount++;
 			decompilerContext->currentTextureBindingPointMTL++;
+
+			uint16 samplerId = decompilerContext->shader->textureUnitSamplerAssignment[i];
+			sint8 samplerSlot = -1;
+			bool alreadySeen = false;
+			for (sint32 s = 0; s < seenSamplerIdCount; s++)
+			{
+				if (seenSamplerIds[s] == samplerId)
+				{
+					samplerSlot = seenSamplerSlots[s]; // may be -1, if this id previously overflowed
+					alreadySeen = true;
+					break;
+				}
+			}
+			if (!alreadySeen)
+			{
+				if (seenSamplerIdCount < MAX_MTL_SAMPLERS)
+				{
+					samplerSlot = (sint8)seenSamplerIdCount;
+				}
+				else
+				{
+					// more than MAX_MTL_SAMPLERS unique guest sampler ids in one shader. Not
+					// observed in real BOTW measurement (max seen: 16 across ~5000 shaders,
+					// two full sessions, 1440p and 4K) - explicit fail rather than alias,
+					// modulo, clamp, or an out-of-bounds Metal sampler binding.
+					decompilerContext->shader->hasError = true;
+					samplerSlot = -1;
+					cemuLog_log(LogType::Force, "[SAMPLERARCH] ERROR: shader {:16x} stage {} needs more than {} unique Metal sampler slots "
+						"(texture unit {} guest sampler id {} has no binding) - shader will not be used",
+						decompilerContext->shaderBaseHash, (sint32)decompilerContext->shaderType, MAX_MTL_SAMPLERS, i, samplerId);
+				}
+				seenSamplerIds[seenSamplerIdCount] = samplerId;
+				seenSamplerSlots[seenSamplerIdCount] = samplerSlot;
+				seenSamplerIdCount++;
+			}
+			decompilerContext->output->resourceMappingMTL.textureUnitToSamplerBindingPoint[i] = samplerSlot;
 		}
 		if (relBindingPointIndex==0)
 			decompilerContext->output->resourceMappingMTL.textureUnitBaseBindingPoint = -1;

--- a/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSLHeader.hpp
+++ b/src/Cafe/HW/Latte/LegacyShaderDecompiler/LatteDecompilerEmitMSLHeader.hpp
@@ -2,6 +2,7 @@
 
 #include "Common/precompiled.h"
 #include "Cafe/HW/Latte/Renderer/Metal/MetalRenderer.h"
+#include "Cafe/HW/Latte/Renderer/Metal/MetalCommon.h"
 #include "Cafe/HW/Latte/Core/LatteShader.h"
 
 namespace LatteDecompiler
@@ -447,6 +448,13 @@ namespace LatteDecompiler
 	static void _emitTextureDefinitions(LatteDecompilerShaderContext* shaderContext)
 	{
 	    bool renderTargetIndexUsed[LATTE_NUM_COLOR_TARGET] = {false};
+	    // tracks which texture unit first declared the sampler parameter for a given Metal
+	    // sampler slot. MSL requires unique [[sampler(N)]] indices among live parameters (MSL
+	    // spec 5.2.1) - two texture units sharing a guest sampler ID share a Metal slot but
+	    // cannot both declare a live parameter at that index, so later units alias to the first
+	    // via #define instead of re-declaring.
+	    sint32 samplerSlotOwnerUnit[MAX_MTL_SAMPLERS];
+	    std::fill(std::begin(samplerSlotOwnerUnit), std::end(samplerSlotOwnerUnit), -1);
 
 		auto src = shaderContext->shaderSource;
 		// texture sampler definition
@@ -500,10 +508,27 @@ namespace LatteDecompiler
     			}
 
     			uint32 binding = shaderContext->output->resourceMappingMTL.textureUnitToBindingPoint[i];
-    			//uint32 textureBinding = shaderContext->output->resourceMappingMTL.textureUnitToBindingPoint[i] % 31;
-    			//uint32 samplerBinding = textureBinding % 16;
     			src->addFmt(" tex{} [[texture({})]]", i, binding);
-    			src->addFmt(", sampler samplr{} [[sampler({})]]", i, binding);
+
+    			sint32 samplerBinding = shaderContext->output->resourceMappingMTL.getSamplerBindingPoint(i);
+    			if (samplerBinding >= 0 && samplerBinding < MAX_MTL_SAMPLERS)
+    			{
+    			    if (samplerSlotOwnerUnit[samplerBinding] < 0)
+    			    {
+    			        samplerSlotOwnerUnit[samplerBinding] = i;
+    			        src->addFmt(", sampler samplr{} [[sampler({})]]", i, samplerBinding);
+    			    }
+    			    else
+    			    {
+    			        // this texture unit shares a Metal sampler slot with an earlier unit;
+    			        // alias its body references to that unit's parameter instead of
+    			        // re-declaring [[sampler(samplerBinding)]] a second time
+    			        src->addFmt("\n#define samplr{} samplr{}\n", i, samplerSlotOwnerUnit[samplerBinding]);
+    			    }
+    			}
+    			// else: no valid sampler binding for this unit (shader->hasError was set during
+    			// analysis when this happens - a shader needing >16 unique guest samplers - so
+    			// this function should not be reached for it; no sampler parameter is declared)
 			}
 		}
 	}

--- a/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Metal/MetalRenderer.cpp
@@ -1689,6 +1689,16 @@ void MetalRenderer::SetTexture(MTL::RenderCommandEncoder* renderCommandEncoder, 
 
 void MetalRenderer::SetSamplerState(MTL::RenderCommandEncoder* renderCommandEncoder, MetalShaderType shaderType, MTL::SamplerState* samplerState, uint32 index)
 {
+    // hard bounds guard: the independent sampler mapping (LatteDecompilerAnalyzer.cpp,
+    // _initTextureBindingPointsMTL) should never produce an out-of-range index - a shader
+    // needing more than MAX_MTL_SAMPLERS unique guest samplers is marked hasError and skipped
+    // before reaching here. This is defense in depth, not the primary guarantee: refuse rather
+    // than write out of bounds or hand Metal an invalid index.
+    if (index >= MAX_MTL_SAMPLERS)
+    {
+        cemuLog_logOnce(LogType::Force, "[SAMPLERARCH] ERROR: refusing out-of-bounds Metal sampler binding {} (limit {})", index, MAX_MTL_SAMPLERS);
+        return;
+    }
     auto& boundSamplerState = m_state.m_encoderState.m_samplers[shaderType][index];
     if (samplerState == boundSamplerState)
         return;
@@ -2060,6 +2070,12 @@ void MetalRenderer::BindStageResources(MTL::RenderCommandEncoder* renderCommandE
 		    cemuLog_logOnce(LogType::Force, "invalid texture binding {}", binding);
             continue;
 		}
+		// independent Metal sampler binding for this texture unit - deliberately not `binding`
+		// (the texture binding). Metal's texture (31) and sampler (16) argument tables are
+		// separate; reusing one index for both overflows the sampler table once a shader has
+		// >16 active texture units. See LatteDecompilerShaderResourceMapping::
+		// textureUnitToSamplerBindingPoint.
+		uint32 samplerBinding = (uint32)shader->resourceMapping.getSamplerBindingPoint(relative_textureUnit);
 
 		auto textureView = m_state.m_textures[hostTextureUnit];
 		if (!textureView)
@@ -2068,7 +2084,7 @@ void MetalRenderer::BindStageResources(MTL::RenderCommandEncoder* renderCommandE
                 SetTexture(renderCommandEncoder, mtlShaderType, m_nullTexture1D, binding);
            	else
                 SetTexture(renderCommandEncoder, mtlShaderType, m_nullTexture2D, binding);
-            SetSamplerState(renderCommandEncoder, mtlShaderType, m_nearestSampler, binding);
+            SetSamplerState(renderCommandEncoder, mtlShaderType, m_nearestSampler, samplerBinding);
             continue;
 		}
 
@@ -2110,7 +2126,7 @@ void MetalRenderer::BindStageResources(MTL::RenderCommandEncoder* renderCommandE
 		{
 		    sampler = m_nearestSampler;
 		}
-        SetSamplerState(renderCommandEncoder, mtlShaderType, sampler, binding);
+        SetSamplerState(renderCommandEncoder, mtlShaderType, sampler, samplerBinding);
 
 		// get texture register word 0
 		uint32 word4 = LatteGPUState.contextRegister[texUnitRegIndex + 4];


### PR DESCRIPTION
### Problem

The native Metal backend used one shared, incrementing counter to assign
binding indices for a shader's active texture units, then reused that
identical index for both Metal's texture argument table (31 slots) and
its sampler argument table (16 slots) - two genuinely separate binding
tables. Any shader with more than 16 active texture units overflowed the
smaller table with no bounds check catching it:

```cpp
// LatteDecompilerAnalyzer.cpp, _initTextureBindingPointsMTL (before)
decompilerContext->output->resourceMappingMTL.textureUnitToBindingPoint[i]
    = decompilerContext->currentTextureBindingPointMTL;
...
decompilerContext->currentTextureBindingPointMTL++;
```

```cpp
// LatteDecompilerEmitMSLHeader.hpp, _emitTextureDefinitions (before)
uint32 binding = shaderContext->output->resourceMappingMTL.textureUnitToBindingPoint[i];
src->addFmt(" tex{} [[texture({})]]", i, binding);
src->addFmt(", sampler samplr{} [[sampler({})]]", i, binding);  // same index for both
```

That unguarded index (up to 30 for a fully-populated shader) then reached
`SetSamplerState`, which had no bounds check of its own and wrote directly
into a fixed 16-slot array (`m_samplers[shaderType][index]` in
`MetalRenderer.h`) - an out-of-bounds write, and an invalid index handed
straight to Metal's `setFragmentSamplerState`/`setVertexSamplerState`.
Breath of the Wild is the specific case that surfaces this: several of its
pixel shaders use 17-18 simultaneous texture units.

### Why a simple fix is viable here (not argument buffers)

The natural-seeming alternative - Metal argument buffers, which remove the
16-slot ceiling entirely - is a substantially larger change touching
pipeline creation and encoder setup throughout the Metal renderer, and
isn't used anywhere in the backend today. Before reaching for that, this
PR checks a narrower question: do the shaders that exceed 16 *texture*
units also exceed 16 *unique sampler configurations*? Texture and sampler
are modeled as genuinely distinct resources at the Latte/GX2 ISA level - a
texture-fetch instruction carries separate `bufferId` and `samplerId`
fields - so a shader can easily use many texture units while reusing far
fewer distinct samplers.

Measured directly, across two full Breath of the Wild sessions (1440p and
4K, real gameplay - open world, village, water, weather, Guardian combat,
the Ganon fight, ~5,000 shaders analyzed combined): the answer is yes.
Every shader that exceeded 16 active textures (max observed: 18) still
resolved to at most 16 unique guest sampler ids - never more. That's the
precondition this fix depends on, and it held with zero exceptions.

### Fix

- `LatteDecompiler.h`: add `textureUnitToSamplerBindingPoint[]` to
  `LatteDecompilerShaderResourceMapping` - an independent Metal sampler
  mapping, parallel to but separate from the existing texture mapping,
  keyed by texture unit and densely assigned by *unique guest sampler id*.
  Texture units that share a guest sampler id share a Metal sampler slot.
- `LatteDecompilerAnalyzer.cpp` (`_initTextureBindingPointsMTL`): assign
  the new mapping during analysis via a dense per-shader guest-sampler-id
  dedup. A shader needing more than `MAX_MTL_SAMPLERS` unique guest
  samplers (not observed in any measured BOTW shader) sets
  `shader->hasError` and logs clearly, rather than aliasing, clamping, or
  writing out of bounds.
- `LatteDecompilerEmitMSLHeader.hpp` (`_emitTextureDefinitions`): emit
  `[[texture()]]` and `[[sampler()]]` from the two independent bindings
  instead of reusing one value for both - the actual bug. MSL forbids two
  live parameters at the same `[[sampler(N)]]` index (MSL spec 5.2.1), so
  a texture unit that shares a Metal sampler slot with an earlier unit
  skips declaring its own sampler parameter and instead gets a
  `#define samplrN samplrM` aliasing its body references to the owning
  unit's parameter. Removed the disabled `% 31` / `% 16` dead code this
  replaces, present-but-inactive since the Metal backend's introduction.
- `MetalRenderer.cpp` (`BindStageResources`): compute the independent
  sampler binding per texture unit and use it for both `SetSamplerState`
  call sites, instead of reusing the texture binding. `SetSamplerState`
  itself gained a hard bounds guard (`index >= MAX_MTL_SAMPLERS`) as
  defense in depth - refuses rather than writing out of bounds. The
  primary guarantee is upstream (`shader->hasError`); this is a second,
  independent line of defense.
- `MetalSamplerCache` is unchanged, still used only for its existing
  `MTL::SamplerState` object-level dedup - this fix doesn't touch how
  sampler *objects* are created or cached, only which binding slot a
  given texture unit's sampler is placed in.

Vulkan and OpenGL resource mapping are untouched - this is Metal-exclusive
(`_initTextureBindingPointsMTL`, the MSL emitter, and `MetalRenderer.cpp`
are all reached only from the Metal backend).

### Testing

- **Structural, before any gameplay**: rebuilt with Cemu's shader-dumping
  enabled, swept every shader compiled during a real title load (~3,000
  shaders). Zero contain `[[sampler(16)]]` or higher, verified against
  the literal generated MSL text. The known 18-texture shader's dumped
  source shows exactly the intended pattern: units 0-15 get real
  `[[sampler(0..15)]]` declarations, units 16/17 get `#define samplr16
  samplr0` / `#define samplr17 samplr1`. All ~3,000 shaders compiled
  successfully through Metal's actual shader compiler (dump happens after
  renderer object creation, not just text generation) - no crashes, no
  compile rejections.
- **Real gameplay, twice**: two full sessions on the built fix (1440p
  ~48 FPS, 4K ~30 FPS - matching the pre-fix baseline, no regression from
  adding the independent mapping), covering open world, a village, water,
  weather, Guardian combat, and the Ganon fight. Zero shaders exceeded 16
  unique samplers in either session; four distinct shaders exceeded 16
  textures across the two sessions, all correctly capped.
- **Camera Rune and a shrine interior**: checked separately, no visual
  issues.
- **Targeted follow-up on a reported visual issue**: after a
  (separately-caused) report of incorrect water rendering, swept every
  shader compiled during that specific session and confirmed none of them
  use the new aliasing mechanism at all - the water shader's behavior is
  unchanged by this fix either way. That white/transparent water turned
  out to be a pre-existing, previously-documented Cemu/BOTW rendering
  quirk that also occurs on Vulkan, unrelated to this change.

### Note

This PR is independent of the Vulkan/GLSL typed-output PR (#2034)
- same base commit, different renderer backend, no code overlap - not
meant to be combined with it.
