### PR TITLE
FSC: Sort merged directory listings by name (fixes ZombiU black screen with update v32)

### DIFF
--- a/src/Cafe/Filesystem/fsc.cpp
+++ b/src/Cafe/Filesystem/fsc.cpp
@@ -366,6 +366,31 @@ private:
 				}
 			}
 		}
+		// When several mounted folders contribute to the same directory (e.g. base title + update),
+		// concatenating the per-layer listings puts the update's files first. On hardware a directory
+		// is listed in FST order, which is sorted by name, and some games rely on that order.
+		// ZombiU indexes its .bfz archives in FSReadDir order and never gets past the boot screen when
+		// the update's Patch.lin.bfz is enumerated before the base archives.
+		if (m_folders.size() > 1)
+		{
+			std::sort(dirIterator->dirEntries.begin(), dirIterator->dirEntries.end(), [](const FSCDirEntry& a, const FSCDirEntry& b) {
+				std::string_view sa(a.path, strnlen(a.path, FSC_MAX_DIR_NAME_LENGTH));
+				std::string_view sb(b.path, strnlen(b.path, FSC_MAX_DIR_NAME_LENGTH));
+				size_t n = std::min(sa.size(), sb.size());
+				for (size_t i = 0; i < n; i++)
+				{
+					uint8 ca = (uint8)sa[i];
+					uint8 cb = (uint8)sb[i];
+					if (ca >= 'A' && ca <= 'Z')
+						ca += 'a' - 'A';
+					if (cb >= 'A' && cb <= 'Z')
+						cb += 'a' - 'A';
+					if (ca != cb)
+						return ca < cb;
+				}
+				return sa.size() < sb.size();
+			});
+		}
 		fscLeave();
 	}
 


### PR DESCRIPTION
Fixes the long-standing "ZombiU doesn't boot with update v32 installed" problem documented on the wiki (and reported in #1823): the game stays on a black screen after the Ubisoft logo, at 30 FPS, forever.

**What the game does**

At boot ZombiU enumerates `/vol/content/lynfsatest/BinCafe` with `FSReadDir` and registers its `.lin.bfz` archives in the order they are returned. Its boot sequence then loads the intro video by resource id. That resource exists in two archives (`Video_Common_1` and a duplicate in `Gen_Common`), and which copy gets used depends on the archive order.

**What goes wrong in Cemu**

`FSCVirtualFileDirectoryIterator::PopulateIterationList` builds the listing of a directory that exists in several mounted layers by iterating the layers in priority order and appending each layer's entries. With an update installed, every file from the update is therefore listed before any file from the base title. The v32 update adds `BinCafe/Patch.lin.bfz`, which becomes the first archive the game registers and shifts all the others. The boot sequence resolves the intro video to the wrong archive (and starts streaming it from the wrong block), waits out its timeouts and the game never leaves the boot screen. On hardware the directory is returned in FST order, i.e. sorted by name, so `Patch.lin.bfz` lands between `Mip0_Common_1` and `SndStream_Common_0` and everything works.

Two experiments showed it is purely the order: removing `Patch.lin.bfz` from the update makes v32 boot, and so does moving the very same file into the base title's `BinCafe` folder, where the host filesystem lists it alphabetically.

**The fix**

Sort the merged listing by name (case-insensitively, like the FSA name comparison) whenever more than one folder contributes to a directory. Listings that come from a single layer are not touched, so games without an update or DLC see exactly what they saw before.

**Testing**

Confirmed with a build of this branch: ZombiU (EUR) with update v32 installed in its normal location now plays the intro video and reaches the main menu, and the game runs normally from there. Base v0 behaves as before.