### PR TITLE
Add Skylanders Portal IPC server

### DIFF
--- a/src/Cafe/CMakeLists.txt
+++ b/src/Cafe/CMakeLists.txt
@@ -430,6 +430,7 @@ add_library(CemuCafe
   OS/libs/nsyshid/Infinity.cpp
   OS/libs/nsyshid/Infinity.h
   OS/libs/nsyshid/Skylander.cpp
+  OS/libs/nsyshid/SkylanderPortalIPC.cpp
   OS/libs/nsyshid/Skylander.h
   OS/libs/nsyshid/SkylanderXbox360.cpp
   OS/libs/nsyshid/SkylanderXbox360.h

--- a/src/Cafe/OS/libs/nsyshid/Skylander.cpp
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.cpp
@@ -815,7 +815,7 @@ namespace nsyshid
 		}
 	}
 
-	uint8 SkylanderUSB::LoadSkylander(uint8* buf, std::unique_ptr<FileStream> file)
+	uint8 SkylanderUSB::LoadSkylander(uint8* buf, std::unique_ptr<FileStream> file, int requestedSlot)
 	{
 		std::lock_guard lock(m_skyMutex);
 
@@ -827,20 +827,30 @@ namespace nsyshid
 		}
 		uint8 foundSlot = 0xFF;
 
-		// mimics spot retaining on the portal
-		for (auto i = 0; i < 16; i++)
+		if (requestedSlot >= 0 && requestedSlot < 16)
 		{
-			if ((m_skylanders[i].status & 1) == 0)
+			if ((m_skylanders[requestedSlot].status & 1) == 0)
 			{
-				if (m_skylanders[i].lastId == skySerial)
+				foundSlot = static_cast<uint8>(requestedSlot);
+			}
+		}
+		else
+		{
+			// mimics spot retaining on the portal
+			for (auto i = 0; i < 16; i++)
+			{
+				if ((m_skylanders[i].status & 1) == 0)
 				{
-					foundSlot = i;
-					break;
-				}
+					if (m_skylanders[i].lastId == skySerial)
+					{
+						foundSlot = i;
+						break;
+					}
 
-				if (i < foundSlot)
-				{
-					foundSlot = i;
+					if (i < foundSlot)
+					{
+						foundSlot = i;
+					}
 				}
 			}
 		}
@@ -874,6 +884,24 @@ namespace nsyshid
 		}
 
 		return false;
+	}
+
+	void SkylanderUSB::GetFigureInfo(uint8 skyNum, uint8& outStatus, uint16& outId, uint16& outVariant)
+	{
+		std::lock_guard lock(m_skyMutex);
+		const auto& thesky = m_skylanders[skyNum];
+		outStatus = thesky.status;
+		
+		if (thesky.status & 1)
+		{
+			outId = (uint16(thesky.data[0x11]) << 8) | uint16(thesky.data[0x10]);
+			outVariant = (uint16(thesky.data[0x1D]) << 8) | uint16(thesky.data[0x1C]);
+		}
+		else
+		{
+			outId = 0;
+			outVariant = 0;
+		}
 	}
 
 	bool SkylanderUSB::CreateSkylander(fs::path pathName, uint16 skyId, uint16 skyVar)

--- a/src/Cafe/OS/libs/nsyshid/Skylander.h
+++ b/src/Cafe/OS/libs/nsyshid/Skylander.h
@@ -85,8 +85,9 @@ namespace nsyshid
 		void WriteBlock(uint8 skyNum, uint8 block, const uint8* toWriteBuf,
 						uint8* replyBuf);
 
-		uint8 LoadSkylander(uint8* buf, std::unique_ptr<FileStream> file);
+		uint8 LoadSkylander(uint8* buf, std::unique_ptr<FileStream> file, int requestedSlot = -1);
 		bool RemoveSkylander(uint8 skyNum);
+		void GetFigureInfo(uint8 skyNum, uint8& outStatus, uint16& outId, uint16& outVariant);
 		bool CreateSkylander(fs::path pathName, uint16 skyId, uint16 skyVar);
 		uint16 SkylanderCRC16(uint16 initValue, const uint8* buffer, uint32 size);
 		static std::map<const std::pair<const uint16, const uint16>, const char*> GetListSkylanders();

--- a/src/Cafe/OS/libs/nsyshid/SkylanderPortalIPC.cpp
+++ b/src/Cafe/OS/libs/nsyshid/SkylanderPortalIPC.cpp
@@ -1,0 +1,216 @@
+#include "SkylanderPortalIPC.h"
+#include "Skylander.h"
+#include <iostream>
+#include <sstream>
+
+namespace nsyshid
+{
+	std::unique_ptr<SkylanderPortalIPCServer> g_skylanderIpcServer = nullptr;
+
+	SkylanderPortalIPCServer::SkylanderPortalIPCServer(uint16_t port)
+		: m_port(port)
+	{
+	}
+
+	SkylanderPortalIPCServer::~SkylanderPortalIPCServer()
+	{
+		Stop();
+	}
+
+	void SkylanderPortalIPCServer::Start()
+	{
+		if (m_running.exchange(true))
+			return;
+
+		m_serverThread = std::thread([this]() {
+			try
+			{
+#ifdef _WIN32
+				Protocol::endpoint endpoint(boost::asio::ip::address_v4::loopback(), m_port);
+#else
+				const std::string socketPath = "/tmp/rpcs3.skylanders.sock";
+				std::remove(socketPath.c_str());
+				Protocol::endpoint endpoint(socketPath);
+#endif
+				m_acceptor = std::make_unique<Protocol::acceptor>(m_ioContext, endpoint);
+				ServerLoop();
+			}
+			catch (std::exception& e)
+			{
+				std::cerr << "Skylander IPC Server Error: " << e.what() << std::endl;
+			}
+		});
+	}
+
+	void SkylanderPortalIPCServer::Stop()
+	{
+		if (!m_running.exchange(false))
+			return;
+
+		if (m_acceptor)
+		{
+			boost::system::error_code ec;
+			m_acceptor->close(ec);
+		}
+
+		if (m_serverThread.joinable())
+		{
+			m_serverThread.join();
+		}
+
+#ifndef _WIN32
+		std::remove("/tmp/rpcs3.skylanders.sock");
+#endif
+	}
+
+	void SkylanderPortalIPCServer::ServerLoop()
+	{
+		while (m_running)
+		{
+			try
+			{
+				Protocol::socket socket(m_ioContext);
+				m_acceptor->accept(socket);
+				if (m_running)
+				{
+					HandleClient(socket);
+				}
+			}
+			catch (...) 
+			{
+				break;
+			}
+		}
+	}
+
+	void SkylanderPortalIPCServer::HandleClient(Protocol::socket& socket)
+	{
+		try
+		{
+			boost::asio::streambuf buffer(4096);
+			boost::system::error_code ec;
+			boost::asio::read_until(socket, buffer, '\n', ec);
+
+			if (!ec)
+			{
+				std::istream is(&buffer);
+				std::string line;
+				std::getline(is, line);
+
+				if (!line.empty() && line.back() == '\r')
+					line.pop_back();
+
+				std::string response = ProcessCommand(line);
+				boost::asio::write(socket, boost::asio::buffer(response));
+			}
+
+			socket.close(ec);
+		}
+		catch (...) {}
+	}
+
+	std::string SkylanderPortalIPCServer::HandleLoad(int slot, const std::string& path)
+	{
+		if (slot < -1 || slot > 15)
+			return "error invalid slot\n";
+
+		auto skyFile = std::unique_ptr<FileStream>(FileStream::openFile2(fs::path(path), true));
+		if (!skyFile) 
+			return "error cannot open file\n";
+
+		std::array<uint8, nsyshid::SKY_FIGURE_SIZE> buf;
+		if (skyFile->readData(buf.data(), buf.size()) != buf.size())
+			return "error file too small\n";
+
+		uint8 result = g_skyportal.LoadSkylander(buf.data(), std::move(skyFile), slot);
+		if (result == 0xFF)
+			return "error no free slot\n";
+
+		return "ok " + std::to_string(result) + "\n";
+	}
+
+	std::string SkylanderPortalIPCServer::HandleRemove(int slot)
+	{
+		if (slot < 0 || slot > 15)
+		return "error invalid slot\n";
+
+		if (!g_skyportal.RemoveSkylander(static_cast<uint8>(slot)))
+			return "error slot empty\n";
+
+		return "ok\n";
+	}
+
+	std::string SkylanderPortalIPCServer::HandleStatus()
+	{
+		std::string result;
+		for (uint8 i = 0; i < 16; i++)
+		{
+			uint8 status;
+			uint16 id, variant;
+			g_skyportal.GetFigureInfo(i, status, id, variant);
+			if (status & 1)
+				result += "slot" + std::to_string(i) + " loaded " + std::to_string(id) + " " + std::to_string(variant) + "\n";
+			else
+				result += "slot" + std::to_string(i) + " empty\n";
+		}
+		result += "ok\n";
+		return result;
+	}
+
+	std::string SkylanderPortalIPCServer::HandleClear()
+	{
+		for (uint8 i = 0; i < 16; i++)
+			g_skyportal.RemoveSkylander(i);
+		return "ok\n";
+	}
+
+		std::string SkylanderPortalIPCServer::ProcessCommand(const std::string& line)
+	{
+		if (line.empty())
+			return "error empty command\n";
+
+		const size_t firstSpace = line.find(' ');
+		const std::string cmd  = line.substr(0, firstSpace);
+
+		if (cmd == "status")
+			return HandleStatus();
+
+		if (cmd == "clear")
+			return HandleClear();
+
+		if (cmd == "remove")
+		{
+			if (firstSpace == std::string::npos)
+				return "error missing slot\n";
+			
+			int slot;
+			try {
+				slot = std::stoi(line.substr(firstSpace + 1));
+			} catch (...) {
+				return "error invalid slot\n";
+			}
+			return HandleRemove(slot);
+		}
+
+		if (cmd == "load")
+		{
+			if (firstSpace == std::string::npos)
+				return "error missing arguments\n";
+			const std::string rest  = line.substr(firstSpace + 1);
+			const size_t secondSpace  = rest.find(' ');
+			if (secondSpace == std::string::npos)
+				return "error missing path\n";
+			int slot;
+			try {
+				slot = std::stoi(rest.substr(0, secondSpace));
+			} catch (...) {
+				return "error invalid arguments\n";
+			}
+			
+			std::string path = rest.substr(secondSpace + 1);
+			return HandleLoad(slot, path);
+		}
+
+		return "error unknown command\n";
+	}
+}

--- a/src/Cafe/OS/libs/nsyshid/SkylanderPortalIPC.h
+++ b/src/Cafe/OS/libs/nsyshid/SkylanderPortalIPC.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <atomic>
+#include <boost/asio.hpp>
+
+
+
+namespace nsyshid
+{
+	class SkylanderPortalIPCServer
+	{
+	public:
+		SkylanderPortalIPCServer(uint16_t port);
+		~SkylanderPortalIPCServer();
+
+		void Start();
+		void Stop();
+
+#ifdef _WIN32
+		using Protocol = boost::asio::ip::tcp;
+#else
+		using Protocol = boost::asio::local::stream_protocol;
+#endif
+
+		void ServerLoop();
+		void HandleClient(Protocol::socket& socket);
+		std::string ProcessCommand(const std::string& command);
+
+		std::string HandleLoad(int slot, const std::string& path);
+		std::string HandleRemove(int slot);
+		std::string HandleStatus();
+		std::string HandleClear();
+
+		uint16_t m_port;
+		std::atomic<bool> m_running{false};
+		std::thread m_serverThread;
+
+		boost::asio::io_context m_ioContext;
+		std::unique_ptr<Protocol::acceptor> m_acceptor;
+	};
+
+	extern std::unique_ptr<SkylanderPortalIPCServer> g_skylanderIpcServer;
+}

--- a/src/config/CemuConfig.cpp
+++ b/src/config/CemuConfig.cpp
@@ -287,6 +287,7 @@ XMLConfigParser CemuConfig::Load(XMLConfigParser& parser)
 	// emulatedusbdevices
 	auto usbdevices = parser.get("EmulatedUsbDevices");
 	emulated_usb_devices.emulate_skylander_portal = usbdevices.get("EmulateSkylanderPortal", emulated_usb_devices.emulate_skylander_portal);
+	emulated_usb_devices.skylander_ipc_server = usbdevices.get("SkylandersIpcServer", emulated_usb_devices.skylander_ipc_server);
 	emulated_usb_devices.emulate_infinity_base = usbdevices.get("EmulateInfinityBase", emulated_usb_devices.emulate_infinity_base);
 	emulated_usb_devices.emulate_dimensions_toypad = usbdevices.get("EmulateDimensionsToypad", emulated_usb_devices.emulate_dimensions_toypad);
 
@@ -451,6 +452,7 @@ XMLConfigParser CemuConfig::Save(XMLConfigParser& parser)
 	// emulated usb devices
 	auto usbdevices = config.set("EmulatedUsbDevices");
 	usbdevices.set("EmulateSkylanderPortal", emulated_usb_devices.emulate_skylander_portal.GetValue());
+	usbdevices.set("SkylandersIpcServer", emulated_usb_devices.skylander_ipc_server.GetValue());
 	usbdevices.set("EmulateInfinityBase", emulated_usb_devices.emulate_infinity_base.GetValue());
 	usbdevices.set("EmulateDimensionsToypad", emulated_usb_devices.emulate_dimensions_toypad.GetValue());
 

--- a/src/config/CemuConfig.h
+++ b/src/config/CemuConfig.h
@@ -532,6 +532,7 @@ struct CemuConfig
 	struct
 	{
 		ConfigValue<bool> emulate_skylander_portal{false};
+		ConfigValue<bool> skylander_ipc_server{false};
 		ConfigValue<bool> emulate_infinity_base{false};
 		ConfigValue<bool> emulate_dimensions_toypad{false};
 	}emulated_usb_devices{};

--- a/src/gui/wxgui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
+++ b/src/gui/wxgui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.cpp
@@ -9,6 +9,7 @@
 
 #include "Cafe/OS/libs/nsyshid/nsyshid.h"
 #include "Cafe/OS/libs/nsyshid/Dimensions.h"
+#include "Cafe/OS/libs/nsyshid/SkylanderPortalIPC.h"
 
 #include "Common/FileStream.h"
 
@@ -35,7 +36,8 @@
 
 EmulatedUSBDeviceFrame::EmulatedUSBDeviceFrame(wxWindow* parent)
 	: wxFrame(parent, wxID_ANY, _("Emulated USB Devices"), wxDefaultPosition,
-			  wxDefaultSize, wxDEFAULT_FRAME_STYLE | wxTAB_TRAVERSAL)
+			  wxDefaultSize, wxDEFAULT_FRAME_STYLE | wxTAB_TRAVERSAL),
+	  m_skylanderUpdateTimer(this)
 {
 	SetIcon(wxICON(X_BOX));
 
@@ -53,9 +55,16 @@ EmulatedUSBDeviceFrame::EmulatedUSBDeviceFrame(wxWindow* parent)
 	SetSizerAndFit(sizer);
 	Layout();
 	Centre(wxBOTH);
+
+	Bind(wxEVT_TIMER, &EmulatedUSBDeviceFrame::OnSkylanderTimer, this, m_skylanderUpdateTimer.GetId());
+	m_skylanderUpdateTimer.Start(500);
+	UpdateIpcServerState();
 }
 
-EmulatedUSBDeviceFrame::~EmulatedUSBDeviceFrame() {}
+EmulatedUSBDeviceFrame::~EmulatedUSBDeviceFrame()
+{
+	m_skylanderUpdateTimer.Stop();
+}
 
 wxPanel* EmulatedUSBDeviceFrame::AddSkylanderPage(wxNotebook* notebook)
 {
@@ -74,8 +83,22 @@ wxPanel* EmulatedUSBDeviceFrame::AddSkylanderPage(wxNotebook* notebook)
 		GetConfig().emulated_usb_devices.emulate_skylander_portal =
 			m_emulatePortal->IsChecked();
 		GetConfigHandle().Save();
+		UpdateIpcServerState();
 	});
 	row->Add(m_emulatePortal, 1, wxEXPAND | wxALL, 2);
+
+	m_skylanderIpcServer =
+		new wxCheckBox(box, wxID_ANY, _("Enable IPC Server"));
+	m_skylanderIpcServer->SetValue(
+		GetConfig().emulated_usb_devices.skylander_ipc_server);
+	m_skylanderIpcServer->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
+		GetConfig().emulated_usb_devices.skylander_ipc_server =
+			m_skylanderIpcServer->IsChecked();
+		GetConfigHandle().Save();
+		UpdateIpcServerState();
+	});
+	row->Add(m_skylanderIpcServer, 1, wxEXPAND | wxALL, 2);
+
 	boxSizer->Add(row, 1, wxEXPAND | wxALL, 2);
 	for (int i = 0; i < nsyshid::MAX_SKYLANDERS; i++)
 	{
@@ -301,9 +324,7 @@ void EmulatedUSBDeviceFrame::LoadSkylanderPath(uint8 slot, wxString path)
 	uint16 skyVar = uint16(fileData[0x1D]) << 8 | uint16(fileData[0x1C]);
 
 	uint8 portalSlot = nsyshid::g_skyportal.LoadSkylander(fileData.data(),
-														  std::move(skyFile));
-	m_skySlots[slot] = std::tuple(portalSlot, skyId, skyVar);
-	UpdateSkylanderEdits();
+														  std::move(skyFile), slot);
 }
 
 void EmulatedUSBDeviceFrame::CreateSkylander(uint8 slot)
@@ -318,13 +339,7 @@ void EmulatedUSBDeviceFrame::CreateSkylander(uint8 slot)
 
 void EmulatedUSBDeviceFrame::ClearSkylander(uint8 slot)
 {
-	if (auto slotInfos = m_skySlots[slot])
-	{
-		auto [curSlot, id, var] = slotInfos.value();
-		nsyshid::g_skyportal.RemoveSkylander(curSlot);
-		m_skySlots[slot] = {};
-		UpdateSkylanderEdits();
-	}
+	nsyshid::g_skyportal.RemoveSkylander(slot);
 }
 
 CreateSkylanderDialog::CreateSkylanderDialog(wxWindow* parent, uint8 slot)
@@ -450,6 +465,58 @@ void EmulatedUSBDeviceFrame::UpdateSkylanderEdits()
 		}
 
 		m_skylanderSlots[i]->ChangeValue(displayString);
+	}
+}
+
+void EmulatedUSBDeviceFrame::OnSkylanderTimer(wxTimerEvent& event)
+{
+	bool changed = false;
+	for (uint8_t i = 0; i < nsyshid::MAX_SKYLANDERS; i++)
+	{
+		uint8_t status;
+		uint16_t id, variant;
+		nsyshid::g_skyportal.GetFigureInfo(i, status, id, variant);
+		
+		if (status & 1)
+		{
+			if (!m_skySlots[i].has_value() || std::get<1>(m_skySlots[i].value()) != id || std::get<2>(m_skySlots[i].value()) != variant)
+			{
+				m_skySlots[i] = std::tuple(i, id, variant);
+				changed = true;
+			}
+		}
+		else
+		{
+			if (m_skySlots[i].has_value())
+			{
+				m_skySlots[i].reset();
+				changed = true;
+			}
+		}
+	}
+	
+	if (changed)
+	{
+		UpdateSkylanderEdits();
+	}
+}
+
+void EmulatedUSBDeviceFrame::UpdateIpcServerState()
+{
+	auto& config = GetConfig().emulated_usb_devices;
+	if (config.emulate_skylander_portal && config.skylander_ipc_server)
+	{
+		if (!nsyshid::g_skylanderIpcServer)
+			nsyshid::g_skylanderIpcServer = std::make_unique<nsyshid::SkylanderPortalIPCServer>(28013);
+		nsyshid::g_skylanderIpcServer->Start();
+	}
+	else
+	{
+		if (nsyshid::g_skylanderIpcServer)
+		{
+			nsyshid::g_skylanderIpcServer->Stop();
+			nsyshid::g_skylanderIpcServer.reset();
+		}
 	}
 }
 

--- a/src/gui/wxgui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
+++ b/src/gui/wxgui/EmulatedUSBDevices/EmulatedUSBDeviceFrame.h
@@ -4,6 +4,7 @@
 
 #include <wx/dialog.h>
 #include <wx/frame.h>
+#include <wx/timer.h>
 
 #include "Cafe/OS/libs/nsyshid/Infinity.h"
 #include "Cafe/OS/libs/nsyshid/Skylander.h"
@@ -26,8 +27,11 @@ class EmulatedUSBDeviceFrame : public wxFrame
 
   private:
 	wxCheckBox* m_emulatePortal;
+	wxCheckBox* m_skylanderIpcServer;
 	wxCheckBox* m_emulateBase;
 	wxCheckBox* m_emulateToypad;
+	wxTimer m_skylanderUpdateTimer;
+
 	std::array<wxTextCtrl*, nsyshid::MAX_SKYLANDERS> m_skylanderSlots;
 	std::array<wxTextCtrl*, nsyshid::MAX_FIGURES> m_infinitySlots;
 	std::array<wxTextCtrl*, 7> m_dimensionSlots;
@@ -45,6 +49,8 @@ class EmulatedUSBDeviceFrame : public wxFrame
 	void CreateSkylander(uint8 slot);
 	void ClearSkylander(uint8 slot);
 	void UpdateSkylanderEdits();
+	void OnSkylanderTimer(wxTimerEvent& event);
+	void UpdateIpcServerState();
 	void LoadFigure(uint8 slot);
 	void LoadFigurePath(uint8 slot, wxString path);
 	void CreateFigure(uint8 slot);


### PR DESCRIPTION
This adds a skylanders portal IPC server largely inspired/modified from this pull request for [the same feature in rpcs3](https://github.com/RPCS3/rpcs3/pull/18960)

1. adds requestedSlot and GetFigureInfo to Skylander.cpp
2. adds the SkylandersPortalIPC.cpp file, where commands are processed essentially the same as in rpcs3. The server is instead implemented with boost/asio (hopefully to the same behavior)
3. changes the emulated portal UI to add a checkbox to enable the IPC server and changes the UI onto a 500ms timer to update the entries shown

Solves feature request #2042 by me. Shoutout to Der-Floh for their rpcs3 pull request being the blueprint for this