### PR TITLE
GX2: Sync with GPU when polling a pending CPU occlusion query (fixes ZombiU lights visible through walls)

### DIFF
--- a/src/Cafe/OS/libs/gx2/GX2_Query.cpp
+++ b/src/Cafe/OS/libs/gx2/GX2_Query.cpp
@@ -4,6 +4,7 @@
 #include "Cafe/HW/Latte/Core/LattePM4.h"
 #include "Cafe/CafeSystem.h"
 #include "GX2_Query.h"
+#include "GX2_Command.h"
 
 #define LATTE_GC_NUM_RB							2
 #define _QUERY_REG_COUNT						8 // each reg/result is 64bits, little endian
@@ -17,6 +18,28 @@ namespace GX2
 	};
 
 	static_assert(sizeof(GX2Query) == 0x40);
+
+	static bool _IsCPUQueryPending(GX2Query* query)
+	{
+		return query->reg[LATTE_GC_NUM_RB * 4 + 1] == _swapEndianU32('OCPU') && query->reg[LATTE_GC_NUM_RB * 4 + 0] == 0;
+	}
+
+	// Wait for the GPU to catch up so that the results of all previously ended occlusion queries are written to memory
+	// Some games poll the result of a CPU occlusion query only a few ms after ending it, within the same frame
+	// (e.g. ZombiU tests lens flare visibility this way and treats a "not ready" result as fully visible).
+	// On hardware the GPU trails the CPU closely enough for the result to be available by then, but the
+	// GPU thread in Cemu can be much further behind
+	static void _SyncForPendingQueryResult()
+	{
+		if (GX2GetDisplayListWriteStatus())
+			return; // can't submit commands while a display list is being recorded
+		GX2ReserveCmdSpace(2);
+		gx2WriteGather_submitU32AsBE(pm4HeaderType3(IT_HLE_SYNC_ASYNC_OPERATIONS, 1));
+		gx2WriteGather_submitU32AsBE(0x00000000); // unused
+		GX2Command_Flush(0x100, true);
+		uint64 ts = GX2GetLastSubmittedTimeStamp();
+		GX2WaitTimeStamp(ts);
+	}
 
 	void _BeginOcclusionQuery(GX2Query* queryInfo, bool isGPUQuery)
 	{
@@ -98,7 +121,12 @@ namespace GX2
 
 	uint32 GX2QueryGetOcclusionResult(GX2Query* query, uint64be* resultOut)
 	{
-		if (query->reg[LATTE_GC_NUM_RB * 4 + 1] == _swapEndianU32('OCPU') && query->reg[LATTE_GC_NUM_RB * 4 + 0] == 0)
+		if (_IsCPUQueryPending(query))
+		{
+			// let the GPU catch up, then check again
+			_SyncForPendingQueryResult();
+		}
+		if (_IsCPUQueryPending(query))
 		{
 			// CPU query result not ready
 			return GX2_FALSE;


### PR DESCRIPTION
Fixes #635 (ZombiU: light glows / lens flares visible through walls). I opened that issue back in 2023 and finally got around to tracking it down.

**What the game does**

ZombiU (Ubisoft's LyN engine) decides whether each light's glow is occluded by drawing a small invisible quad at the light position inside a CPU-type occlusion query (`GX2QueryBegin(GX2_QUERY_TYPE_OCCLUSION_CPU)`), and then reads the result with `GX2QueryGetOcclusionResult` only a few milliseconds later, **within the same frame**. Zero samples → glow hidden. Samples > 0, *or result not ready yet* → glow drawn at full intensity.

This works on the console because the game does a full GPU wait at the end of every frame (`GX2Flush` → `GX2GetLastSubmittedTimeStamp` → `GX2WaitTimeStamp` right before `GX2SwapScanBuffers`), so the GPU is never far behind and the query result has already been written by the time the game polls it.

**What goes wrong in Cemu**

The GPU thread can be well behind the PPC thread at that point, so the result isn't written yet and `GX2QueryGetOcclusionResult` returns `GX2_FALSE`. With logging added around the query functions, about 94% of ZombiU's polls hit the "not ready" path, which the game treats as "fully visible" — hence glows shining through walls, in both OpenGL and Vulkan, since forever. The query results themselves are correct when they do arrive (0 samples behind walls, > 0 when visible); it's purely a timing issue.

**The fix**

When `GX2QueryGetOcclusionResult` finds a CPU query that is still pending, emit the `IT_HLE_SYNC_ASYNC_OPERATIONS` packet, flush and wait for the GPU to retire it (the same thing `GX2DrawDone` does with full sync), then re-check. Only polls of queries that are actually pending pay for this, so games whose results are already available are unaffected, and the sync is skipped while a display list is being recorded. GPU-type queries (and the XCX workaround) are untouched.

**Testing**

ZombiU (EUR), Vulkan, on an i5-13600KF / NVIDIA: glows are now correctly hidden behind walls both standing still and while moving, fade in normally when the light comes into view, and the game stays at a steady 30 FPS. In this game the sync triggers about 1.6 times per frame (the game polls in two batches per frame). I also tried the simpler alternative of not resetting the query data at `GX2QueryBegin` so that the previous frame's result stays readable, but ZombiU also feeds these queries into another system that expects the current frame's result, and that produced heavy motion blur artifacts — so waiting for the real result is the right thing to do here.