### PR TITLE
docs: fix typo folowing -> following

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -124,7 +124,7 @@ This section refers to running `cmake -S...` (truncated).
    * Add the following and try running the command again:
       * `-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON`
 * Environment variable `VCPKG_FORCE_SYSTEM_BINARIES` must be set.
-   * Execute the folowing and then try running the command again:
+   * Execute the following and then try running the command again:
       * `export VCPKG_FORCE_SYSTEM_BINARIES=1`
 * If you are getting a random error, read the [package-name-and-platform]-out.log and [package-name-and-platform]-err.log for the actual reason to see if you might be lacking the headers from a dependency.
 


### PR DESCRIPTION
Corrects the misspelling `folowing` -> `following` in `BUILD.md`.

Documentation only, no behaviour change.