### PR TITLE
OSDynLoad_Acquire: make HLE-registered libraries acquirable

### DIFF
--- a/src/Cafe/OS/RPL/rpl.cpp
+++ b/src/Cafe/OS/RPL/rpl.cpp
@@ -2069,7 +2069,13 @@ uint32 RPLLoader_GetHandleByModuleName(const char* name)
 		if (dep->moduleName == moduleName)
 		{
 			cemu_assert_debug(dep->loadAttempted);
-			if (!dep->isCafeOSModule && !dep->rplLoaderContext)
+			// A module is also valid if it is backed purely by HLE functions
+			// registered through osLib_registerHLEFunction (which is DLLEXPORT'd
+			// for exactly this purpose). Such libraries have no .rpl file and are
+			// not built-in Cafe OS modules, but RPLLoader_FindModuleOrHLEExport
+			// already resolves their exports via rpl_mapHLEImport - only the
+			// handle lookup was missing, leaving them unreachable at runtime.
+			if (!dep->isCafeOSModule && !dep->rplLoaderContext && !osLib_hasLibrary(moduleName.c_str()))
 				return RPL_INVALID_HANDLE; // module not found
 			return dep->coreinitHandle;
 		}

--- a/src/Cafe/OS/common/OSCommon.cpp
+++ b/src/Cafe/OS/common/OSCommon.cpp
@@ -107,6 +107,25 @@ extern "C" DLLEXPORT void osLib_registerHLEFunction(const char* libraryName, con
 	osLib_addFunctionInternal(libraryName, functionName, osFunction);
 }
 
+// Returns true if ANY HLE function has been registered under this library name.
+// osLib_registerHLEFunction is DLLEXPORT'd specifically so external code (mods,
+// injected libraries) can register HLE functions. Without a library-level lookup
+// there is no way for OSDynLoad_Acquire to know such a library exists, so those
+// registrations are unreachable at runtime.
+bool osLib_hasLibrary(const char* libraryName)
+{
+	if (!s_osFunctionTable)
+		return false;
+	uint32 libHashA, libHashB;
+	osLib_generateHashFromName(libraryName, &libHashA, &libHashB);
+	for (auto& it : *s_osFunctionTable)
+	{
+		if (it.libHashA == libHashA && it.libHashB == libHashB)
+			return true;
+	}
+	return false;
+}
+
 sint32 osLib_getFunctionIndex(const char* libraryName, const char* functionName)
 {
 	uint32 libHashA, libHashB;

--- a/src/Cafe/OS/common/OSCommon.h
+++ b/src/Cafe/OS/common/OSCommon.h
@@ -7,6 +7,7 @@ struct PPCInterpreter_t;
 
 void osLib_generateHashFromName(const char* name, uint32* hashA, uint32* hashB);
 sint32 osLib_getFunctionIndex(const char* libraryName, const char* functionName);
+bool osLib_hasLibrary(const char* libraryName);
 uint32 osLib_getPointer(const char* libraryName, const char* functionName);
 
 void osLib_addFunctionInternal(const char* libraryName, const char* functionName, void(*osFunction)(PPCInterpreter_t* hCPU));

--- a/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
+++ b/src/Cafe/OS/libs/coreinit/coreinit_DynLoad.cpp
@@ -108,7 +108,7 @@ namespace coreinit
 			*moduleHandleOut = rplHandle;
 		if (rplHandle == RPL_INVALID_HANDLE)
 		{
-			cemuLog_logDebug(LogType::Force, "OSDynLoad_Acquire() failed to load module '{}'", libName);
+			cemuLog_log(LogType::Force, "OSDynLoad_Acquire() failed to load module '{}'", libName); // [botwm-diag] promoted from logDebug (compiled out in release)
 			return 0xFFFCFFE9; // module not found
 		}
 


### PR DESCRIPTION
## Problem

`osLib_registerHLEFunction` is `DLLEXPORT`ed so that external code can register HLE
functions under a library name. But guest code can never obtain a handle to such a
library. `RPLLoader_GetHandleByModuleName` (`src/Cafe/OS/RPL/rpl.cpp`) rejects any
module that is neither a Cafe OS module nor backed by an `.rpl` file:

```cpp
if (!dep->isCafeOSModule && !dep->rplLoaderContext)
    return RPL_INVALID_HANDLE; // module not found
```

A library that exists purely as HLE registrations is exactly that case: it has no
`.rpl` file and is not a built-in Cafe OS module. So `OSDynLoad_Acquire("my_hle_lib")`
always fails, and every function registered through the exported API is unreachable
from the guest.

`RPLLoader_FindModuleOrHLEExport` already resolves these exports via
`rpl_mapHLEImport` — only the handle lookup was missing.

## Why this is easy to miss

The failure is invisible in release builds. `coreinit_DynLoad.cpp` reports it with
`cemuLog_logDebug`, which is compiled out, so `OSDynLoad_Acquire` returns
"module not found" with no diagnostic anywhere. Behaviour is identical on 1.27.1 and
2.6.

## Change

- Add `osLib_hasLibrary(const char*)` — true if any HLE function is registered under
  that library name.
- Accept such modules in `RPLLoader_GetHandleByModuleName`.
- Promote the `OSDynLoad_Acquire` failure from `cemuLog_logDebug` to `cemuLog_log`.

**The logging change is separable** — happy to drop it if you would rather that stay
debug-only. It is included because the silence is what made this take so long to
identify.

## Validation

Tested with an injection-based mod that registers its interceptor library through
`osLib_registerHLEFunction`:

- On stock 2.6 and 1.27.1 the acquire fails for every such library, and the mod's
  hooks never resolve.
- With this change the acquire succeeds. The call site retries on failure and caches
  the pointer only on success, so the failure log lines stop at the moment the library
  becomes reachable while the caller keeps polling at roughly 480 calls/sec.
- Guest→HLE dispatch confirmed directly: recompiled guest code
  (`PPCRecompiler_getJumpTableBase`) was observed dispatching into a function
  registered by the injected library.

Built with this repository's own `build.yml` (Windows x64).
