### PR TITLE
Latte: Fix creation of cubemap destination textures in surface copies

### DIFF
--- a/src/Cafe/HW/Latte/Core/LatteSurfaceCopy.cpp
+++ b/src/Cafe/HW/Latte/Core/LatteSurfaceCopy.cpp
@@ -83,7 +83,14 @@ void LatteSurfaceCopy_copySurfaceNew(const LatteSurfaceCopyParam& src, const Lat
 	// create destination texture if it doesnt exist
 	if (!destinationTexture)
 	{
-		destinationView = LatteTexture_CreateMapping(dst.physDataAddr, MPTR_NULL, rect.x + rect.width, rect.y + rect.height, 1, dst.pitch, Latte::MakeHWTileMode(dst.tilemode), dst.swizzle, 0, 1, dst.sliceIndex, 1, dst.surfaceFormat, dst.dim, Latte::IsMSAA(dst.dim) ? Latte::E_DIM::DIM_2D_MSAA : Latte::E_DIM::DIM_2D, false);
+		// use a dim matching the created slice range. Passing the GX2 dim (e.g. cubemap) with depth 1 gives a texture that never gets allocated on the host
+		const sint32 dstDepth = dst.sliceIndex + 1;
+		Latte::E_DIM dstDimBase;
+		if (Latte::IsMSAA(dst.dim))
+			dstDimBase = dstDepth > 1 ? Latte::E_DIM::DIM_2D_ARRAY_MSAA : Latte::E_DIM::DIM_2D_MSAA;
+		else
+			dstDimBase = dstDepth > 1 ? Latte::E_DIM::DIM_2D_ARRAY : Latte::E_DIM::DIM_2D;
+		destinationView = LatteTexture_CreateMapping(dst.physDataAddr, MPTR_NULL, rect.x + rect.width, rect.y + rect.height, dstDepth, dst.pitch, Latte::MakeHWTileMode(dst.tilemode), dst.swizzle, 0, 1, dst.sliceIndex, 1, dst.surfaceFormat, dstDimBase, Latte::IsMSAA(dst.dim) ? Latte::E_DIM::DIM_2D_MSAA : Latte::E_DIM::DIM_2D, false);
 		destinationTexture = destinationView->baseTexture;
 	}
 	// copy texture


### PR DESCRIPTION
Since the GX2CopySurface rework, `LatteSurfaceCopy_copySurfaceNew` creates a missing destination texture with `dst.dim` taken straight from the GX2 surface but with a depth of 1. For a cubemap destination that gives `DIM_CUBEMAP` with depth 1, so the cubemap branch in `LatteTexture_ReloadData` runs `depth / 6 == 0` iterations and `AllocateOnHost()` is never called. On Vulkan the `VkImage` is then used without any memory bound (the validation layer reports `VUID-vkCmdCopyImage-dstImage-07966` / `VUID-VkImageMemoryBarrier-image-01932` for it) and the GPU faults on the next access. On NVIDIA this is a guaranteed `VK_ERROR_DEVICE_LOST` (Xid 31, PROP read at address 0) when entering the Zelda attraction in Nintendo Land; the corrupted rendering in the same attraction reported in #2043 on RDNA2 looks like the same texture being read as garbage instead of faulting.

This derives the base dim from the slice range that is actually created (2D / 2D_ARRAY, MSAA variants included) and passes `sliceIndex + 1` as depth, the same way the render target and copy source paths already do it. Tested with Nintendo Land (Zelda attraction loads and plays, no validation errors left) on NVIDIA 595 / Linux.
