### PR TITLE
Vulkan: Reuse the running instance in GetDevices to fix crash when opening settings in-game

### DIFF
--- a/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
+++ b/src/Cafe/HW/Latte/Renderer/Vulkan/VulkanRenderer.cpp
@@ -108,6 +108,32 @@ std::vector<VulkanRenderer::DeviceInfo> VulkanRenderer::GetDevices()
 
 	std::vector<DeviceInfo> result;
 
+	// use the instance of the running renderer if there is one. Creating and destroying a second instance while a swapchain
+	// is active breaks the NVIDIA Wayland driver (crash in vkAcquireNextImageKHR when opening the settings in-game)
+	if (g_renderer && g_renderer->GetType() == RendererAPI::Vulkan)
+	{
+		VulkanRenderer* vkr = VulkanRenderer::GetInstance();
+		if (vkr->m_instance != VK_NULL_HANDLE && vkr->m_mainSwapchainInfo && vkr->m_mainSwapchainInfo->m_surface != VK_NULL_HANDLE)
+		{
+			uint32_t device_count = 0;
+			vkEnumeratePhysicalDevices(vkr->m_instance, &device_count, nullptr);
+			std::vector<VkPhysicalDevice> devices(device_count);
+			vkEnumeratePhysicalDevices(vkr->m_instance, &device_count, devices.data());
+			for (const auto& device : devices)
+			{
+				if (IsDeviceSuitable(vkr->m_mainSwapchainInfo->m_surface, device))
+				{
+					VkPhysicalDeviceIDProperties physDeviceIDProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES };
+					VkPhysicalDeviceProperties2 physDeviceProps = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
+					physDeviceProps.pNext = &physDeviceIDProps;
+					vkGetPhysicalDeviceProperties2(device, &physDeviceProps);
+					result.emplace_back(physDeviceProps.properties.deviceName, physDeviceIDProps.deviceUUID);
+				}
+			}
+			return result;
+		}
+	}
+
 	std::vector<const char*> requiredExtensions;
 	requiredExtensions.clear();
 	requiredExtensions.emplace_back(VK_KHR_SURFACE_EXTENSION_NAME);


### PR DESCRIPTION
Opening the general settings while a game is running crashed every time for me on Linux/Wayland with the NVIDIA driver (595). `GeneralSettings2` fills the graphics device list through `VulkanRenderer::GetDevices()`, which creates a temporary `VkInstance` plus a temporary surface on the main window and destroys both again. With NVIDIA's Wayland WSI that teardown also takes down state shared with the live swapchain: the next `vkAcquireNextImageKHR` on the Latte thread ends up calling a null function pointer inside the driver (gdb shows `?? () at 0x0` below `libnvidia-glcore` in `AcquireNextSwapchainImage`). Cemu's own crash handler only prints `[(nil)]` for this, which is probably why it's hard to spot in user logs.

While the Vulkan renderer is active, enumerate the devices through its existing instance and main swapchain surface instead of creating a second instance. The temporary instance path is kept for the case where no renderer is running yet.
